### PR TITLE
최소 엔티티 스키마 / api adapter / mock 추가

### DIFF
--- a/frontend/src/entities/invite/model/schema.ts
+++ b/frontend/src/entities/invite/model/schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const inviteStatusSchema = z.enum(['PENDING', 'ACCEPTED', 'DECLINED']);
+
+export const inviteSchema = z.object({
+  id: z.string(),
+  bandId: z.string(),
+  bandName: z.string().default(''),
+  inviteeEmail: z.email(),
+  inviteCode: z.string().default(''),
+  inviteLink: z.string().url().nullable().default(null),
+  token: z.string().nullable().default(null),
+  status: inviteStatusSchema.default('PENDING'),
+});

--- a/frontend/src/entities/invite/model/types.ts
+++ b/frontend/src/entities/invite/model/types.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod';
+import { inviteSchema, inviteStatusSchema } from './schema';
+
+export type Invite = z.infer<typeof inviteSchema>;
+export type InviteStatus = z.infer<typeof inviteStatusSchema>;

--- a/frontend/src/entities/join-request/model/schema.ts
+++ b/frontend/src/entities/join-request/model/schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const joinRequestStatusSchema = z.enum([
+  'PENDING',
+  'APPROVED',
+  'REJECTED',
+]);
+
+export const joinRequestSchema = z.object({
+  id: z.string(),
+  bandId: z.string(),
+  message: z.string().default(''),
+  status: joinRequestStatusSchema.default('PENDING'),
+});

--- a/frontend/src/entities/join-request/model/types.ts
+++ b/frontend/src/entities/join-request/model/types.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod';
+import { joinRequestSchema, joinRequestStatusSchema } from './schema';
+
+export type JoinRequest = z.infer<typeof joinRequestSchema>;
+export type JoinRequestStatus = z.infer<typeof joinRequestStatusSchema>;

--- a/frontend/src/entities/material/model/schema.ts
+++ b/frontend/src/entities/material/model/schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const fileMaterialSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  url: z.string().url().nullable().default(null),
+  uploadedAt: z.string().default(''),
+});
+
+export const videoMaterialSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  url: z.string().url(),
+  uploadedAt: z.string().default(''),
+});

--- a/frontend/src/entities/material/model/types.ts
+++ b/frontend/src/entities/material/model/types.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod';
+import { fileMaterialSchema, videoMaterialSchema } from './schema';
+
+export type FileMaterial = z.infer<typeof fileMaterialSchema>;
+export type VideoMaterial = z.infer<typeof videoMaterialSchema>;

--- a/frontend/src/entities/member/model/schema.ts
+++ b/frontend/src/entities/member/model/schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const memberSchema = z.object({
+  id: z.string(),
+  profileId: z.string().nullable().default(null),
+  name: z.string(),
+  nickname: z.string().default(''),
+  role: z.string().default('MEMBER'),
+  instruments: z.array(z.string()).default([]),
+  isAssigned: z.boolean().default(false),
+});

--- a/frontend/src/entities/member/model/types.ts
+++ b/frontend/src/entities/member/model/types.ts
@@ -1,0 +1,4 @@
+import type { z } from 'zod';
+import { memberSchema } from './schema';
+
+export type Member = z.infer<typeof memberSchema>;

--- a/frontend/src/entities/performance/model/schema.ts
+++ b/frontend/src/entities/performance/model/schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const performanceSchema = z.object({
+  id: z.string(),
+  bandId: z.string(),
+  spaceId: z.string().nullable().default(null),
+  title: z.string(),
+  description: z.string().default(''),
+  eventDate: z.string(),
+  status: z.string().default('PLANNED'),
+});

--- a/frontend/src/entities/performance/model/types.ts
+++ b/frontend/src/entities/performance/model/types.ts
@@ -1,0 +1,4 @@
+import type { z } from 'zod';
+import { performanceSchema } from './schema';
+
+export type Performance = z.infer<typeof performanceSchema>;

--- a/frontend/src/entities/practice-record/model/schema.ts
+++ b/frontend/src/entities/practice-record/model/schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const practiceRecordSchema = z.object({
+  id: z.string(),
+  scheduleId: z.string().nullable().default(null),
+  practicedAt: z.string(),
+  label: z.string().default(''),
+});

--- a/frontend/src/entities/practice-record/model/types.ts
+++ b/frontend/src/entities/practice-record/model/types.ts
@@ -1,0 +1,4 @@
+import type { z } from 'zod';
+import { practiceRecordSchema } from './schema';
+
+export type PracticeRecord = z.infer<typeof practiceRecordSchema>;

--- a/frontend/src/entities/profile/model/schema.ts
+++ b/frontend/src/entities/profile/model/schema.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const profileSchema = z.object({
+  id: z.string(),
+  email: z.email().optional(),
+  nickname: z.string().default(''),
+  displayName: z.string().default(''),
+  bio: z.string().default(''),
+  preferredGenres: z.array(z.string()).default([]),
+  profileMusic: z
+    .object({
+      title: z.string(),
+      artistName: z.string().default(''),
+      url: z.string().url().nullable().default(null),
+    })
+    .nullable()
+    .default(null),
+  bandSummaries: z
+    .array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+      }),
+    )
+    .default([]),
+  skills: z.array(z.string()).default([]),
+});

