### PR TITLE
전역 공통 UI 컴포넌트 생성

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,9 +20,11 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.564.0",
+    "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.1",
     "tailwindcss": "^4.1.18",
     "zod": "^4.3.6"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       lucide-react:
         specifier: ^0.564.0
         version: 0.564.0(react@19.2.4)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -44,6 +47,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.4(react@19.2.4)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.4.1
         version: 3.4.1
@@ -3148,6 +3154,12 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
@@ -3558,6 +3570,12 @@ packages:
 
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -7027,6 +7045,11 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
@@ -7543,6 +7566,11 @@ snapshots:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.8.1
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 

--- a/frontend/src/shared/ui/back-button/back-button.test.tsx
+++ b/frontend/src/shared/ui/back-button/back-button.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BackButton } from "./back-button";
+
+// 모킹: @tanstack/react-router
+const mockHistoryBack = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  useRouter: () => ({
+    history: {
+      back: mockHistoryBack,
+    },
+  }),
+}));
+
+describe("BackButton", () => {
+  beforeEach(() => {
+    mockHistoryBack.mockClear();
+  });
+
+  it("기본 렌더링: 아이콘과 라벨이 표시된다", () => {
+    render(<BackButton label="뒤로가기" />);
+    // 아이콘은 svg로 렌더링됨
+    expect(document.querySelector("svg")).toBeInTheDocument();
+    // 라벨 텍스트 확인
+    expect(screen.getByText("뒤로가기")).toBeInTheDocument();
+  });
+
+  it("라벨이 없으면 아이콘만 표시된다 (라벨 빈 문자열)", () => {
+    render(<BackButton label="" />);
+    expect(document.querySelector("svg")).toBeInTheDocument();
+    // 텍스트가 없어야 함 (버튼 내부는 아이콘만)
+    const button = screen.getByRole("button");
+    expect(button).toHaveTextContent("");
+  });
+
+  it("클릭 시 router.history.back()이 호출된다", () => {
+    render(<BackButton />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(mockHistoryBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("custom onClick 핸들러가 있으면 router.history.back() 대신 호출된다", () => {
+    const customClick = vi.fn();
+    render(<BackButton onClick={customClick} />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(customClick).toHaveBeenCalledTimes(1);
+    expect(mockHistoryBack).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/shared/ui/back-button/back-button.tsx
+++ b/frontend/src/shared/ui/back-button/back-button.tsx
@@ -1,0 +1,20 @@
+import { ArrowLeft } from "lucide-react";
+import { useRouter } from "@tanstack/react-router";
+import { Button } from "@/shared/ui/button";
+import type { ButtonProps } from "@/shared/ui/button/button";
+
+interface BackButtonProps extends Omit<ButtonProps, "children"> {
+  label?: string;
+}
+
+export function BackButton({ label = "", onClick, ...props }: BackButtonProps) {
+  const router = useRouter();
+  const handleClick = onClick ?? (() => router.history.back());
+
+  return (
+    <Button variant="default" onClick={handleClick} {...props}>
+      <ArrowLeft className="mr-2 h-4 w-4" />
+      {label}
+    </Button>
+  );
+}

--- a/frontend/src/shared/ui/back-button/index.ts
+++ b/frontend/src/shared/ui/back-button/index.ts
@@ -1,0 +1,1 @@
+export { BackButton } from './back-button';

--- a/frontend/src/shared/ui/button/button-variants.ts
+++ b/frontend/src/shared/ui/button/button-variants.ts
@@ -4,6 +4,7 @@ export const buttonVariants = cva("", {
   variants: {
     variant: {
       default: "",
+      outline: "",
     },
     size: {
       default: "",

--- a/frontend/src/shared/ui/button/button.test.tsx
+++ b/frontend/src/shared/ui/button/button.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Button } from "./button";
+
+describe("Button", () => {
+  it("기본 렌더링: children이 표시된다", () => {
+    render(<Button>저장</Button>);
+    expect(screen.getByRole("button", { name: "저장" })).toBeInTheDocument();
+  });
+
+  it("isLoading=true이면 버튼이 disabled 상태가 된다", () => {
+    render(<Button isLoading>저장</Button>);
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("isLoading=true 기본값: Loader2 스피너 아이콘이 렌더링된다", () => {
+    render(<Button isLoading>저장</Button>);
+    expect(document.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("isLoading=true + loadingContent(텍스트)이면 해당 텍스트가 표시된다", () => {
+    render(
+      <Button isLoading loadingContent="저장 중...">
+        저장
+      </Button>,
+    );
+    expect(screen.getByText("저장 중...")).toBeInTheDocument();
+  });
+
+  it("isLoading=true + loadingContent(JSX)이면 해당 컴포넌트가 표시된다", () => {
+    render(
+      <Button isLoading loadingContent={<span data-testid="custom-loading" />}>
+        저장
+      </Button>,
+    );
+    expect(screen.getByTestId("custom-loading")).toBeInTheDocument();
+  });
+
+  it("isLoading=true + loadingContent(텍스트)이면 원래 children은 표시되지 않는다", () => {
+    render(
+      <Button isLoading loadingContent="저장 중...">
+        저장
+      </Button>,
+    );
+    expect(screen.queryByText("저장")).not.toBeInTheDocument();
+  });
+
+  it("isLoading=false이면 children이 정상 표시된다", () => {
+    render(<Button isLoading={false}>저장</Button>);
+    expect(screen.getByRole("button", { name: "저장" })).toBeInTheDocument();
+    expect(screen.getByRole("button")).not.toBeDisabled();
+  });
+
+  it("disabled prop이 true이면 disabled 상태가 된다", () => {
+    render(<Button disabled>저장</Button>);
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+});

--- a/frontend/src/shared/ui/button/button.tsx
+++ b/frontend/src/shared/ui/button/button.tsx
@@ -1,31 +1,47 @@
 import * as React from "react";
+import { Loader2 } from "lucide-react";
 import { type VariantProps } from "class-variance-authority";
 import { Slot } from "radix-ui";
 
 import { cn } from "@/shared/lib/utils";
 import { buttonVariants } from "./button-variants";
 
+interface ButtonProps
+  extends React.ComponentProps<"button">, VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+  isLoading?: boolean;
+  loadingContent?: React.ReactNode;
+}
+
+// isLoading=true일 때는 항상 <button> 태그로 렌더링 (asChild 무시)
 function Button({
   className,
   variant = "default",
   size = "default",
   asChild = false,
+  isLoading = false,
+  loadingContent,
+  children,
+  disabled,
   ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
-  }) {
-  const Comp = asChild ? Slot.Root : "button";
+}: ButtonProps) {
+  const Comp = asChild && !isLoading ? Slot.Root : "button";
 
   return (
     <Comp
       data-slot="button"
       data-variant={variant}
       data-size={size}
+      disabled={isLoading || disabled}
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
-    />
+    >
+      {isLoading
+        ? (loadingContent ?? <Loader2 className="h-4 w-4 animate-spin" />)
+        : children}
+    </Comp>
   );
 }
 
 export { Button };
+export type { ButtonProps };

--- a/frontend/src/shared/ui/checkbox.tsx
+++ b/frontend/src/shared/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { CheckIcon } from 'lucide-react';
+import { Checkbox as CheckboxPrimitive } from 'radix-ui';
+
+import { cn } from '@/shared/lib/utils';
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/frontend/src/shared/ui/dialog.tsx
+++ b/frontend/src/shared/ui/dialog.tsx
@@ -1,0 +1,156 @@
+import * as React from "react";
+import { XIcon } from "lucide-react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+
+import { cn } from "@/shared/lib/utils";
+import { Button } from "@/shared/ui/button";
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/frontend/src/shared/ui/sonner.tsx
+++ b/frontend/src/shared/ui/sonner.tsx
@@ -1,0 +1,38 @@
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react"
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 5분

<br/>

## 📌 작업 요약
modal,toast,button,back-button,checkbox 작성

<br/>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요 (이미지 첨부 가능)

1. button isLoading,loadingComponent props 추가 및 테스트 진행
2. dialog(modal),sonner(toast),checkbox를 shadcn에서 import
3. back-button 구현 및 테스트



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 뒤로가기 버튼 컴포넌트 추가
  * 버튼에 로딩 상태 및 커스텀 로딩 콘텐츠 지원
  * 체크박스 컴포넌트 추가
  * 다이얼로그 컴포넌트 추가
  * 알림 기능 개선 및 테마 지원
  * 버튼에 아웃라인 스타일 옵션 추가

* **Tests**
  * 뒤로가기 버튼 단위 테스트 추가
  * 버튼 컴포넌트 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->