### PR TITLE
Feat/band list

### DIFF
--- a/frontend/src/entities/band/api/band-api.test.ts
+++ b/frontend/src/entities/band/api/band-api.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiClient } from '@/shared/api/client';
+import { getBands } from './band-api';
+
+const mock = new MockAdapter(apiClient);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('getBands 어댑터', () => {
+  it('GET /bands 응답을 schema로 검증한 뒤 bands를 반환한다', async () => {
+    mock.onGet('/bands').reply(200, {
+      status: 'success',
+      error: null,
+      message: '내 밴드 목록 조회 성공',
+      data: {
+        totalCount: 1,
+        bands: [
+          {
+            id: 'band-1',
+            name: '합주하자',
+            description: '주 1회 합주',
+            visibility: true,
+            inviteCode: 'INV123',
+            bmId: 'bm-1',
+            myRole: 'BM',
+            joinedAt: '2026-03-01T12:10:00.000+09:00',
+            createdAt: '2026-03-01T12:00:00.000+09:00',
+            memberCount: 10,
+          },
+        ],
+      },
+    });
+
+    await expect(getBands()).resolves.toEqual([
+      {
+        id: 'band-1',
+        name: '합주하자',
+        description: '주 1회 합주',
+        visibility: true,
+        inviteCode: 'INV123',
+        bmId: 'bm-1',
+        myRole: 'BM',
+        joinedAt: '2026-03-01T12:10:00.000+09:00',
+        createdAt: '2026-03-01T12:00:00.000+09:00',
+        memberCount: 10,
+      },
+    ]);
+  });
+
+  it('필수 필드가 누락되면 reject된다', async () => {
+    mock.onGet('/bands').reply(200, {
+      status: 'success',
+      error: null,
+      message: '내 밴드 목록 조회 성공',
+      data: {
+        totalCount: 1,
+        bands: [
+          {
+            id: 'band-1',
+            name: '합주하자',
+            description: '주 1회 합주',
+            visibility: true,
+            inviteCode: 'INV123',
+            bmId: 'bm-1',
+            myRole: 'BM',
+            createdAt: '2026-03-01T12:00:00.000+09:00',
+          },
+        ],
+      },
+    });
+
+    await expect(getBands()).rejects.toThrow();
+  });
+});

--- a/frontend/src/entities/band/api/band-api.ts
+++ b/frontend/src/entities/band/api/band-api.ts
@@ -1,17 +1,9 @@
 import { apiClient } from '@/shared/api';
 import type { Band } from '../model/types';
-
-interface BandListApiResponse {
-  status: 'success' | 'error';
-  error: string | null;
-  message: string;
-  data: {
-    totalCount: number;
-    bands: Band[];
-  };
-}
+import { bandListResponseSchema } from '../model/schema';
 
 export const getBands = async (): Promise<Band[]> => {
-  const response = await apiClient.get<BandListApiResponse>('/bands');
-  return response.data.data.bands;
+  const response = await apiClient.get('/bands');
+  const parsed = bandListResponseSchema.parse(response.data);
+  return parsed.data.bands;
 };

--- a/frontend/src/entities/band/api/band-api.ts
+++ b/frontend/src/entities/band/api/band-api.ts
@@ -1,4 +1,17 @@
-import { apiGet } from '@/shared/api';
+import { apiClient } from '@/shared/api';
 import type { Band } from '../model/types';
 
-export const getBands = (): Promise<Band[]> => apiGet<Band[]>('/bands');
+interface BandListApiResponse {
+  status: 'success' | 'error';
+  error: string | null;
+  message: string;
+  data: {
+    totalCount: number;
+    bands: Band[];
+  };
+}
+
+export const getBands = async (): Promise<Band[]> => {
+  const response = await apiClient.get<BandListApiResponse>('/bands');
+  return response.data.data.bands;
+};

--- a/frontend/src/entities/band/model/schema.ts
+++ b/frontend/src/entities/band/model/schema.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const bandRoleSchema = z.enum(['BM', 'MEMBER']);
+
+export const bandSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  visibility: z.boolean(),
+  inviteCode: z.string(),
+  bmId: z.string(),
+  createdAt: z.string(),
+});
+
+export const bandSchema = bandSummarySchema.extend({
+  myRole: bandRoleSchema,
+  joinedAt: z.string(),
+  memberCount: z.number().int().nonnegative().optional(),
+});
+
+export const bandListResponseSchema = z.object({
+  status: z.enum(['success', 'error']),
+  error: z.string().nullable(),
+  message: z.string(),
+  data: z.object({
+    totalCount: z.number().int().nonnegative(),
+    bands: z.array(bandSchema),
+  }),
+});