--- a/frontend/src/entities/profile/model/types.ts
+++ b/frontend/src/entities/profile/model/types.ts
@@ -1,0 +1,4 @@
+import type { z } from 'zod';
+import { profileSchema } from './schema';
+
+export type Profile = z.infer<typeof profileSchema>;

--- a/frontend/src/entities/session/model/schema.ts
+++ b/frontend/src/entities/session/model/schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const sessionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  order: z.number().int().nonnegative().default(0),
+});

--- a/frontend/src/entities/session/model/types.ts
+++ b/frontend/src/entities/session/model/types.ts
@@ -1,0 +1,4 @@
+import type { z } from 'zod';
+import { sessionSchema } from './schema';
+
+export type Session = z.infer<typeof sessionSchema>;

--- a/frontend/src/entities/song-team/model/schema.ts
+++ b/frontend/src/entities/song-team/model/schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const songTeamSchema = z.object({
+  id: z.string(),
+  songId: z.string(),
+  name: z.string(),
+  memberCount: z.number().int().nonnegative().default(0),
+});

--- a/frontend/src/entities/song-team/model/types.ts
+++ b/frontend/src/entities/song-team/model/types.ts
@@ -1,0 +1,4 @@
+import type { z } from 'zod';
+import { songTeamSchema } from './schema';
+
+export type SongTeam = z.infer<typeof songTeamSchema>;

--- a/frontend/src/entities/song/model/schema.ts
+++ b/frontend/src/entities/song/model/schema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const songSchema = z.object({
+  id: z.string(),
+  bandId: z.string().optional(),
+  title: z.string(),
+  artistName: z.string().default(''),
+  key: z.string().default(''),
+  bpm: z.number().int().positive().nullable().default(null),
+  duration: z.string().default(''),
+  sourceUrl: z.string().nullable().default(null),
+  sourceType: z.string().nullable().default(null),
+  referenceLinks: z
+    .array(
+      z.object({
+        label: z.string(),
+        url: z.string().url(),
+      }),
+    )
+    .default([]),
+  sessionNames: z.array(z.string()).default([]),
+  teamName: z.string().nullable().default(null),
+  participantMemberIds: z.array(z.string()).default([]),
+  memo: z.string().default(''),
+  status: z.string().default('ACTIVE'),
+});

--- a/frontend/src/entities/song/model/types.ts
+++ b/frontend/src/entities/song/model/types.ts
@@ -1,0 +1,4 @@
+import type { z } from 'zod';
+import { songSchema } from './schema';
+
+export type Song = z.infer<typeof songSchema>;

--- a/frontend/src/entities/space/model/schema.ts
+++ b/frontend/src/entities/space/model/schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const spaceTypeSchema = z.enum(['PERFORMANCE_PREP', 'PRACTICE']);
+
+export const spaceSchema = z.object({
+  id: z.string(),
+  bandId: z.string(),
+  name: z.string(),
+  description: z.string().default(''),
+  spaceType: spaceTypeSchema.default('PRACTICE'),
+  eventDate: z.string().nullable().default(null),
+});

--- a/frontend/src/entities/space/model/types.ts
+++ b/frontend/src/entities/space/model/types.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod';
+import { spaceSchema, spaceTypeSchema } from './schema';
+
+export type Space = z.infer<typeof spaceSchema>;
+export type SpaceType = z.infer<typeof spaceTypeSchema>;

--- a/frontend/src/entities/team/model/schema.ts
+++ b/frontend/src/entities/team/model/schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const teamSchema = z.object({
+  id: z.string(),
+  songId: z.string(),
+  name: z.string(),
+  sessionNames: z.array(z.string()).default([]),
+  memberIds: z.array(z.string()).default([]),
+});

--- a/frontend/src/entities/team/model/types.ts
+++ b/frontend/src/entities/team/model/types.ts
@@ -1,0 +1,4 @@
+import type { z } from 'zod';
+import { teamSchema } from './schema';
+
+export type Team = z.infer<typeof teamSchema>;

--- a/frontend/src/features/invite-accept/api/invite-api.test.ts
+++ b/frontend/src/features/invite-accept/api/invite-api.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { acceptInvite } from './invite-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('invite accept 어댑터', () => {
+  it('초대를 수락한다', async () => {
+    mock.onPost('/invites/token-1/accept').reply(200, {
+      success: true,
+      data: undefined,
+    });
+
+    await expect(acceptInvite('token-1')).resolves.toBeUndefined();
+  });
+});

--- a/frontend/src/features/invite-accept/api/invite-api.ts
+++ b/frontend/src/features/invite-accept/api/invite-api.ts
@@ -1,0 +1,4 @@
+import { apiPost } from '@/shared/api';
+
+export const acceptInvite = (token: string): Promise<void> =>
+  apiPost<void>(`/invites/${token}/accept`);

--- a/frontend/src/features/invite-create/api/invite-api.test.ts
+++ b/frontend/src/features/invite-create/api/invite-api.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { createInvite } from './invite-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('invite create 어댑터', () => {
+  it('밴드 초대를 생성한다', async () => {
+    const requestBody = { inviteeEmail: 'member@example.com' };
+
+    mock.onPost('/bands/band-1/invites', requestBody).reply(200, {
+      success: true,
+      data: {
+        id: 'invite-1',
+        bandId: 'band-1',
+        bandName: '신촌 락밴드',
+        inviteeEmail: 'member@example.com',
+        inviteCode: 'INV-team-1-DEMO1',
+        inviteLink: 'https://example.com/invites/demo',
+        token: 'token-1',
+        status: 'PENDING',
+      },
+    });
+
+    const result = await createInvite('band-1', requestBody);
+
+    expect(result.inviteeEmail).toBe('member@example.com');
+  });
+});

