### PR TITLE
합주 공간 목록 조회 API 스켈레톤 구현

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint \"src/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "start": "node dist/main.js",
-    "start:dev": "tsx watch src/main.ts"
+    "start:dev": "tsx watch src/main.ts",
+    "test": "node --import tsx --test src/**/*.spec.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.1.13",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 
+import { SpacesModule } from './modules/spaces/spaces.module';
+
 @Module({
-  imports: [],
+  imports: [SpacesModule],
 })
 export class AppModule {}

--- a/backend/src/common/api-response/api-response.ts
+++ b/backend/src/common/api-response/api-response.ts
@@ -1,0 +1,40 @@
+export interface ApiErrorDetails {
+  [key: string]: string | number | boolean | null | undefined;
+}
+
+export interface ApiError {
+  code: string;
+  details?: ApiErrorDetails;
+}
+
+export interface ApiSuccessResponse<T> {
+  status: 'success';
+  error: null;
+  message: string;
+  data: T;
+}
+
+export interface ApiFailResponse {
+  status: 'fail';
+  error: ApiError;
+  message: string;
+  data: Record<string, never>;
+}
+
+export type ApiResponse<T> = ApiSuccessResponse<T> | ApiFailResponse;
+
+/**
+ * 성공 응답 형식을 문서 기준으로 고정한다.
+ *
+ * @param message 클라이언트에 전달할 성공 메시지
+ * @param data 실제 응답 데이터
+ * @returns 공통 성공 응답 객체
+ */
+export function createSuccessResponse<T>(message: string, data: T): ApiSuccessResponse<T> {
+  return {
+    status: 'success',
+    error: null,
+    message,
+    data,
+  };
+}

--- a/backend/src/common/api-response/index.ts
+++ b/backend/src/common/api-response/index.ts
@@ -1,0 +1,1 @@
+export * from './api-response';

--- a/backend/src/common/pagination/index.ts
+++ b/backend/src/common/pagination/index.ts
@@ -1,0 +1,1 @@
+export * from './pagination.util';

--- a/backend/src/common/pagination/pagination.util.ts
+++ b/backend/src/common/pagination/pagination.util.ts
@@ -1,0 +1,44 @@
+export interface PaginationParams {
+  page: number;
+  size: number;
+}
+
+export interface PaginationResult {
+  page: number;
+  size: number;
+  totalCount: number;
+  hasNext: boolean;
+}
+
+/**
+ * 목록 조회 응답에서 공통으로 쓰는 페이지네이션 메타데이터를 계산한다.
+ *
+ * @param totalCount 필터링과 정렬이 끝난 전체 데이터 수
+ * @param params 요청에서 전달받은 페이지 정보
+ * @returns 응답에 그대로 담을 수 있는 페이지네이션 메타데이터
+ */
+export function createPagination(totalCount: number, params: PaginationParams): PaginationResult {
+  const totalPageCount = Math.ceil(totalCount / params.size);
+  const hasNext = params.page < totalPageCount;
+
+  return {
+    page: params.page,
+    size: params.size,
+    totalCount,
+    hasNext,
+  };
+}
+
+/**
+ * 페이지 정보에 맞게 현재 페이지에 해당하는 데이터만 잘라낸다.
+ *
+ * @param items 전체 목록 또는 필터링된 목록
+ * @param params 요청에서 전달받은 페이지 정보
+ * @returns 현재 페이지에 노출할 데이터 목록
+ */
+export function paginateItems<T>(items: T[], params: PaginationParams): T[] {
+  const startIndex = (params.page - 1) * params.size;
+  const endIndex = startIndex + params.size;
+
+  return items.slice(startIndex, endIndex);
+}

--- a/backend/src/common/query/index.ts
+++ b/backend/src/common/query/index.ts
@@ -1,0 +1,1 @@
+export * from './query-param.util';