--- a/frontend/src/entities/band/model/types.ts
+++ b/frontend/src/entities/band/model/types.ts
@@ -1,12 +1,4 @@
-export interface Band {
-  id: string;
-  name: string;
-  description: string | null;
-  visibility: boolean;
-  inviteCode: string;
-  bmId: string;
-  myRole: 'BM' | 'MEMBER';
-  joinedAt: string;
-  createdAt: string;
-  memberCount?: number;
-}
+import type { z } from 'zod';
+import { bandSchema } from './schema';
+
+export type Band = z.infer<typeof bandSchema>;

--- a/frontend/src/entities/band/model/types.ts
+++ b/frontend/src/entities/band/model/types.ts
@@ -1,5 +1,12 @@
 export interface Band {
   id: string;
   name: string;
-  memberCount: number;
+  description: string | null;
+  visibility: boolean;
+  inviteCode: string;
+  bmId: string;
+  myRole: 'BM' | 'MEMBER';
+  joinedAt: string;
+  createdAt: string;
+  memberCount?: number;
 }

--- a/frontend/src/entities/band/ui/BandCard.test.tsx
+++ b/frontend/src/entities/band/ui/BandCard.test.tsx
@@ -1,11 +1,40 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { BandCard } from './BandCard';
 
+const navigate = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigate,
+}));
+
 describe('BandCard', () => {
-  it('밴드 이름을 표시한다', () => {
-    render(<BandCard band={{ id: '1', name: '우리 밴드', memberCount: 5 }} />);
+  it('밴드 이름을 표시하고 클릭 시 상세 페이지로 이동한다', () => {
+    render(
+      <BandCard
+        band={{
+          id: '1',
+          name: '우리 밴드',
+          description: '주 1회 합주',
+          visibility: true,
+          inviteCode: 'INV123',
+          bmId: 'bm-1',
+          myRole: 'BM',
+          joinedAt: '2026-03-01T12:10:00.000+09:00',
+          createdAt: '2026-03-01T12:00:00.000+09:00',
+          memberCount: 5,
+        }}
+      />,
+    );
+
     expect(screen.getByText('우리 밴드')).toBeInTheDocument();
-    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('5명')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '우리 밴드 상세 보기' }));
+
+    expect(navigate).toHaveBeenCalledWith({
+      to: '/band/$bandId',
+      params: { bandId: '1' },
+    });
   });
 });