--- a/frontend/src/features/invite-create/api/invite-api.ts
+++ b/frontend/src/features/invite-create/api/invite-api.ts
@@ -1,0 +1,11 @@
+import { apiPost } from '@/shared/api';
+import type { Invite } from '@/entities/invite/model/types';
+
+export interface CreateInviteRequest {
+  inviteeEmail: string;
+}
+
+export const createInvite = (
+  bandId: string,
+  data: CreateInviteRequest,
+): Promise<Invite> => apiPost<Invite>(`/bands/${bandId}/invites`, data);

--- a/frontend/src/features/invite-decline/api/invite-api.test.ts
+++ b/frontend/src/features/invite-decline/api/invite-api.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { declineInvite } from './invite-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('invite decline 어댑터', () => {
+  it('초대를 거절한다', async () => {
+    mock.onPost('/invites/token-2/decline').reply(200, {
+      success: true,
+      data: undefined,
+    });
+
+    await expect(declineInvite('token-2')).resolves.toBeUndefined();
+  });
+});

--- a/frontend/src/features/invite-decline/api/invite-api.ts
+++ b/frontend/src/features/invite-decline/api/invite-api.ts
@@ -1,0 +1,4 @@
+import { apiPost } from '@/shared/api';
+
+export const declineInvite = (token: string): Promise<void> =>
+  apiPost<void>(`/invites/${token}/decline`);

--- a/frontend/src/features/invite-list/api/invite-api.test.ts
+++ b/frontend/src/features/invite-list/api/invite-api.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { getInvites } from './invite-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('invite list 어댑터', () => {
+  it('초대 목록을 조회한다', async () => {
+    mock.onGet('/invites/band-1', { params: { page: 1, size: 10 } }).reply(200, {
+      success: true,
+      data: [
+        {
+          id: 'invite-1',
+          bandId: 'band-1',
+          bandName: '신촌 락밴드',
+          inviteeEmail: 'member@example.com',
+          inviteCode: 'INV-team-1-DEMO1',
+          inviteLink: 'https://example.com/invites/demo',
+          token: 'token-1',
+          status: 'PENDING',
+        },
+      ],
+    });
+
+    const result = await getInvites('band-1', { page: 1, size: 10 });
+
+    expect(result[0]?.bandName).toBe('신촌 락밴드');
+  });
+});

--- a/frontend/src/features/invite-list/api/invite-api.ts
+++ b/frontend/src/features/invite-list/api/invite-api.ts
@@ -1,0 +1,16 @@
+import { apiGet } from '@/shared/api';
+import type { Invite } from '@/entities/invite/model/types';
+
+export interface GetInvitesParams {
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+export const getInvites = (
+  bandId: string,
+  params?: GetInvitesParams,
+): Promise<Invite[]> =>
+  apiGet<Invite[]>(`/invites/${bandId}`, {
+    params,
+  });

--- a/frontend/src/features/profile-get/api/profile-api.test.ts
+++ b/frontend/src/features/profile-get/api/profile-api.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { getMyProfile } from './profile-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('profile get 어댑터', () => {
+  it('내 프로필을 조회한다', async () => {
+    mock.onGet('/me/profile').reply(200, {
+      success: true,
+      data: {
+        id: 'profile-1',
+        nickname: '김민준',
+        displayName: '김민준',
+        bio: '음악으로 세상과 소통하는 기타리스트',
+        preferredGenres: ['Rock', 'J-Pop'],
+        profileMusic: {
+          title: 'Time of our life',
+          artistName: 'Day6',
+          url: null,
+        },
+        bandSummaries: [
+          { id: 'band-1', name: '신촌 락밴드' },
+          { id: 'band-2', name: '홍대 인디즈' },
+        ],
+        skills: ['일렉기타', '통기타'],
+      },
+    });
+
+    const result = await getMyProfile();
+
+    expect(result.displayName).toBe('김민준');
+  });
+});

--- a/frontend/src/features/profile-get/api/profile-api.ts
+++ b/frontend/src/features/profile-get/api/profile-api.ts
@@ -1,0 +1,4 @@
+import { apiGet } from '@/shared/api';
+import type { Profile } from '@/entities/profile/model/types';
+
+export const getMyProfile = (): Promise<Profile> => apiGet<Profile>('/me/profile');

--- a/frontend/src/features/profile-update/api/profile-api.test.ts
+++ b/frontend/src/features/profile-update/api/profile-api.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { updateMyProfile } from './profile-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('profile update 어댑터', () => {
+  it('내 프로필을 수정한다', async () => {
+    const requestBody = {
+      bio: '수정된 소개',
+      preferredGenres: ['Rock'],
+      skills: ['일렉기타'],
+    };
+
+    mock.onPatch('/me/profile', requestBody).reply(200, {
+      success: true,
+      data: {
+        id: 'profile-1',
+        nickname: '김민준',
+        displayName: '김민준',
+        bio: '수정된 소개',
+        preferredGenres: ['Rock'],
+        profileMusic: null,
+        bandSummaries: [],
+        skills: ['일렉기타'],
+      },
+    });
+
+    const result = await updateMyProfile(requestBody);
+
+    expect(result.bio).toBe('수정된 소개');
+  });
+});