--- a/backend/src/common/query/query-param.util.ts
+++ b/backend/src/common/query/query-param.util.ts
@@ -1,0 +1,68 @@
+import { BadRequestException } from '@nestjs/common';
+
+/**
+ * 빈 문자열을 의미 없는 입력으로 보고 undefined 로 정리한다.
+ *
+ * @param value 원본 쿼리 문자열
+ * @returns 조건 분기에서 바로 사용할 수 있는 문자열 또는 undefined
+ */
+export function normalizeOptionalString(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const trimmedValue = value.trim();
+
+  if (trimmedValue.length === 0) {
+    return undefined;
+  }
+
+  return trimmedValue;
+}
+
+/**
+ * 양의 정수만 허용하는 쿼리 파라미터를 검증한다.
+ *
+ * @param value 원본 쿼리 문자열
+ * @param fieldName 에러 메시지에 표시할 필드명
+ * @param defaultValue 값이 없을 때 사용할 기본값
+ * @returns 검증이 끝난 양의 정수
+ */
+export function parseOptionalPositiveInteger(value: string | undefined, fieldName: string, defaultValue: number): number {
+  if (value === undefined) {
+    return defaultValue;
+  }
+
+  const parsedValue = Number(value);
+  const isInteger = Number.isInteger(parsedValue);
+  const isPositive = parsedValue > 0;
+
+  if (!isInteger || !isPositive) {
+    throw new BadRequestException(`${fieldName}는 1 이상의 정수여야 합니다.`);
+  }
+
+  return parsedValue;
+}
+
+/**
+ * boolean 성격의 쿼리 문자열을 명시적으로 변환한다.
+ *
+ * @param value 원본 쿼리 문자열
+ * @param fieldName 에러 메시지에 표시할 필드명
+ * @returns boolean 값 또는 undefined
+ */
+export function parseOptionalBoolean(value: string | undefined, fieldName: string): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === 'true') {
+    return true;
+  }
+
+  if (value === 'false') {
+    return false;
+  }
+
+  throw new BadRequestException(`${fieldName}는 true 또는 false 여야 합니다.`);
+}

--- a/backend/src/modules/spaces/dto/get-band-spaces-query.dto.ts
+++ b/backend/src/modules/spaces/dto/get-band-spaces-query.dto.ts
@@ -1,0 +1,41 @@
+import { normalizeOptionalString, parseOptionalBoolean, parseOptionalPositiveInteger } from '../../../common/query';
+
+export interface GetBandSpacesQueryParams {
+  query?: string;
+  onlyMine?: string;
+  inProgressOnly?: string;
+  page?: string;
+  size?: string;
+  sort?: string;
+}
+
+export interface GetBandSpacesQuery {
+  query?: string;
+  onlyMine?: boolean;
+  inProgressOnly?: boolean;
+  page: number;
+  size: number;
+  sort?: string;
+}
+
+/**
+ * 문자열 쿼리를 서비스에서 다루기 쉬운 형태로 변환한다.
+ *
+ * @param params 컨트롤러에서 전달받은 원본 쿼리 문자열
+ * @returns 필터링과 페이지네이션에 바로 사용할 수 있는 쿼리 객체
+ */
+export function parseGetBandSpacesQuery(params: GetBandSpacesQueryParams): GetBandSpacesQuery {
+  const parsedPage = parseOptionalPositiveInteger(params.page, 'page', 1);
+  const parsedSize = parseOptionalPositiveInteger(params.size, 'size', 20);
+  const parsedOnlyMine = parseOptionalBoolean(params.onlyMine, 'onlyMine');
+  const parsedInProgressOnly = parseOptionalBoolean(params.inProgressOnly, 'inProgressOnly');
+
+  return {
+    query: normalizeOptionalString(params.query),
+    onlyMine: parsedOnlyMine,
+    inProgressOnly: parsedInProgressOnly,
+    page: parsedPage,
+    size: parsedSize,
+    sort: normalizeOptionalString(params.sort),
+  };
+}