--- a/frontend/src/entities/band/ui/BandCard.tsx
+++ b/frontend/src/entities/band/ui/BandCard.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from '@tanstack/react-router';
+import { SVGIcon } from '@/shared/ui/icon';
 import type { Band } from '../model/types';
 
 type BandCardProps = {
@@ -5,10 +7,36 @@ type BandCardProps = {
 };
 
 export const BandCard = ({ band }: BandCardProps) => {
+  const navigate = useNavigate();
+
   return (
-    <div>
-      <span>{band.name}</span>
-      <span>{band.memberCount}</span>
-    </div>
+    <button
+      type="button"
+      aria-label={`${band.name} 상세 보기`}
+      className="motion-lift flex w-full border border-muted/30 flex-col rounded-3xl bg-white p-3 shadow-xl/5"
+      onClick={() =>
+        navigate({ to: '/band/$bandId', params: { bandId: band.id } })
+      }
+    >
+      <div aria-hidden="true" className="aspect-square rounded-xl bg-muted-foreground" />
+
+      <div className="flex min-h-24 flex-col justify-between px-2 pb-1 pt-4">
+        <div className="space-y-1 text-center">
+          <p className="truncate text-lg font-semibold tracking-tight">
+            {band.name}
+          </p>
+          {band.description ? (
+            <p className="line-clamp-1 text-sm text-muted">
+              {band.description}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="flex items-center justify-end gap-1.5 text-sm text-muted">
+          <SVGIcon icon="Member" size="sm" />
+          <span>{band.memberCount ?? 0}명</span>
+        </div>
+      </div>
+    </button>
   );
 };

--- a/frontend/src/features/band-create/api/band-api.test.ts
+++ b/frontend/src/features/band-create/api/band-api.test.ts
@@ -11,34 +11,71 @@ afterEach(() => {
 });
 
 describe('createBand 어댑터', () => {
-  it('POST /bands 를 올바른 body로 호출하고 응답(id, name)을 반환한다', async () => {
-    const requestBody = { name: '우리 밴드' };
-    const responseData = { id: 'band-123', name: '우리 밴드' };
+  it('POST /bands 를 올바른 body로 호출하고 응답 band를 반환한다', async () => {
+    const requestBody = {
+      name: '우리 밴드',
+      description: '주 1회 합주',
+      visibility: true,
+    };
+    const responseData = {
+      band: {
+        id: 'band-123',
+        name: '우리 밴드',
+        description: '주 1회 합주',
+        visibility: true,
+        inviteCode: 'INV123',
+        bmId: 'bm-1',
+        createdAt: '2026-03-03T18:20:10.123+09:00',
+        updatedAt: '2026-03-03T18:20:10.123+09:00',
+      },
+    };
 
     mock.onPost('/bands', requestBody).reply(200, {
-      success: true,
+      status: 'success',
+      error: null,
+      message: '밴드 생성 성공',
       data: responseData,
     });
 
     const result = await createBand(requestBody);
 
-    expect(result).toEqual(responseData);
+    expect(result).toEqual(responseData.band);
   });
 
-  it('name이 서버에 그대로 전달된다', async () => {
+  it('name, description, visibility가 서버에 그대로 전달된다', async () => {
     let capturedBody: unknown;
 
     mock.onPost('/bands').reply((config) => {
       capturedBody = JSON.parse(config.data as string);
       return [
         200,
-        { success: true, data: { id: 'band-456', name: '테스트 밴드' } },
+        {
+          status: 'success',
+          error: null,
+          message: '밴드 생성 성공',
+          data: {
+            band: {
+              id: 'band-456',
+              name: '테스트 밴드',
+              description: null,
+              visibility: true,
+              inviteCode: 'INV456',
+              bmId: 'bm-1',
+              createdAt: '2026-03-03T18:20:10.123+09:00',
+              updatedAt: '2026-03-03T18:20:10.123+09:00',
+            },
+          },
+        },
       ];
     });
 
-    await createBand({ name: '테스트 밴드' });
+    await createBand({ name: '테스트 밴드', description: null, visibility: true });
 
-    expect(capturedBody).toEqual({ name: '테스트 밴드' });
+    expect(capturedBody).toEqual({
+      name: '테스트 밴드',
+      description: null,
+      visibility: true,
+    });
   });
 
   it('서버 에러(422) 시 reject된다', async () => {
@@ -47,6 +84,8 @@ describe('createBand 어댑터', () => {
       error: { code: 'INVALID_INPUT', message: '이름이 올바르지 않습니다' },
     });
 
-    await expect(createBand({ name: '' })).rejects.toThrow();
+    await expect(
+      createBand({ name: '', description: null, visibility: true }),
+    ).rejects.toThrow();
   });
 });

--- a/frontend/src/features/band-create/api/band-api.test.ts
+++ b/frontend/src/features/band-create/api/band-api.test.ts
@@ -88,4 +88,27 @@ describe('createBand 어댑터', () => {
       createBand({ name: '', description: null, visibility: true }),
     ).rejects.toThrow();
   });
+
+  it('필수 응답 필드가 누락되면 reject된다', async () => {
+    mock.onPost('/bands').reply(200, {
+      status: 'success',
+      error: null,
+      message: '밴드 생성 성공',
+      data: {
+        band: {
+          id: 'band-123',
+          name: '우리 밴드',
+          description: '주 1회 합주',
+          visibility: true,
+          inviteCode: 'INV123',
+          createdAt: '2026-03-03T18:20:10.123+09:00',
+          updatedAt: '2026-03-03T18:20:10.123+09:00',
+        },
+      },
+    });
+
+    await expect(
+      createBand({ name: '우리 밴드', description: '주 1회 합주', visibility: true }),
+    ).rejects.toThrow();
+  });
 });

--- a/frontend/src/features/band-create/api/band-api.ts
+++ b/frontend/src/features/band-create/api/band-api.ts
@@ -1,4 +1,6 @@
 import { apiPost } from '@/shared/api';
+import { bandSummarySchema } from '@/entities/band/model/schema';
+import { z } from 'zod';
 
 export interface BandCreateRequest {
   name: string;
@@ -6,20 +8,15 @@ export interface BandCreateRequest {
   visibility: boolean;
 }
 
-export interface BandCreateResponse {
-  id: string;
-  name: string;
-  description: string | null;
-  visibility: boolean;
-  inviteCode: string;
-  bmId: string;
-  createdAt: string;
-  updatedAt: string;
-}
+export const bandCreateResponseSchema = bandSummarySchema.extend({
+  updatedAt: z.string(),
+});
+
+export type BandCreateResponse = z.infer<typeof bandCreateResponseSchema>;
 
 export const createBand = (
   data: BandCreateRequest,
 ): Promise<BandCreateResponse> =>
   apiPost<{ band: BandCreateResponse }>('/bands', data).then(
-    (response) => response.band,
+    (response) => bandCreateResponseSchema.parse(response.band),
   );

--- a/frontend/src/features/band-create/api/band-api.ts
+++ b/frontend/src/features/band-create/api/band-api.ts
@@ -1,16 +1,25 @@
 import { apiPost } from '@/shared/api';
 
-// 프론트엔드 주도 인터페이스 (API 명세 확정 전 임시)
-// 명세 확정 후: endpoint/body key/응답 매핑만 이 파일에서 수정
 export interface BandCreateRequest {
   name: string;
+  description: string | null;
+  visibility: boolean;
 }
 
 export interface BandCreateResponse {
   id: string;
   name: string;
+  description: string | null;
+  visibility: boolean;
+  inviteCode: string;
+  bmId: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export const createBand = (
   data: BandCreateRequest,
-): Promise<BandCreateResponse> => apiPost<BandCreateResponse>('/bands', data);
+): Promise<BandCreateResponse> =>
+  apiPost<{ band: BandCreateResponse }>('/bands', data).then(
+    (response) => response.band,
+  );

--- a/frontend/src/features/band-create/model/schema.ts
+++ b/frontend/src/features/band-create/model/schema.ts
@@ -2,6 +2,13 @@ import { z } from 'zod';
 
 export const bandCreateSchema = z.object({
   name: z.string().trim().min(1, '밴드 이름을 입력해주세요'),
+  description: z
+    .string()
+    .trim()
+    .max(200, '밴드 소개는 200자 이하로 입력해주세요')
+    .nullable()
+    .default(null),
+  visibility: z.boolean().default(true),
 });
 
 export type BandCreateFormValues = z.infer<typeof bandCreateSchema>;

--- a/frontend/src/features/band-create/model/useBandCreate.test.tsx
+++ b/frontend/src/features/band-create/model/useBandCreate.test.tsx
@@ -33,7 +33,11 @@ describe('useBandCreate', () => {
       wrapper: createTestWrapper(),
     });
 
-    result.current.submit({ name: '새로운 밴드' });
+    void result.current.submit({
+      name: '새로운 밴드',
+      description: '주 1회 합주',
+      visibility: true,
+    });
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(true);
@@ -61,7 +65,11 @@ describe('useBandCreate', () => {
       wrapper: createTestWrapper(),
     });
 
-    result.current.submit({ name: '실패하는 밴드' });
+    void result.current.submit({
+      name: '실패하는 밴드',
+      description: null,
+      visibility: true,
+    });
 
     await waitFor(
       () => {

--- a/frontend/src/features/band-create/model/useBandCreate.ts
+++ b/frontend/src/features/band-create/model/useBandCreate.ts
@@ -5,7 +5,7 @@ import type { BandCreateRequest } from '../api/band-api';
 import { bandKeys } from '@/entities/band/api/useBands';
 
 export interface UseBandCreateResult {
-  submit: (data: BandCreateRequest) => void;
+  submit: (data: BandCreateRequest) => Promise<void>;
   isLoading: boolean;
   error: string | null;
 }
@@ -23,8 +23,12 @@ export const useBandCreate = (): UseBandCreateResult => {
     },
   });
 
-  const submit = (data: BandCreateRequest) => {
-    mutation.mutate(data);
+  const submit = async (data: BandCreateRequest) => {
+    try {
+      await mutation.mutateAsync(data);
+    } catch {
+      return;
+    }
   };
 
   return {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -63,7 +63,7 @@
   --success-surface: #ebfef5;
   --success: #05e173;
   --success-foreground: #020119;
-  --background: #faf9f0;
+  --background: #f7f7f7;
   --foreground: #1b1b32;
   --primary-foreground: #faf9f0;
   --secondary-foreground: #020119;
@@ -80,7 +80,7 @@
 
 .dark {
   --background: #020119;
-  --foreground: #faf9f0;
+  --foreground: #f7f7f7;
   --card: rgb(27 27 50 / 0.88);
   --card-foreground: #faf9f0;
   --popover: #1b1b32;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -67,8 +67,8 @@
   --foreground: #1b1b32;
   --primary-foreground: #faf9f0;
   --secondary-foreground: #020119;
-  --muted: #e6e9f0;
-  --muted-foreground: #7473b5;
+  --muted: #737373;
+  --muted-foreground: #b1b1b2;
   --card: rgb(255 255 255 / 0.7);
   --card-foreground: #1b1b32;
   --popover: #faf9f0;
@@ -94,7 +94,7 @@
   --secondary: #ddfe55;
   --secondary-foreground: #020119;
   --muted: #1b1b32;
-  --muted-foreground: #bdbcdc;
+  --muted-foreground: #d9dadd;
   --accent-surface: rgb(242 207 209 / 0.16);
   --accent-light: #d35f64;
   --accent: #c8393f;
@@ -130,6 +130,17 @@
       BlinkMacSystemFont,
       'Segoe UI',
       sans-serif;
+  }
+}
+
+@layer components {
+  .motion-lift {
+    @apply transition-all duration-200 ease-out will-change-transform;
+  }
+
+  .motion-lift:hover,
+  .motion-lift:focus-visible {
+    transform: translateY(-4px);
   }
 }
 

--- a/frontend/src/mocks/band/handlers.ts
+++ b/frontend/src/mocks/band/handlers.ts
@@ -45,16 +45,30 @@ export const bandHandlers = [
 
   // 밴드 생성 Mock
   http.post(`${API_URL}/bands`, async ({ request }) => {
-    const body = (await request.json()) as { name: string };
+    const body = (await request.json()) as {
+      name: string;
+      description: string | null;
+      visibility: boolean;
+    };
 
     // 단순 딜레이 시뮬레이션
     await new Promise((resolve) => setTimeout(resolve, 300));
 
     return HttpResponse.json({
-      success: true,
+      status: 'success',
+      error: null,
+      message: '밴드 생성 성공',
       data: {
-        id: `band-${Date.now()}`,
-        name: body.name,
+        band: {
+          id: `band-${Date.now()}`,
+          name: body.name,
+          description: body.description,
+          visibility: body.visibility,
+          inviteCode: 'NEW123',
+          bmId: 'bm-new',
+          createdAt: '2026-03-03T18:20:10.123+09:00',
+          updatedAt: '2026-03-03T18:20:10.123+09:00',
+        },
       },
     });
   }),

--- a/frontend/src/mocks/band/handlers.ts
+++ b/frontend/src/mocks/band/handlers.ts
@@ -1,18 +1,45 @@
 import type { Band } from '@/entities/band/model/types';
-import type { ApiResponse } from '@/shared/api';
 import { http, HttpResponse } from 'msw';
 import { API_URL } from '../config';
 
 export const bandHandlers = [
   // 밴드 목록 조회 Mock
   http.get(`${API_URL}/bands`, () => {
-    return HttpResponse.json<ApiResponse<Band[]>>({
-      success: true,
-      data: [
-        { id: '1', name: '홍대 인디 밴드', memberCount: 1 },
-        { id: '2', name: '직장인 연합 밴드', memberCount: 1 },
-        { id: '3', name: '주말 잼 세션', memberCount: 1 },
-      ],
+    const bands: Band[] = [
+      {
+        id: 'a8c6b7b1-0f0a-4e3a-8a0c-4f6ef3d2d9c1',
+        name: '합주하자',
+        description: '주 1회 합주',
+        visibility: true,
+        inviteCode: '7KQ2M9',
+        bmId: 'b6d0f0b1-7c7d-4e23-9c7b-0c0d9f6a2a21',
+        myRole: 'BM',
+        joinedAt: '2026-03-01T12:10:00.000+09:00',
+        createdAt: '2026-03-01T12:00:00.000+09:00',
+        memberCount: 10,
+      },
+      {
+        id: 'e2f9a1c1-3d4b-4f2a-9d1f-8a7c1f2d3e4a',
+        name: '락스타',
+        description: null,
+        visibility: true,
+        inviteCode: 'P1Z8Q0',
+        bmId: '9aa1bb22-0000-0000-0000-000000000000',
+        myRole: 'MEMBER',
+        joinedAt: '2026-02-20T18:30:00.000+09:00',
+        createdAt: '2026-02-10T09:00:00.000+09:00',
+        memberCount: 4,
+      },
+    ];
+
+    return HttpResponse.json({
+      status: 'success',
+      error: null,
+      message: '내 밴드 목록 조회 성공',
+      data: {
+        totalCount: bands.length,
+        bands,
+      },
     });
   }),
 
@@ -23,12 +50,11 @@ export const bandHandlers = [
     // 단순 딜레이 시뮬레이션
     await new Promise((resolve) => setTimeout(resolve, 300));
 
-    return HttpResponse.json<ApiResponse<Band>>({
+    return HttpResponse.json({
       success: true,
       data: {
         id: `band-${Date.now()}`,
         name: body.name,
-        memberCount: 1,
       },
     });
   }),

--- a/frontend/src/shared/ui/button/button-variants.ts
+++ b/frontend/src/shared/ui/button/button-variants.ts
@@ -6,9 +6,9 @@ export const buttonVariants = cva(
   variants: {
     variant: {
         default:
-          'bg-primary text-primary-foreground',
+          'bg-primary text-primary-foreground text-secondary-surface',
         outline:
-          'border border-border/80 bg-background/75 text-foreground',
+          'border border-primary-light bg-transparent text-foreground',
         ghost: 'bg-transparent text-foreground',
     },
     size: {

--- a/frontend/src/shared/ui/checkbox.tsx
+++ b/frontend/src/shared/ui/checkbox.tsx
@@ -12,7 +12,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-lg border shadow-xs transition-shadow outline-none disabled:cursor-not-allowed disabled:opacity-50',
+        'peer border-border dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-xs border outline-none disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       {...props}

--- a/frontend/src/shared/ui/dialog.tsx
+++ b/frontend/src/shared/ui/dialog.tsx
@@ -59,7 +59,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-3xl border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
           className,
         )}
         {...props}
@@ -68,7 +68,8 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent-surface data-[state=open]:text-accent-light absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent-surface 
+            data-[state=open]:text-accent-light absolute top-6 right-6 rounded-xs text-muted hover:text-foreground focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-6"
           >
             <XIcon />
             <span className="sr-only">Close</span>
@@ -123,7 +124,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn("text-2xl leading-none font-semibold", className)}
       {...props}
     />
   );
@@ -136,7 +137,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-muted text-sm", className)}
       {...props}
     />
   );

--- a/frontend/src/shared/ui/input.tsx
+++ b/frontend/src/shared/ui/input.tsx
@@ -31,7 +31,7 @@ function Input({ className, type, isSearchBar = false, ...props }: InputProps) {
       type={type}
       data-slot="input"
       className={cn(
-        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input w-full rounded-full border bg-input px-4 py-3 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'file:text-foreground placeholder:text-muted selection:bg-primary selection:text-primary-foreground border-border w-full rounded-full border bg-input px-4 py-3 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         'focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         isSearchBar && 'pl-11',

--- a/frontend/src/widgets/band-list/ui/BandCreateDialog.tsx
+++ b/frontend/src/widgets/band-list/ui/BandCreateDialog.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+import { bandCreateSchema } from '@/features/band-create/model/schema';
+import { useBandCreate } from '@/features/band-create/model/useBandCreate';
+import { Button } from '@/shared/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/ui/dialog';
+import { Input } from '@/shared/ui/input';
+import { Checkbox } from '@/shared/ui/checkbox';
+
+type BandCreateDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+const initialForm = {
+  name: '',
+  description: '',
+  visibility: true,
+};
+
+export const BandCreateDialog = ({
+  open,
+  onOpenChange,
+}: BandCreateDialogProps) => {
+  const [form, setForm] = useState(initialForm);
+  const [fieldError, setFieldError] = useState<string | null>(null);
+  const { submit, isLoading, error } = useBandCreate();
+
+  const resetForm = () => {
+    setForm(initialForm);
+    setFieldError(null);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      resetForm();
+    }
+
+    onOpenChange(nextOpen);
+  };
+
+  const handleSubmit = async () => {
+    const parsed = bandCreateSchema.safeParse({
+      name: form.name,
+      description: form.description.trim() || null,
+      visibility: form.visibility,
+    });
+
+    if (!parsed.success) {
+      setFieldError(parsed.error.issues[0]?.message ?? '입력값을 확인해주세요');
+      return;
+    }
+
+    setFieldError(null);
+    await submit(parsed.data);
+    handleOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>새 밴드 만들기</DialogTitle>
+          <DialogDescription>밴드 이름을 입력하세요</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6 pt-4">
+          <label htmlFor="band-name" className="flex flex-col gap-3">
+            <span className="text-lg font-semibold">밴드 이름</span>
+            <Input
+              id="band-name"
+              value={form.name}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, name: event.target.value }))
+              }
+              placeholder="예: 신촌 락밴드"
+            />
+          </label>
+
+          <label htmlFor="band-description" className="flex flex-col gap-3">
+            <span className="text-lg font-semibold">밴드 소개</span>
+            <textarea
+              id="band-description"
+              value={form.description}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  description: event.target.value,
+                }))
+              }
+              placeholder="주 1회 합주하는 밴드입니다."
+              className="w-full rounded-xl border border-border bg-white p-4 outline-none transition focus-visible:ring-2 focus-visible:ring-ring/50"
+            />
+          </label>
+
+          <label className="flex items-center gap-3 text-muted">
+            <Checkbox
+              checked={form.visibility}
+              onCheckedChange={(checked) =>
+                setForm((current) => ({
+                  ...current,
+                  visibility: checked === true,
+                }))
+              }
+            />
+            공개 밴드로 생성하기
+          </label>
+
+          {fieldError ? (
+            <p className="text-sm text-destructive">{fieldError}</p>
+          ) : null}
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        </div>
+
+        <DialogFooter className="sm:justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+          >
+            취소
+          </Button>
+          <Button
+            type="button"
+            isLoading={isLoading}
+            onClick={() => void handleSubmit()}
+            loadingContent="생성 중..."
+          >
+            밴드 만들기
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/widgets/band-list/ui/BandList.test.tsx
+++ b/frontend/src/widgets/band-list/ui/BandList.test.tsx
@@ -1,9 +1,13 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { http, HttpResponse, delay } from 'msw';
 import { server } from '@/mocks/server';
 import { BandList } from './BandList';
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}));
 
 const renderWithClient = (ui: React.ReactElement) => {
   const queryClient = new QueryClient({
@@ -18,8 +22,11 @@ describe('BandList', () => {
   it('밴드 목록을 렌더링한다', async () => {
     renderWithClient(<BandList />);
 
-    expect(await screen.findByText('홍대 인디 밴드')).toBeInTheDocument();
-    expect(screen.getByText('직장인 연합 밴드')).toBeInTheDocument();
+    expect(await screen.findByText('합주하자')).toBeInTheDocument();
+    expect(screen.getByText('락스타')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '밴드 만들기' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '초대 코드 입력' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '목록 편집' })).toBeInTheDocument();
   });
 
   it('로딩 중일 때 로딩 상태를 표시한다', async () => {
@@ -37,7 +44,15 @@ describe('BandList', () => {
   it('밴드가 없을 때 빈 상태를 표시한다', async () => {
     server.use(
       http.get('/api/bands', () => {
-        return HttpResponse.json({ success: true, data: [] });
+        return HttpResponse.json({
+          status: 'success',
+          error: null,
+          message: '내 밴드 목록 조회 성공',
+          data: {
+            totalCount: 0,
+            bands: [],
+          },
+        });
       }),
     );
 

--- a/frontend/src/widgets/band-list/ui/BandList.tsx
+++ b/frontend/src/widgets/band-list/ui/BandList.tsx
@@ -1,9 +1,14 @@
+import { useState } from 'react';
 import { Button } from '@/shared/ui/button';
 import { SVGIcon } from '@/shared/ui/icon';
 import { BandCard } from '@/entities/band/ui/BandCard';
 import { useBands } from '@/entities/band/api/useBands';
+import { BandCreateDialog } from './BandCreateDialog';
+import { InviteCodeDialog } from './InviteCodeDialog';
 
 export const BandList = () => {
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [isInviteCodeDialogOpen, setIsInviteCodeDialogOpen] = useState(false);
   const { data: bands = [], isLoading } = useBands();
 
   if (isLoading) return <div data-testid="band-list">로딩 중...</div>;
@@ -15,12 +20,13 @@ export const BandList = () => {
     <section data-testid="band-list" className="space-y-7">
       <div className="flex items-start justify-between gap-6">
         <div className="space-y-5">
-          <h2 className="text-4xl font-semibold tracking-tight">밴드</h2>
+          <h2 className="text-3xl font-semibold tracking-tight">밴드</h2>
 
           <div className="flex flex-wrap items-center gap-3">
             <Button
               type="button"
-              className="h-11 rounded-full bg-secondary-surface px-5 text-sm font-semibold text-secondary-foreground shadow-xl/5"
+              className="bg-secondary-surface  text-secondary-foreground shadow-xl/5"
+              onClick={() => setIsCreateDialogOpen(true)}
             >
               <span>밴드 만들기</span>
               <SVGIcon icon="AddWithCircle" size="sm" />
@@ -28,7 +34,8 @@ export const BandList = () => {
 
             <Button
               type="button"
-              className="h-11 rounded-full bg-secondary-surface px-5 text-sm font-semibold text-secondary-foreground shadow-xl/5"
+              className="bg-secondary-surface text-secondary-foreground shadow-xl/5"
+              onClick={() => setIsInviteCodeDialogOpen(true)}
             >
               <span>초대 코드 입력</span>
             </Button>
@@ -52,6 +59,15 @@ export const BandList = () => {
           </li>
         ))}
       </ul>
+
+      <BandCreateDialog
+        open={isCreateDialogOpen}
+        onOpenChange={setIsCreateDialogOpen}
+      />
+      <InviteCodeDialog
+        open={isInviteCodeDialogOpen}
+        onOpenChange={setIsInviteCodeDialogOpen}
+      />
     </section>
   );
 };

--- a/frontend/src/widgets/band-list/ui/BandList.tsx
+++ b/frontend/src/widgets/band-list/ui/BandList.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@/shared/ui/button';
+import { SVGIcon } from '@/shared/ui/icon';
 import { BandCard } from '@/entities/band/ui/BandCard';
 import { useBands } from '@/entities/band/api/useBands';
 
@@ -10,14 +12,46 @@ export const BandList = () => {
     return <div data-testid="band-list">아직 참여한 밴드가 없어요</div>;
 
   return (
-    <div data-testid="band-list">
-      <ul>
+    <section data-testid="band-list" className="space-y-7">
+      <div className="flex items-start justify-between gap-6">
+        <div className="space-y-5">
+          <h2 className="text-4xl font-semibold tracking-tight">밴드</h2>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              type="button"
+              className="h-11 rounded-full bg-secondary-surface px-5 text-sm font-semibold text-secondary-foreground shadow-xl/5"
+            >
+              <span>밴드 만들기</span>
+              <SVGIcon icon="AddWithCircle" size="sm" />
+            </Button>
+
+            <Button
+              type="button"
+              className="h-11 rounded-full bg-secondary-surface px-5 text-sm font-semibold text-secondary-foreground shadow-xl/5"
+            >
+              <span>초대 코드 입력</span>
+            </Button>
+          </div>
+        </div>
+
+        <Button
+          type="button"
+          variant="ghost"
+          className="gap-2 px-0 text-sm font-medium text-muted hover:text-foreground"
+        >
+          <span>목록 편집</span>
+          <SVGIcon icon="Setting" size="sm" />
+        </Button>
+      </div>
+
+      <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {bands.map((band) => (
           <li key={band.id}>
             <BandCard band={band} />
           </li>
         ))}
       </ul>
-    </div>
+    </section>
   );
 };

--- a/frontend/src/widgets/band-list/ui/InviteCodeDialog.tsx
+++ b/frontend/src/widgets/band-list/ui/InviteCodeDialog.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { Button } from '@/shared/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/ui/dialog';
+import { Input } from '@/shared/ui/input';
+
+type InviteCodeDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export const InviteCodeDialog = ({
+  open,
+  onOpenChange,
+}: InviteCodeDialogProps) => {
+  const [inviteCode, setInviteCode] = useState('');
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>초대 코드 입력</DialogTitle>
+          <DialogDescription>
+            초대 코드를 입력하는 UI만 먼저 연결합니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Input
+          value={inviteCode}
+          onChange={(event) => setInviteCode(event.target.value)}
+          placeholder="초대 코드를 입력하세요"
+        />
+
+        <DialogFooter className="sm:justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            취소
+          </Button>
+          <Button type="button" onClick={() => onOpenChange(false)}>
+            확인
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/widgets/page-header/page-header.tsx
+++ b/frontend/src/widgets/page-header/page-header.tsx
@@ -55,7 +55,7 @@ export const PageHeader = ({
               {showBack ? (
                 <BackButton
                   label="뒤로"
-                  variant="outline"
+                  variant="ghost"
                   className="text-sm"
                   onClick={onBack}
                 />


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 5분

<br/>

## 📌 작업 요약

- 홈에서 내 밴드 목록을 카드 형태로 조회합니다.
- 상단 액션으로 밴드 생성 모달과 초대 코드 입력 모달을 엽니다.
- 밴드 생성 API를 실제 명세에 맞게 연결합니다.
- 목록 조회 응답과 생성 응답을 각각 다른 schema로 검증합니다.

<br/>

## 📝 작업 내용

https://github.com/user-attachments/assets/efbc7f57-135a-4252-b676-204d7a7ce3f0

### 1. 밴드 목록 카드 UI 구현
- 밴드 목록 영역에 제목, `밴드 만들기`, `초대 코드 입력`, `목록 편집` 액션을 추가했습니다.
- 목록 편집 버튼은 버튼 ui만 구현했습니다.
- 밴드 카드는 버튼형 컴포넌트로 구현해 클릭 시 해당 밴드 상세로 이동하게 했습니다.
- **카드 hover 시 살짝 떠오르는 모션을 공통 클래스로 등록했습니다.**

### 2. 밴드 생성 / 초대 코드 입력 모달 추가
- `BandCreateDialog`를 추가해 밴드 이름, 소개, 공개 여부를 입력 받도록 했습니다.
- 초대 코드 입력은 아직 API가 없어서 입력 UI와 열기/닫기 동작만 구현했습니다.

### 3. API adapter 및 schema 정리
- 밴드 목록 조회 응답은 `status/error/message/data` envelope까지 포함해 schema로 검증합니다.
- 밴드 생성 응답은 공통 band summary schema를 재사용하되 `updatedAt`를 확장한 별도 schema로 검증합니다.

### 4. MSW mock 정리
- 밴드 목록 mock을 실제 목록 응답 명세 형태로 수정했습니다.
- 밴드 생성 mock도 실제 생성 응답 명세 형태로 수정했습니다.

<br/>

## 💬 리뷰 요구사항

- button, input, dialog 등 공통 컴포넌트 약간의 스타일 수정이 있어서 다음 작업 전 확인해주시는 게 좋겠습니다.
- api 문서를 읽어보니 바로 사용하지 않는 inviteCode, createdAt 등을 반환하더라구요, 왜 그런지 여쭤봤는데 컨벤션이라고 하셔서, 아예 응답 반환 값도 검증하도록 구현하였습니다.
- 그림자 만들 때 `shadow-xl/5`, 카드 떠오르는 모션은 `motion-lift` 를 사용하시면 됩니다!
- codex에게 화면 초안을 만들어 달라고 했더니 기본 button, iuput, dialog에 이미 들어간 스타일을 덮어서 다시 만들어 주더군용.. 주의해야 할 것 같습니다!
<br/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 밴드 만들기 다이얼로그 추가 (이름, 설명, 공개 여부 입력)
  * 초대 코드를 통한 밴드 초대 기능
  * 밴드 카드에서 상세 페이지로 이동 기능
  * 목록 편집 버튼 추가

* **스타일**
  * 색상 스키마 업데이트
  * UI 컴포넌트 스타일 개선
  * 인터랙션 모션 효과 추가

* **테스트**
  * 밴드 API 테스트 추가
  * 밴드 목록 테스트 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->