--- a/frontend/src/features/profile-update/api/profile-api.ts
+++ b/frontend/src/features/profile-update/api/profile-api.ts
@@ -1,0 +1,13 @@
+import { apiPatch } from '@/shared/api';
+import type { Profile } from '@/entities/profile/model/types';
+
+export interface UpdateProfileRequest {
+  bio?: string;
+  preferredGenres?: string[];
+  profileMusicUrl?: string | null;
+  skills?: string[];
+}
+
+export const updateMyProfile = (
+  data: UpdateProfileRequest,
+): Promise<Profile> => apiPatch<Profile>('/me/profile', data);

--- a/frontend/src/features/song-create/api/song-api.test.ts
+++ b/frontend/src/features/song-create/api/song-api.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { createSong } from './song-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('song create 어댑터', () => {
+  it('곡을 생성한다', async () => {
+    const requestBody = {
+      title: '새 곡',
+      artistName: 'NewJeans',
+      sourceUrl: 'https://spotify.com/demo',
+    };
+
+    mock.onPost('/songs/band-1', requestBody).reply(200, {
+      success: true,
+      data: {
+        id: 'song-2',
+        bandId: 'band-1',
+        title: '새 곡',
+        artistName: 'NewJeans',
+        key: '',
+        bpm: null,
+        duration: '',
+        sourceUrl: 'https://spotify.com/demo',
+        sourceType: null,
+        referenceLinks: [],
+        sessionNames: [],
+        teamName: null,
+        participantMemberIds: [],
+        memo: '',
+        status: 'ACTIVE',
+      },
+    });
+
+    const result = await createSong('band-1', requestBody);
+
+    expect(result.title).toBe('새 곡');
+  });
+});

--- a/frontend/src/features/song-create/api/song-api.ts
+++ b/frontend/src/features/song-create/api/song-api.ts
@@ -1,0 +1,16 @@
+import { apiPost } from '@/shared/api';
+import type { Song } from '@/entities/song/model/types';
+
+export interface CreateSongRequest {
+  title: string;
+  artistName: string;
+  sourceUrl?: string | null;
+  sourceType?: string | null;
+  memo?: string;
+  status?: string;
+}
+
+export const createSong = (
+  bandId: string,
+  data: CreateSongRequest,
+): Promise<Song> => apiPost<Song>(`/songs/${bandId}`, data);

--- a/frontend/src/features/song-delete/api/song-api.test.ts
+++ b/frontend/src/features/song-delete/api/song-api.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { deleteSong } from './song-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('song delete 어댑터', () => {
+  it('곡을 삭제한다', async () => {
+    mock.onDelete('/songs/song-1').reply(200, {
+      success: true,
+      data: undefined,
+    });
+
+    await expect(deleteSong('song-1')).resolves.toBeUndefined();
+  });
+});

--- a/frontend/src/features/song-delete/api/song-api.ts
+++ b/frontend/src/features/song-delete/api/song-api.ts
@@ -1,0 +1,4 @@
+import { apiDelete } from '@/shared/api';
+
+export const deleteSong = (songId: string): Promise<void> =>
+  apiDelete<void>(`/songs/${songId}`);

--- a/frontend/src/features/song-get/api/song-api.test.ts
+++ b/frontend/src/features/song-get/api/song-api.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { getSong } from './song-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('song get 어댑터', () => {
+  it('곡 단건을 조회한다', async () => {
+    mock.onGet('/songs/song-1').reply(200, {
+      success: true,
+      data: {
+        id: 'song-1',
+        bandId: 'band-1',
+        title: '좋은 날',
+        artistName: 'IU',
+        key: 'A 장조',
+        bpm: 128,
+        duration: '4:20',
+        sourceUrl: null,
+        sourceType: null,
+        referenceLinks: [
+          { label: 'YouTube', url: 'https://youtube.com/watch?v=demo' },
+        ],
+        sessionNames: ['보컬1', '일렉기타'],
+        teamName: '듀얼 기타 편성',
+        participantMemberIds: ['member-1', 'member-2'],
+        memo: '첫 절은 어쿠스틱하게 시작',
+        status: 'ACTIVE',
+      },
+    });
+
+    const result = await getSong('song-1');
+
+    expect(result.referenceLinks).toHaveLength(1);
+  });
+});

--- a/frontend/src/features/song-get/api/song-api.ts
+++ b/frontend/src/features/song-get/api/song-api.ts
@@ -1,0 +1,5 @@
+import { apiGet } from '@/shared/api';
+import type { Song } from '@/entities/song/model/types';
+
+export const getSong = (songId: string): Promise<Song> =>
+  apiGet<Song>(`/songs/${songId}`);