--- a/backend/src/modules/spaces/repositories/spaces.mock-repository.ts
+++ b/backend/src/modules/spaces/repositories/spaces.mock-repository.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@nestjs/common';
+
+import type { BandSpaceListItem } from '../types/band-space-list-item.type';
+
+@Injectable()
+export class SpacesMockRepository {
+  private readonly spaces: BandSpaceListItem[] = [
+    {
+      spaceId: 'space-001',
+      bandId: 'band-001',
+      createdByUserId: 'user-001',
+      name: '2026 하계공연 준비',
+      description: '여름 축제 공연 준비 팀',
+      spaceType: 'STUDIO',
+      status: 'ACTIVE',
+      startDate: '2026-08-01',
+      endDate: '2026-08-20',
+      memberCount: 10,
+      songCount: 12,
+      isMine: true,
+      myMembership: {
+        isMember: true,
+        role: 'LEADER',
+      },
+      createdAt: '2026-02-18T10:20:30Z',
+      updatedAt: '2026-02-20T12:00:00Z',
+    },
+    {
+      spaceId: 'space-002',
+      bandId: 'band-001',
+      createdByUserId: 'user-002',
+      name: '봄 정기공연 어쿠스틱 세션',
+      description: '어쿠스틱 편성 연습 공간',
+      spaceType: 'PRACTICE_ROOM',
+      status: 'ACTIVE',
+      startDate: '2026-03-01',
+      endDate: '2026-03-25',
+      memberCount: 5,
+      songCount: 4,
+      isMine: false,
+      myMembership: {
+        isMember: true,
+        role: 'MEMBER',
+      },
+      createdAt: '2026-02-25T08:00:00Z',
+      updatedAt: '2026-02-28T09:30:00Z',
+    },
+    {
+      spaceId: 'space-003',
+      bandId: 'band-002',
+      createdByUserId: 'user-003',
+      name: '온라인 편곡 회의',
+      description: '원격으로 진행하는 편곡 논의 공간',
+      spaceType: 'ONLINE',
+      status: 'INACTIVE',
+      startDate: '2026-04-01',
+      endDate: '2026-04-10',
+      memberCount: 3,
+      songCount: 1,
+      isMine: true,
+      myMembership: {
+        isMember: true,
+        role: 'LEADER',
+      },
+      createdAt: '2026-03-01T10:00:00Z',
+      updatedAt: '2026-03-02T10:00:00Z',
+    },
+  ];
+
+  findAll(): BandSpaceListItem[] {
+    return this.spaces;
+  }
+}

--- a/backend/src/modules/spaces/repositories/spaces.mock-repository.ts
+++ b/backend/src/modules/spaces/repositories/spaces.mock-repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import type { BandSpaceListItem } from '../types/band-space-list-item.type';
+import type { GetSpaceDetailResult } from '../types/space-detail.type';
 
 @Injectable()
 export class SpacesMockRepository {
@@ -67,7 +68,71 @@ export class SpacesMockRepository {
     },
   ];
 
+  private readonly spaceDetails: GetSpaceDetailResult[] = [
+    {
+      space: {
+        spaceId: 'space-001',
+        bandId: 'band-001',
+        name: '2026 하계공연 준비',
+        description: '여름 축제 공연 준비 팀',
+        spaceType: 'STUDIO',
+        status: 'ACTIVE',
+        startDate: '2026-08-01',
+        endDate: '2026-08-20',
+        createdAt: '2026-02-18T10:20:30Z',
+        updatedAt: '2026-02-20T12:00:00Z',
+      },
+      members: [
+        {
+          userId: 'user-001',
+          nickname: '김민준',
+          role: 'LEADER',
+          status: 'ACTIVE',
+          joinedAt: '2026-02-18T10:21:00Z',
+        },
+        {
+          userId: 'user-002',
+          nickname: '이서연',
+          role: 'MEMBER',
+          status: 'ACTIVE',
+          joinedAt: '2026-02-18T10:22:00Z',
+        },
+      ],
+      songCount: 12,
+      scheduleCount: 28,
+    },
+    {
+      space: {
+        spaceId: 'space-002',
+        bandId: 'band-001',
+        name: '봄 정기공연 어쿠스틱 세션',
+        description: '어쿠스틱 편성 연습 공간',
+        spaceType: 'PRACTICE_ROOM',
+        status: 'ACTIVE',
+        startDate: '2026-03-01',
+        endDate: '2026-03-25',
+        createdAt: '2026-02-25T08:00:00Z',
+        updatedAt: '2026-02-28T09:30:00Z',
+      },
+      members: [
+        {
+          userId: 'user-002',
+          nickname: '이서연',
+          role: 'LEADER',
+          status: 'ACTIVE',
+          joinedAt: '2026-02-25T08:10:00Z',
+        },
+      ],
+      songCount: 4,
+      scheduleCount: 9,
+    },
+  ];
+
   findAll(): BandSpaceListItem[] {
     return this.spaces;
+  }
+
+  findDetailBySpaceId(spaceId: string): GetSpaceDetailResult | undefined {
+    return this.spaceDetails.find(spaceDetail => spaceDetail.space.spaceId === spaceId);
   }
 }

--- a/backend/src/modules/spaces/spaces.controller.spec.ts
+++ b/backend/src/modules/spaces/spaces.controller.spec.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+
+import test from 'node:test';
+
+import { SpacesMockRepository } from './repositories/spaces.mock-repository';
+import { SpacesController } from './spaces.controller';
+import { SpacesService } from './spaces.service';
+
+test('합주 공간 목록 조회 컨트롤러는 문서 기준 성공 응답 형식을 반환한다', () => {
+  const repository = new SpacesMockRepository();
+  const service = new SpacesService(repository);
+  const controller = new SpacesController(service);
+
+  const response = controller.getBandSpaces('band-001', {
+    query: '공연',
+    page: '1',
+    size: '10',
+  });
+
+  assert.equal(response.status, 'success');
+  assert.equal(response.error, null);
+  assert.equal(response.message, '합주 공간 목록 조회 성공');
+  assert.equal(response.data.items.length, 2);
+  assert.equal(response.data.pagination.totalCount, 2);
+});

--- a/backend/src/modules/spaces/spaces.controller.spec.ts
+++ b/backend/src/modules/spaces/spaces.controller.spec.ts
@@ -6,7 +6,7 @@ import { SpacesMockRepository } from './repositories/spaces.mock-repository';
 import { SpacesController } from './spaces.controller';
 import { SpacesService } from './spaces.service';
 