--- a/frontend/src/features/song-list/api/song-api.test.ts
+++ b/frontend/src/features/song-list/api/song-api.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { getSongs } from './song-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('song list 어댑터', () => {
+  it('곡 목록을 조회한다', async () => {
+    mock
+      .onGet('/songs/band-1', { params: { query: '좋은 날', page: 1 } })
+      .reply(200, {
+        success: true,
+        data: [
+          {
+            id: 'song-1',
+            bandId: 'band-1',
+            title: '좋은 날',
+            artistName: 'IU',
+            key: 'A 장조',
+            bpm: 128,
+            duration: '4:20',
+            sourceUrl: null,
+            sourceType: null,
+            referenceLinks: [],
+            sessionNames: ['보컬1', '일렉기타'],
+            teamName: '듀얼 기타 편성',
+            participantMemberIds: ['member-1'],
+            memo: '',
+            status: 'ACTIVE',
+          },
+        ],
+      });
+
+    const result = await getSongs('band-1', { query: '좋은 날', page: 1 });
+
+    expect(result[0]?.title).toBe('좋은 날');
+  });
+});

--- a/frontend/src/features/song-list/api/song-api.ts
+++ b/frontend/src/features/song-list/api/song-api.ts
@@ -1,0 +1,18 @@
+import { apiGet } from '@/shared/api';
+import type { Song } from '@/entities/song/model/types';
+
+export interface GetSongsParams {
+  query?: string;
+  status?: string;
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+export const getSongs = (
+  bandId: string,
+  params?: GetSongsParams,
+): Promise<Song[]> =>
+  apiGet<Song[]>(`/songs/${bandId}`, {
+    params,
+  });

--- a/frontend/src/features/song-team-list/api/song-team-api.test.ts
+++ b/frontend/src/features/song-team-list/api/song-team-api.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { getSongTeams } from './song-team-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('song team list 어댑터', () => {
+  it('특정 곡의 팀 목록을 조회한다', async () => {
+    mock.onGet('/songs/teams/song-1', { params: { page: 1, size: 10 } }).reply(200, {
+      success: true,
+      data: [
+        {
+          id: 'team-1',
+          songId: 'song-1',
+          name: '듀얼 기타 편성',
+          memberCount: 5,
+        },
+      ],
+    });
+
+    const result = await getSongTeams('song-1', { page: 1, size: 10 });
+
+    expect(result[0]?.name).toBe('듀얼 기타 편성');
+  });
+});

--- a/frontend/src/features/song-team-list/api/song-team-api.ts
+++ b/frontend/src/features/song-team-list/api/song-team-api.ts
@@ -1,0 +1,16 @@
+import { apiGet } from '@/shared/api';
+import type { SongTeam } from '@/entities/song-team/model/types';
+
+export interface GetSongTeamsParams {
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+export const getSongTeams = (
+  songId: string,
+  params?: GetSongTeamsParams,
+): Promise<SongTeam[]> =>
+  apiGet<SongTeam[]>(`/songs/teams/${songId}`, {
+    params,
+  });

--- a/frontend/src/features/song-update/api/song-api.test.ts
+++ b/frontend/src/features/song-update/api/song-api.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { updateSong } from './song-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('song update 어댑터', () => {
+  it('곡을 수정한다', async () => {
+    const requestBody = {
+      memo: '수정된 메모',
+      status: 'ARCHIVED',
+    };
+
+    mock.onPatch('/songs/song-1', requestBody).reply(200, {
+      success: true,
+      data: {
+        id: 'song-1',
+        bandId: 'band-1',
+        title: '좋은 날',
+        artistName: 'IU',
+        key: 'A 장조',
+        bpm: 128,
+        duration: '4:20',
+        sourceUrl: null,
+        sourceType: null,
+        referenceLinks: [],
+        sessionNames: ['보컬1'],
+        teamName: null,
+        participantMemberIds: [],
+        memo: '수정된 메모',
+        status: 'ARCHIVED',
+      },
+    });
+
+    const result = await updateSong('song-1', requestBody);
+
+    expect(result.memo).toBe('수정된 메모');
+    expect(result.status).toBe('ARCHIVED');
+  });
+});

--- a/frontend/src/features/song-update/api/song-api.ts
+++ b/frontend/src/features/song-update/api/song-api.ts
@@ -1,0 +1,15 @@
+import { apiPatch } from '@/shared/api';
+import type { Song } from '@/entities/song/model/types';
+
+export interface UpdateSongRequest {
+  title?: string;
+  artistName?: string;
+  sourceUrl?: string | null;
+  memo?: string;
+  status?: string;
+}
+
+export const updateSong = (
+  songId: string,
+  data: UpdateSongRequest,
+): Promise<Song> => apiPatch<Song>(`/songs/${songId}`, data);

--- a/frontend/src/features/space-create/api/space-api.test.ts
+++ b/frontend/src/features/space-create/api/space-api.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { createSpace } from './space-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('space create 어댑터', () => {
+  it('공연 공간을 생성한다', async () => {
+    const requestBody = {
+      name: '신규 공연 공간',
+      description: '설명',
+      spaceType: 'PRACTICE' as const,
+      eventDate: null,
+    };
+
+    mock.onPost('/bands/band-1/spaces', requestBody).reply(200, {
+      success: true,
+      data: {
+        id: 'space-2',
+        bandId: 'band-1',
+        name: '신규 공연 공간',
+        description: '설명',
+        spaceType: 'PRACTICE',
+        eventDate: null,
+      },
+    });
+
+    const result = await createSpace('band-1', requestBody);
+
+    expect(result.name).toBe('신규 공연 공간');
+  });
+});

--- a/frontend/src/features/space-create/api/space-api.ts
+++ b/frontend/src/features/space-create/api/space-api.ts
@@ -1,0 +1,14 @@
+import { apiPost } from '@/shared/api';
+import type { Space, SpaceType } from '@/entities/space/model/types';
+
+export interface CreateSpaceRequest {
+  name: string;
+  description?: string;
+  spaceType?: SpaceType;
+  eventDate?: string | null;
+}
+
+export const createSpace = (
+  bandId: string,
+  data: CreateSpaceRequest,
+): Promise<Space> => apiPost<Space>(`/bands/${bandId}/spaces`, data);

--- a/frontend/src/features/space-get/api/space-api.test.ts
+++ b/frontend/src/features/space-get/api/space-api.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { getSpace } from './space-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('space get 어댑터', () => {
+  it('공연 공간 단건을 조회한다', async () => {
+    mock.onGet('/spaces/space-1').reply(200, {
+      success: true,
+      data: {
+        id: 'space-1',
+        bandId: 'band-1',
+        name: '2026 하계공연 무대',
+        description: '여름 축제 공연 준비',
+        spaceType: 'PERFORMANCE_PREP',
+        eventDate: '2026-08-20',
+      },
+    });
+
+    const result = await getSpace('space-1');
+
+    expect(result.spaceType).toBe('PERFORMANCE_PREP');
+  });
+});

--- a/frontend/src/features/space-get/api/space-api.ts
+++ b/frontend/src/features/space-get/api/space-api.ts
@@ -1,0 +1,5 @@
+import { apiGet } from '@/shared/api';
+import type { Space } from '@/entities/space/model/types';
+
+export const getSpace = (spaceId: string): Promise<Space> =>
+  apiGet<Space>(`/spaces/${spaceId}`);

--- a/frontend/src/features/space-list/api/space-api.test.ts
+++ b/frontend/src/features/space-list/api/space-api.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { getBandSpaces } from './space-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('space list 어댑터', () => {
+  it('밴드 공연 공간 목록을 조회한다', async () => {
+    mock
+      .onGet('/bands/band-1/spaces', { params: { query: '하계공연', page: 1 } })
+      .reply(200, {
+        success: true,
+        data: [
+          {
+            id: 'space-1',
+            bandId: 'band-1',
+            name: '2026 하계공연 무대',
+            description: '여름 축제 공연 준비',
+            spaceType: 'PERFORMANCE_PREP',
+            eventDate: '2026-08-20',
+          },
+        ],
+      });
+
+    const result = await getBandSpaces('band-1', { query: '하계공연', page: 1 });
+
+    expect(result[0]?.name).toBe('2026 하계공연 무대');
+  });
+});