-test('합주 공간 목록 조회 컨트롤러는 문서 기준 성공 응답 형식을 반환한다', () => {
+test('합주 공간 목록 조회 컨트롤러는 공통 성공 응답 형식을 반환한다', () => {
   const repository = new SpacesMockRepository();
   const service = new SpacesService(repository);
   const controller = new SpacesController(service);
@@ -22,4 +22,20 @@ test('합주 공간 목록 조회 컨트롤러는 문서 기준 성공 응답 �
   assert.equal(response.message, '합주 공간 목록 조회 성공');
   assert.equal(response.data.items.length, 2);
   assert.equal(response.data.pagination.totalCount, 2);
+});
+
+test('합주 공간 상세 조회 컨트롤러는 공통 성공 응답 형식을 반환한다', () => {
+  const repository = new SpacesMockRepository();
+  const service = new SpacesService(repository);
+  const controller = new SpacesController(service);
+
+  const response = controller.getSpaceDetail('space-001');
+
+  assert.equal(response.status, 'success');
+  assert.equal(response.error, null);
+  assert.equal(response.message, '합주 공간 상세 조회 성공');
+  assert.equal(response.data.space.spaceId, 'space-001');
+  assert.equal(response.data.members.length, 2);
+  assert.equal(response.data.songCount, 12);
+  assert.equal(response.data.scheduleCount, 28);
 });

--- a/backend/src/modules/spaces/spaces.controller.ts
+++ b/backend/src/modules/spaces/spaces.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+
+import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
+
+import { type GetBandSpacesQueryParams, parseGetBandSpacesQuery } from './dto/get-band-spaces-query.dto';
+import type { GetBandSpacesResult } from './types/band-space-list-item.type';
+import { SpacesService } from './spaces.service';
+
+@Controller('bands/:bandId/spaces')
+export class SpacesController {
+  constructor(private readonly spacesService: SpacesService) {}
+
+  @Get()
+  getBandSpaces(@Param('bandId') bandId: string, @Query() rawQuery: GetBandSpacesQueryParams): ApiSuccessResponse<GetBandSpacesResult> {
+    const query = parseGetBandSpacesQuery(rawQuery);
+    const spaces = this.spacesService.getBandSpaces(bandId, query);
+
+    return createSuccessResponse('합주 공간 목록 조회 성공', spaces);
+  }
+}

--- a/backend/src/modules/spaces/spaces.controller.ts
+++ b/backend/src/modules/spaces/spaces.controller.ts
@@ -4,17 +4,25 @@ import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api
 
 import { type GetBandSpacesQueryParams, parseGetBandSpacesQuery } from './dto/get-band-spaces-query.dto';
 import type { GetBandSpacesResult } from './types/band-space-list-item.type';
+import type { GetSpaceDetailResult } from './types/space-detail.type';
 import { SpacesService } from './spaces.service';
 
-@Controller('bands/:bandId/spaces')
+@Controller()
 export class SpacesController {
   constructor(private readonly spacesService: SpacesService) {}
 
-  @Get()
+  @Get('bands/:bandId/spaces')
   getBandSpaces(@Param('bandId') bandId: string, @Query() rawQuery: GetBandSpacesQueryParams): ApiSuccessResponse<GetBandSpacesResult> {
     const query = parseGetBandSpacesQuery(rawQuery);
     const spaces = this.spacesService.getBandSpaces(bandId, query);
 
     return createSuccessResponse('합주 공간 목록 조회 성공', spaces);
+  }
+
+  @Get('spaces/:spaceId')
+  getSpaceDetail(@Param('spaceId') spaceId: string): ApiSuccessResponse<GetSpaceDetailResult> {
+    const spaceDetail = this.spacesService.getSpaceDetail(spaceId);
+
+    return createSuccessResponse('합주 공간 상세 조회 성공', spaceDetail);
   }
 }

--- a/backend/src/modules/spaces/spaces.module.ts
+++ b/backend/src/modules/spaces/spaces.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { SpacesMockRepository } from './repositories/spaces.mock-repository';
+import { SpacesController } from './spaces.controller';
+import { SpacesService } from './spaces.service';
+
+@Module({
+  controllers: [SpacesController],
+  providers: [SpacesService, SpacesMockRepository],
+})
+export class SpacesModule {}

--- a/backend/src/modules/spaces/spaces.service.spec.ts
+++ b/backend/src/modules/spaces/spaces.service.spec.ts
@@ -25,3 +25,17 @@ test('합주 공간 목록 조회 서비스는 밴드, 검색어, 페이지네�
   assert.equal(result.pagination.totalCount, 2);
   assert.equal(result.pagination.hasNext, true);
 });
+
+test('합주 공간 상세 조회 서비스는 공간 상세 정보와 멤버 목록을 반환한다', () => {
+  const repository = new SpacesMockRepository();
+  const service = new SpacesService(repository);
+
+  const result = service.getSpaceDetail('space-001');
+
+  assert.equal(result.space.spaceId, 'space-001');
+  assert.equal(result.space.bandId, 'band-001');
+  assert.equal(result.members.length, 2);
+  assert.equal(result.members[0]?.nickname, '김민준');
+  assert.equal(result.songCount, 12);
+  assert.equal(result.scheduleCount, 28);
+});

--- a/backend/src/modules/spaces/spaces.service.spec.ts
+++ b/backend/src/modules/spaces/spaces.service.spec.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+
+import test from 'node:test';
+
+import { SpacesMockRepository } from './repositories/spaces.mock-repository';
+import { SpacesService } from './spaces.service';
+
+test('합주 공간 목록 조회 서비스는 밴드, 검색어, 페이지네이션 조건을 적용한다', () => {
+  const repository = new SpacesMockRepository();
+  const service = new SpacesService(repository);
+
+  const result = service.getBandSpaces('band-001', {
+    query: '공연',
+    onlyMine: undefined,
+    inProgressOnly: true,
+    page: 1,
+    size: 1,
+    sort: 'createdAt,asc',
+  });
+
+  assert.equal(result.items.length, 1);
+  assert.equal(result.items[0]?.spaceId, 'space-001');
+  assert.equal(result.pagination.page, 1);
+  assert.equal(result.pagination.size, 1);
+  assert.equal(result.pagination.totalCount, 2);
+  assert.equal(result.pagination.hasNext, true);
+});

--- a/backend/src/modules/spaces/spaces.service.ts
+++ b/backend/src/modules/spaces/spaces.service.ts
@@ -1,0 +1,85 @@
+import { Injectable } from '@nestjs/common';
+
+import { createPagination, paginateItems } from '../../common/pagination';
+
+import type { GetBandSpacesQuery } from './dto/get-band-spaces-query.dto';
+import { SpacesMockRepository } from './repositories/spaces.mock-repository';
+import type { BandSpaceListItem, GetBandSpacesResult } from './types/band-space-list-item.type';
+
+@Injectable()
+export class SpacesService {
+  constructor(private readonly spacesRepository: SpacesMockRepository) {}
+
+  getBandSpaces(bandId: string, query: GetBandSpacesQuery): GetBandSpacesResult {
+    const allSpaces = this.spacesRepository.findAll();
+    const bandSpaces = allSpaces.filter(space => space.bandId === bandId);
+    const searchedSpaces = this.applySearchFilter(bandSpaces, query.query);
+    const mineFilteredSpaces = this.applyOnlyMineFilter(searchedSpaces, query.onlyMine);
+    const statusFilteredSpaces = this.applyInProgressFilter(mineFilteredSpaces, query.inProgressOnly);
+    const sortedSpaces = this.applySort(statusFilteredSpaces, query.sort);
+    const pagination = createPagination(sortedSpaces.length, {
+      page: query.page,
+      size: query.size,
+    });
+    const pagedSpaces = paginateItems(sortedSpaces, {
+      page: query.page,
+      size: query.size,
+    });
+
+    return {
+      items: pagedSpaces,
+      pagination,
+    };
+  }
+
+  private applySearchFilter(spaces: BandSpaceListItem[], keyword: string | undefined): BandSpaceListItem[] {
+    if (keyword === undefined) {
+      return spaces;
+    }
+
+    const normalizedKeyword = keyword.toLowerCase();
+
+    return spaces.filter(space => {
+      const matchesName = space.name.toLowerCase().includes(normalizedKeyword);
+      const matchesDescription = space.description.toLowerCase().includes(normalizedKeyword);
+
+      return matchesName || matchesDescription;
+    });
+  }
+
+  private applyOnlyMineFilter(spaces: BandSpaceListItem[], onlyMine: boolean | undefined): BandSpaceListItem[] {
+    if (onlyMine !== true) {
+      return spaces;
+    }
+
+    return spaces.filter(space => space.isMine);
+  }
+
+  private applyInProgressFilter(spaces: BandSpaceListItem[], inProgressOnly: boolean | undefined): BandSpaceListItem[] {
+    if (inProgressOnly !== true) {
+      return spaces;
+    }
+
+    return spaces.filter(space => space.status === 'ACTIVE');
+  }
+
+  private applySort(spaces: BandSpaceListItem[], sort: string | undefined): BandSpaceListItem[] {
+    if (sort === undefined || sort === 'createdAt,desc') {
+      return [...spaces].sort((leftSpace, rightSpace) => rightSpace.createdAt.localeCompare(leftSpace.createdAt));
+    }
+
+    if (sort === 'createdAt,asc') {
+      return [...spaces].sort((leftSpace, rightSpace) => leftSpace.createdAt.localeCompare(rightSpace.createdAt));
+    }
+
+    if (sort === 'name,asc') {
+      return [...spaces].sort((leftSpace, rightSpace) => leftSpace.name.localeCompare(rightSpace.name));
+    }
+
+    if (sort === 'name,desc') {
+      return [...spaces].sort((leftSpace, rightSpace) => rightSpace.name.localeCompare(leftSpace.name));
+    }
+
+    return spaces;
+  }
+}

--- a/backend/src/modules/spaces/spaces.service.ts
+++ b/backend/src/modules/spaces/spaces.service.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 
 import { createPagination, paginateItems } from '../../common/pagination';
 
 import type { GetBandSpacesQuery } from './dto/get-band-spaces-query.dto';
 import { SpacesMockRepository } from './repositories/spaces.mock-repository';
 import type { BandSpaceListItem, GetBandSpacesResult } from './types/band-space-list-item.type';
+import type { GetSpaceDetailResult } from './types/space-detail.type';
 
 @Injectable()
 export class SpacesService {
@@ -30,6 +31,16 @@ export class SpacesService {
       items: pagedSpaces,
       pagination,
     };
+  }
+
+  getSpaceDetail(spaceId: string): GetSpaceDetailResult {
+    const spaceDetail = this.spacesRepository.findDetailBySpaceId(spaceId);
+
+    if (spaceDetail === undefined) {
+      throw new NotFoundException('요청한 합주 공간을 찾을 수 없습니다.');
+    }
+
+    return spaceDetail;
   }
 
   private applySearchFilter(spaces: BandSpaceListItem[], keyword: string | undefined): BandSpaceListItem[] {

--- a/backend/src/modules/spaces/types/band-space-list-item.type.ts
+++ b/backend/src/modules/spaces/types/band-space-list-item.type.ts
@@ -1,0 +1,40 @@
+export type SpaceType = 'PRACTICE_ROOM' | 'STUDIO' | 'ONLINE' | 'ETC';
+
+export type SpaceStatus = 'ACTIVE' | 'INACTIVE';
+
+export type SpaceMemberRole = 'LEADER' | 'MEMBER';
+
+export interface BandSpaceMembership {
+  isMember: boolean;
+  role: SpaceMemberRole;
+}
+
+export interface BandSpaceListItem {
+  spaceId: string;
+  bandId: string;
+  createdByUserId: string;
+  name: string;
+  description: string;
+  spaceType: SpaceType;
+  status: SpaceStatus;
+  startDate: string;
+  endDate: string;
+  memberCount: number;
+  songCount: number;
+  isMine: boolean;
+  myMembership: BandSpaceMembership;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Pagination {
+  page: number;
+  size: number;
+  totalCount: number;
+  hasNext: boolean;
+}
+
+export interface GetBandSpacesResult {
+  items: BandSpaceListItem[];
+  pagination: Pagination;
+}

--- a/backend/src/modules/spaces/types/space-detail.type.ts
+++ b/backend/src/modules/spaces/types/space-detail.type.ts
@@ -1,0 +1,29 @@
+import type { BandSpaceMembership, SpaceStatus, SpaceType } from './band-space-list-item.type';
+
+export interface SpaceDetail {
+  spaceId: string;
+  bandId: string;
+  name: string;
+  description: string;
+  spaceType: SpaceType;
+  status: SpaceStatus;
+  startDate: string;
+  endDate: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SpaceMemberDetail {
+  userId: string;
+  nickname: string;
+  role: BandSpaceMembership['role'];
+  status: 'ACTIVE' | 'INACTIVE';
+  joinedAt: string;
+}
+
+export interface GetSpaceDetailResult {
+  space: SpaceDetail;
+  members: SpaceMemberDetail[];
+  songCount: number;
+  scheduleCount: number;
+}


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 15분

<br/>

## 📌 작업 요약

- `GET /bands/{bandId}/spaces` API를 DB, Docker, ORM 연결 전 단계에서 스켈레톤 수준으로 먼저 구현해봤습니다.
- `GET /spaces/{spaceId}` API도 같은 방식으로 추가 구현했습니다.
- 서비스 흐름과 모듈 구조를 먼저 정리해두고 싶어서 먼저 한번 구현해봤어요.
- 실제 DB 연동 대신 mock repository를 기반으로 API 계약과 레이어 구조를 잡는데 집중했습니다.

<br/>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요 (이미지 첨부 가능)

1. `GET /bands/:bandId/spaces` 스켈레톤 API 구현

- `SpacesModule`, `SpacesController`, `SpacesService` 추가
- `AppModule` 에 `SpacesModule` 등록
- 현재는 실제 DB 대신 `SpacesMockRepository` 에서 하드코딩된 목록 데이터를 반환하도록 구현

2. `GET /spaces/:spaceId` 스켈레톤 API 구현

- 합주공간 상세 조회용 타입 추가
- `SpacesService` 에 상세 조회 메서드 추가
- `SpacesMockRepository` 에 상세 조회용 목 데이터와 조회 메서드 추가
- 존재하지 않는 공간 조회 시 `NotFoundException` 을 반환하도록 구현

3. 응답 구조

- 공통 성공 응답 래퍼를 위한 `createSuccessResponse` 추가
- 응답 형식을 `status`, `error`, `message`, `data` 구조로 맞춤
- 현재 실패 응답은 타입만 선언되어 있으며, 추후 글로벌 예외 필터 연결 예정

4. 쿼리 파라미터 파싱 로직 정리

- `query`, `onlyMine`, `inProgressOnly`, `page`, `size`, `sort` 처리용 파싱 로직 구현

5. 공통 유틸 분리

- 쿼리 파라미터 파싱 유틸을 `common/query` 로 분리
- 페이지네이션 메타 계산 및 슬라이싱 로직을 `common/pagination` 으로 분리
- 재사용 가능한 범위만 공통화하고, 도메인에 종속된 검색/정렬 로직은 `SpacesService` 내부에 유지

6. 테스트 추가

- 서비스 테스트 추가
  - 밴드 필터링
  - 검색어 필터링
  - 페이지네이션 동작 검증
  - 공간 상세 정보 조회 검증
- 컨트롤러 테스트 추가
  - 공통 성공 응답 래퍼 반환 검증
  - 공간 상세 조회 응답 검증
- `package.json` 에 `test` 스크립트 추가

<br/>

## 🚨 주요 고민 및 해결 과정

> 주요 고민이나 문제 해결 과정 공유

### 문제

Docker, DB, ORM 등이 아직 준비가 되지 않은 상태였습니다. 그래서 영속성 구현보다 먼저 API 요청/응답 계약과 레이어 구조를 스켈레톤 형태로 선행 정리했습니다.

### 해결 과정

1. 영속성 없는 스켈레톤 API부터 구현

- DB 대신 `mock repository` 를 두고 서비스 계층이 실제 조회 로직을 수행하도록 구성
- 이렇게 하면 나중에 ORM 연결 시 서비스는 최대한 유지하고 repository만 교체 가능

2. 공통화는 재사용 가치가 높은 범위까지만 진행

- `query param parsing`, `pagination` 은 여러 API에서 반복될 가능성이 높아 공통 유틸로 분리
- 반면 `공간 이름/설명 검색`, `공간 상태 필터`, `공간 정렬 규칙` 은 공간 도메인 전용 로직이라 공통화하지 않음

<br/>

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 현재 DB/ORM 없이 스켈레톤을 먼저 구현하는 방향이 적절한지 봐주시면 좋겠습니다!
- 공통 API 응답, 유틸 함수, DTO 등이 적절한지 봐주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 검색, 필터링, 페이지 기능을 지원하는 합주 공간 목록 조회 API 추가
- 합주 공간 상세 정보 조회 API 추가

## 테스트
- 합주 공간 기능에 대한 테스트 커버리지 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->