--- a/frontend/src/features/space-list/api/space-api.ts
+++ b/frontend/src/features/space-list/api/space-api.ts
@@ -1,0 +1,19 @@
+import { apiGet } from '@/shared/api';
+import type { Space } from '@/entities/space/model/types';
+
+export interface GetSpacesParams {
+  query?: string;
+  onlyMine?: boolean;
+  inProgressOnly?: boolean;
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+export const getBandSpaces = (
+  bandId: string,
+  params?: GetSpacesParams,
+): Promise<Space[]> =>
+  apiGet<Space[]>(`/bands/${bandId}/spaces`, {
+    params,
+  });

--- a/frontend/src/mocks/band/handlers.ts
+++ b/frontend/src/mocks/band/handlers.ts
@@ -1,10 +1,11 @@
 import type { Band } from '@/entities/band/model/types';
 import type { ApiResponse } from '@/shared/api';
 import { http, HttpResponse } from 'msw';
+import { API_URL } from '../config';
 
 export const bandHandlers = [
   // 밴드 목록 조회 Mock
-  http.get('/bands', () => {
+  http.get(`${API_URL}/bands`, () => {
     return HttpResponse.json<ApiResponse<Band[]>>({
       success: true,
       data: [
@@ -16,7 +17,7 @@ export const bandHandlers = [
   }),
 
   // 밴드 생성 Mock
-  http.post('/bands', async ({ request }) => {
+  http.post(`${API_URL}/bands`, async ({ request }) => {
     const body = (await request.json()) as { name: string };
 
     // 단순 딜레이 시뮬레이션

--- a/frontend/src/mocks/config.ts
+++ b/frontend/src/mocks/config.ts
@@ -1,0 +1,1 @@
+export const API_URL = '/api';

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,8 +1,17 @@
 import { bandHandlers } from './band/handlers';
+import { inviteHandlers } from './invite/handlers';
+import { profileHandlers } from './profile/handlers';
 import { scheduleHandlers } from './schedule/handlers';
+import { songHandlers } from './song/handlers';
+import { songTeamHandlers } from './song-team/handlers';
+import { spaceHandlers } from './space/handlers';
 
 export const handlers = [
   ...bandHandlers,
+  ...inviteHandlers,
+  ...profileHandlers,
   ...scheduleHandlers,
-  // 이후 추가될 타 도메인 핸들러들
+  ...songHandlers,
+  ...songTeamHandlers,
+  ...spaceHandlers,
 ];

--- a/frontend/src/mocks/invite/handlers.ts
+++ b/frontend/src/mocks/invite/handlers.ts
@@ -1,0 +1,47 @@
+import { http, HttpResponse } from 'msw';
+import type { ApiResponse } from '@/shared/api';
+import type { Invite } from '@/entities/invite/model/types';
+import { API_URL } from '../config';
+
+const invite: Invite = {
+  id: 'invite-1',
+  bandId: 'band-1',
+  bandName: '신촌 락밴드',
+  inviteeEmail: 'member@example.com',
+  inviteCode: 'INV-team-1-DEMO1',
+  inviteLink: 'https://example.com/invites/demo',
+  token: 'token-1',
+  status: 'PENDING',
+};
+
+export const inviteHandlers = [
+  http.get(`${API_URL}/invites/:bandId`, () => {
+    return HttpResponse.json<ApiResponse<Invite[]>>({
+      success: true,
+      data: [invite],
+    });
+  }),
+  http.post(`${API_URL}/bands/:bandId/invites`, async ({ request }) => {
+    const body = (await request.json()) as { inviteeEmail: string };
+
+    return HttpResponse.json<ApiResponse<Invite>>({
+      success: true,
+      data: {
+        ...invite,
+        inviteeEmail: body.inviteeEmail,
+      },
+    });
+  }),
+  http.post(`${API_URL}/invites/:token/accept`, () => {
+    return HttpResponse.json<ApiResponse<void>>({
+      success: true,
+      data: undefined,
+    });
+  }),
+  http.post(`${API_URL}/invites/:token/decline`, () => {
+    return HttpResponse.json<ApiResponse<void>>({
+      success: true,
+      data: undefined,
+    });
+  }),
+];

--- a/frontend/src/mocks/profile/handlers.ts
+++ b/frontend/src/mocks/profile/handlers.ts
@@ -1,0 +1,43 @@
+import { http, HttpResponse } from 'msw';
+import type { ApiResponse } from '@/shared/api';
+import type { Profile } from '@/entities/profile/model/types';
+import { API_URL } from '../config';
+
+const profile: Profile = {
+  id: 'profile-1',
+  email: 'member@example.com',
+  nickname: '김민준',
+  displayName: '김민준',
+  bio: '음악으로 세상과 소통하는 기타리스트',
+  preferredGenres: ['Rock', 'J-Pop', 'Blues'],
+  profileMusic: {
+    title: 'Time of our life',
+    artistName: 'Day6',
+    url: null,
+  },
+  bandSummaries: [
+    { id: 'band-1', name: '신촌 락밴드' },
+    { id: 'band-2', name: '홍대 인디즈' },
+  ],
+  skills: ['일렉기타', '통기타', '보컬'],
+};
+
+export const profileHandlers = [
+  http.get(`${API_URL}/me/profile`, () => {
+    return HttpResponse.json<ApiResponse<Profile>>({
+      success: true,
+      data: profile,
+    });
+  }),
+  http.patch(`${API_URL}/me/profile`, async ({ request }) => {
+    const body = (await request.json()) as Partial<Profile>;
+
+    return HttpResponse.json<ApiResponse<Profile>>({
+      success: true,
+      data: {
+        ...profile,
+        ...body,
+      },
+    });
+  }),
+];

--- a/frontend/src/mocks/schedule/handlers.ts
+++ b/frontend/src/mocks/schedule/handlers.ts
@@ -1,8 +1,9 @@
 import { http, HttpResponse } from 'msw';
 import type { Schedule } from '@/entities/schedule/model/types';
+import { API_URL } from '../config';
 
 export const scheduleHandlers = [
-  http.post('/api/schedule', async ({ request }) => {
+  http.post(`${API_URL}/schedule`, async ({ request }) => {
     const payload = (await request.json()) as Omit<
       Schedule,
       'id' | 'createdAt' | 'updatedAt'

--- a/frontend/src/mocks/song-team/handlers.ts
+++ b/frontend/src/mocks/song-team/handlers.ts
@@ -1,0 +1,22 @@
+import { http, HttpResponse } from 'msw';
+import type { ApiResponse } from '@/shared/api';
+import type { SongTeam } from '@/entities/song-team/model/types';
+import { API_URL } from '../config';
+
+const songTeams: SongTeam[] = [
+  {
+    id: 'team-1',
+    songId: 'song-1',
+    name: '듀얼 기타 편성',
+    memberCount: 5,
+  },
+];
+
+export const songTeamHandlers = [
+  http.get(`${API_URL}/songs/teams/:songId`, () => {
+    return HttpResponse.json<ApiResponse<SongTeam[]>>({
+      success: true,
+      data: songTeams,
+    });
+  }),
+];

--- a/frontend/src/mocks/song/handlers.ts
+++ b/frontend/src/mocks/song/handlers.ts
@@ -1,0 +1,71 @@
+import { http, HttpResponse } from 'msw';
+import type { ApiResponse } from '@/shared/api';
+import type { Song } from '@/entities/song/model/types';
+import { API_URL } from '../config';
+
+const song: Song = {
+  id: 'song-1',
+  bandId: 'band-1',
+  title: '좋은 날',
+  artistName: 'IU',
+  key: 'A 장조',
+  bpm: 128,
+  duration: '4:20',
+  sourceUrl: null,
+  sourceType: null,
+  referenceLinks: [
+    { label: 'YouTube', url: 'https://youtube.com/watch?v=demo' },
+  ],
+  sessionNames: ['보컬1', '일렉기타'],
+  teamName: '듀얼 기타 편성',
+  participantMemberIds: ['member-1', 'member-2'],
+  memo: '첫 절은 어쿠스틱하게 시작',
+  status: 'ACTIVE',
+};
+
+export const songHandlers = [
+  http.get(`${API_URL}/songs/:id`, ({ params }) => {
+    const id = String(params.id);
+
+    if (id.startsWith('band-')) {
+      return HttpResponse.json<ApiResponse<Song[]>>({
+        success: true,
+        data: [song],
+      });
+    }
+
+    return HttpResponse.json<ApiResponse<Song>>({
+      success: true,
+      data: song,
+    });
+  }),
+  http.post(`${API_URL}/songs/:bandId`, async ({ request }) => {
+    const body = (await request.json()) as Partial<Song>;
+
+    return HttpResponse.json<ApiResponse<Song>>({
+      success: true,
+      data: {
+        ...song,
+        ...body,
+        id: 'song-created',
+      },
+    });
+  }),
+  http.patch(`${API_URL}/songs/:songId`, async ({ request }) => {
+    const body = (await request.json()) as Partial<Song>;
+
+    return HttpResponse.json<ApiResponse<Song>>({
+      success: true,
+      data: {
+        ...song,
+        ...body,
+      },
+    });
+  }),
+  http.delete(`${API_URL}/songs/:songId`, () => {
+    return HttpResponse.json<ApiResponse<void>>({
+      success: true,
+      data: undefined,
+    });
+  }),
+];

--- a/frontend/src/mocks/space/handlers.ts
+++ b/frontend/src/mocks/space/handlers.ts
@@ -1,0 +1,40 @@
+import { http, HttpResponse } from 'msw';
+import type { ApiResponse } from '@/shared/api';
+import type { Space } from '@/entities/space/model/types';
+import { API_URL } from '../config';
+
+const space: Space = {
+  id: 'space-1',
+  bandId: 'band-1',
+  name: '2026 하계공연 무대',
+  description: '여름 축제 공연 준비',
+  spaceType: 'PERFORMANCE_PREP',
+  eventDate: '2026-08-20',
+};
+
+export const spaceHandlers = [
+  http.get(`${API_URL}/bands/:bandId/spaces`, () => {
+    return HttpResponse.json<ApiResponse<Space[]>>({
+      success: true,
+      data: [space],
+    });
+  }),
+  http.get(`${API_URL}/spaces/:spaceId`, () => {
+    return HttpResponse.json<ApiResponse<Space>>({
+      success: true,
+      data: space,
+    });
+  }),
+  http.post(`${API_URL}/bands/:bandId/spaces`, async ({ request }) => {
+    const body = (await request.json()) as Partial<Space>;
+
+    return HttpResponse.json<ApiResponse<Space>>({
+      success: true,
+      data: {
+        ...space,
+        ...body,
+        id: 'space-created',
+      },
+    });
+  }),
+];

--- a/frontend/src/shared/api/config.ts
+++ b/frontend/src/shared/api/config.ts
@@ -1,4 +1,4 @@
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "";
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "/api";
 
 export const API_TIMEOUT = 10_000;
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,4 +30,13 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
 });


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 5m

<br/>

## 📌 작업 요약

- `pnpm run dev`를 실행했을 때 제대로 api 요청이 되지 않아, `vite.config`에 proxy 설정을 추가하고(http), `/api` prefix를 msw에 적용했습니다.
- API 명세(구글시트)와 프로토타입을 참고하여 최소 엔티티 스키마를 추가했습니다.
- features를 행위 기준으로 분리한 최소 API adapter와 mock/test 기반을 정리했습니다.

<br/>

## 📝 작업 내용

1. API 명세가 아직 확정되지 않은 영역에 대해 화면 렌더에 필요한 최소 entity schema/type 추가
2. 다음 액션 feature의 최소 API adapter 추가
- `invite-list`, `invite-create`, `invite-accept`, `invite-decline`
- `profile-get`, `profile-update`
- `song-list`, `song-get`, `song-create`, `song-update`, `song-delete`
- `song-team-list`
- `space-list`, `space-get`, `space-create`
3. 각 adapter에 대한 최소 단위 테스트 추가
4. MSW mock handler를 최소 응답 기준으로 추가

<br/>

## 🚨 주요 고민 및 해결 과정

전체 UI/플로우를 먼저 만들지 않고 엔티티와 API 연결의 가장 초기 단계만 고정했습니다.
이후 TDD를 짧은 step 단위로 진행할 수 있는 기반을 마련합니다.

<br/>

## 💬 리뷰 요구사항

- 파일이 많지만 대부분 비슷한 내용이고, 타입 등은 확정되지 않은 부분이 많아서(임시 최솟값 작성) 간단하게 넘겨만 보시면 됩니다!
- 아직 응답 명세가 비어 있는 필드는 과도하게 확정하지 않고 nullable/default/optional 위주로 최소화했습니다.
- UI 구현, hook 확장, 통합 플로우 테스트는 이번 범위에서 제외했습니다.
- 명세 응답값까지 확정된 후 파일 수정하여 확정하면 될 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 사용자 초대 기능 추가 (초대 생성, 수락, 거절, 목록 조회)
  * 프로필 관리 기능 강화 (프로필 조회 및 수정)
  * 곡 관리 기능 확대 (생성, 조회, 수정, 삭제)
  * 스페이스 관리 기능 추가 (생성, 조회, 목록 조회)
  * 데이터 검증 스키마 시스템 구축

* **Tests**
  * API 엔드포인트별 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->