### PR TITLE
로컬 DB 설정 단순화 및 Prisma 시드 데이터 추가

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,4 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=jamplay
 POSTGRES_PORT=5432
-DB_APP_USER=jamplay_app
-DB_APP_PASSWORD=jamplay1234
-DATABASE_URL="postgresql://jamplay_app:jamplay1234@localhost:5432/jamplay?schema=public"
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/jamplay?schema=public"

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -5,6 +5,10 @@ import importPlugin from 'eslint-plugin-import';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import prettierPlugin from 'eslint-plugin-prettier';
 import { builtinModules } from 'node:module';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDirectory = dirname(fileURLToPath(import.meta.url));
 
 export default [
   // ------------------------------------------------------------
@@ -56,7 +60,8 @@ export default [
 
       parser: tseslint.parser,
       parserOptions: {
-        projectService: true,
+        project: ['./tsconfig.eslint.json'],
+        tsconfigRootDir: currentDirectory,
       },
     },
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,11 +14,13 @@
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "prisma:format": "prisma format",
     "prisma:generate": "prisma generate",
+    "prisma:push": "prisma db push",
     "prisma:seed": "prisma db seed",
     "prisma:validate": "prisma validate",
     "prisma:migrate:dev": "prisma migrate dev",
     "prisma:migrate:deploy": "prisma migrate deploy",
     "prisma:studio": "prisma studio",
+    "prestart:dev": "node -e \"const fs=require('node:fs'); fs.rmSync('dist', { recursive: true, force: true }); fs.rmSync('tsconfig.build.tsbuildinfo', { force: true }); fs.rmSync('tsconfig.tsbuildinfo', { force: true });\"",
     "start": "node dist/main.js",
     "start:dev": "nest start --watch",
     "test": "node --import tsx --test src/**/*.spec.ts"
@@ -49,8 +51,5 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.55.0"
-  },
-  "prisma": {
-    "seed": "tsx prisma/seed.ts"
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,6 @@
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "prisma:format": "prisma format",
     "prisma:generate": "prisma generate",
-    "prisma:push": "prisma db push",
     "prisma:seed": "prisma db seed",
     "prisma:validate": "prisma validate",
     "prisma:migrate:dev": "prisma migrate dev",

--- a/backend/prisma.config.ts
+++ b/backend/prisma.config.ts
@@ -1,0 +1,24 @@
+import { existsSync } from 'node:fs';
+import { loadEnvFile } from 'node:process';
+
+import { defineConfig } from 'prisma/config';
+
+if (existsSync('.env')) {
+  loadEnvFile('.env');
+}
+
+if (existsSync('.env.development')) {
+  loadEnvFile('.env.development');
+}
+
+/**
+ * Prisma CLI 설정을 파일로 분리해
+ * 구식 package.json 설정 경고를 없애고
+ * 시드 명령 위치를 명확하게 고정한다.
+ */
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  migrations: {
+    seed: 'tsx prisma/seed.ts',
+  },
+});

--- a/backend/prisma/migrations/20260329000000_init/migration.sql
+++ b/backend/prisma/migrations/20260329000000_init/migration.sql
@@ -1,0 +1,437 @@
+-- CreateSchema
+CREATE SCHEMA IF NOT EXISTS "public";
+
+-- CreateEnum
+CREATE TYPE "UserStatus" AS ENUM ('ACTIVE', 'SUSPENDED');
+
+-- CreateEnum
+CREATE TYPE "JoinRequestStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+
+-- CreateEnum
+CREATE TYPE "BandSpaceMemberRole" AS ENUM ('LEADER', 'MEMBER');
+
+-- CreateEnum
+CREATE TYPE "BandSpaceMemberStatus" AS ENUM ('ACTIVE', 'INACTIVE');
+
+-- CreateEnum
+CREATE TYPE "SkillLevelType" AS ENUM ('BEGINNER', 'INTERMEDIATE', 'ADVANCED');
+
+-- CreateEnum
+CREATE TYPE "TeamStatus" AS ENUM ('ACTIVE', 'INACTIVE');
+
+-- CreateEnum
+CREATE TYPE "SongKey" AS ENUM ('UNKNOWN', 'C', 'CM', 'D', 'DM', 'E', 'EM', 'F', 'FM', 'G', 'GM', 'A', 'AM', 'B', 'BM');
+
+-- CreateEnum
+CREATE TYPE "BandInvitationStatus" AS ENUM ('PENDING', 'ACCEPTED', 'DECLINED', 'EXPIRED');
+
+-- CreateEnum
+CREATE TYPE "NotificationType" AS ENUM ('INFO', 'WARNING', 'REMINDER');
+
+-- CreateEnum
+CREATE TYPE "AttendanceStatus" AS ENUM ('ATTEND', 'ABSENT', 'LATE', 'UNKNOWN');
+
+-- CreateEnum
+CREATE TYPE "ScheduleType" AS ENUM ('PRACTICE', 'PERFORMANCE', 'MEETING', 'ETC');
+
+-- CreateEnum
+CREATE TYPE "ScheduleStatus" AS ENUM ('SCHEDULED', 'CANCELLED', 'DONE');
+
+-- CreateEnum
+CREATE TYPE "BandSpaceType" AS ENUM ('PRACTICE_ROOM', 'STUDIO', 'ONLINE', 'ETC');
+
+-- CreateEnum
+CREATE TYPE "BandSpaceStatus" AS ENUM ('ACTIVE', 'INACTIVE');
+
+-- CreateEnum
+CREATE TYPE "BandMemberRole" AS ENUM ('BM', 'ADMIN', 'MEMBER');
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" UUID NOT NULL,
+    "email" VARCHAR(255),
+    "password_hash" VARCHAR(255),
+    "status" "UserStatus" NOT NULL DEFAULT 'ACTIVE',
+    "last_login_at" TIMESTAMPTZ(6),
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" TIMESTAMPTZ(6),
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "skill_types" (
+    "id" UUID NOT NULL,
+    "name" VARCHAR(40),
+
+    CONSTRAINT "skill_types_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "genres" (
+    "id" UUID NOT NULL,
+    "name" VARCHAR(20),
+
+    CONSTRAINT "genres_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user_profiles" (
+    "user_id" UUID NOT NULL,
+    "nickname" VARCHAR(255) NOT NULL,
+    "self_description" TEXT,
+    "profile_music_url" TEXT,
+    "avatar_url" TEXT,
+    "updated_at" TIMESTAMPTZ(6),
+
+    CONSTRAINT "user_profiles_pkey" PRIMARY KEY ("user_id")
+);
+
+-- CreateTable
+CREATE TABLE "notifications" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "type" "NotificationType" NOT NULL,
+    "title" VARCHAR(120),
+    "is_read" BOOLEAN NOT NULL DEFAULT false,
+    "reminds_at" TIMESTAMPTZ(6),
+    "created_at" TIMESTAMPTZ(6) DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user_skills" (
+    "id" UUID NOT NULL,
+    "skill_level" "SkillLevelType" NOT NULL DEFAULT 'BEGINNER',
+    "is_primary" BOOLEAN DEFAULT false,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "skill_type_id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+
+    CONSTRAINT "user_skills_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "favor_genres" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "genre_id" UUID NOT NULL,
+
+    CONSTRAINT "favor_genres_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "bands" (
+    "id" UUID NOT NULL,
+    "name" VARCHAR(40),
+    "bm_id" UUID NOT NULL,
+    "description" TEXT,
+    "visibility" BOOLEAN DEFAULT true,
+    "invite_code" VARCHAR(255),
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+    "deleted_at" TIMESTAMPTZ(6),
+
+    CONSTRAINT "bands_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "band_join_requests" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "band_id" UUID NOT NULL,
+    "message" TEXT,
+    "status" "JoinRequestStatus" NOT NULL DEFAULT 'PENDING',
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "band_join_requests_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "band_invitations" (
+    "id" UUID NOT NULL,
+    "band_id" UUID NOT NULL,
+    "inviter_user_id" UUID NOT NULL,
+    "invitee_user_id" UUID NOT NULL,
+    "invitation_token" VARCHAR(255),
+    "status" "BandInvitationStatus" NOT NULL DEFAULT 'PENDING',
+    "responded_at" TIMESTAMPTZ(6),
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "band_invitations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "band_members" (
+    "id" UUID NOT NULL,
+    "band_id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "role" "BandMemberRole" NOT NULL DEFAULT 'MEMBER',
+    "joined_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "band_members_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "band_blacklists" (
+    "id" UUID NOT NULL,
+    "band_id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "reason" TEXT,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "band_blacklists_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "places" (
+    "id" UUID NOT NULL,
+    "band_id" UUID NOT NULL,
+    "name" VARCHAR(120),
+    "address" VARCHAR(255),
+    "detail_address" VARCHAR(255),
+    "is_active" BOOLEAN DEFAULT true,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "places_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "band_spaces" (
+    "id" UUID NOT NULL,
+    "band_id" UUID NOT NULL,
+    "name" VARCHAR(150),
+    "description" TEXT,
+    "space_type" "BandSpaceType",
+    "status" "BandSpaceStatus",
+    "start_date" DATE,
+    "end_date" DATE,
+    "created_by_user_id" UUID NOT NULL,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6),
+    "deleted_at" TIMESTAMPTZ(6),
+
+    CONSTRAINT "band_spaces_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "space_members" (
+    "id" UUID NOT NULL,
+    "space_id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "role" "BandSpaceMemberRole" NOT NULL DEFAULT 'MEMBER',
+    "status" "BandSpaceMemberStatus" NOT NULL DEFAULT 'ACTIVE',
+    "joined_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "space_members_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "songs" (
+    "id" UUID NOT NULL,
+    "band_id" UUID,
+    "title" VARCHAR(200),
+    "artist_name" VARCHAR(200),
+    "key" "SongKey",
+    "bpm" SMALLINT,
+    "source_url" TEXT,
+    "source_type" VARCHAR(20),
+    "memo" TEXT,
+    "difficulty_level" SMALLINT,
+    "created_by_user_id" UUID,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "songs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "song_skills" (
+    "id" UUID NOT NULL,
+    "song_id" UUID NOT NULL,
+    "skill_type_id" UUID NOT NULL,
+
+    CONSTRAINT "song_skills_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "schedules" (
+    "id" UUID NOT NULL,
+    "band_space_id" UUID NOT NULL,
+    "place_id" UUID NOT NULL,
+    "title" VARCHAR(150),
+    "schedule_type" "ScheduleType",
+    "start_at" TIMESTAMPTZ(6),
+    "end_at" TIMESTAMPTZ(6),
+    "memo" TEXT,
+    "status" "ScheduleStatus",
+    "created_by_user_id" UUID NOT NULL,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "schedules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "schedule_participants" (
+    "id" UUID NOT NULL,
+    "schedule_id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "attendance_status" "AttendanceStatus",
+    "note" TEXT,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "schedule_participants_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "teams" (
+    "id" UUID NOT NULL,
+    "band_id" UUID NOT NULL,
+    "name" VARCHAR(150),
+    "target_schedule_id" UUID,
+    "note" TEXT,
+    "status" "TeamStatus" DEFAULT 'ACTIVE',
+    "team_leader_user_id" UUID,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "teams_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "team_members" (
+    "id" UUID NOT NULL,
+    "team_id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "joined_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "team_members_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "team_songs" (
+    "id" UUID NOT NULL,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "team_id" UUID NOT NULL,
+    "song_id" UUID NOT NULL,
+
+    CONSTRAINT "team_songs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- AddForeignKey
+ALTER TABLE "user_profiles" ADD CONSTRAINT "user_profiles_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_skills" ADD CONSTRAINT "user_skills_skill_type_id_fkey" FOREIGN KEY ("skill_type_id") REFERENCES "skill_types"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_skills" ADD CONSTRAINT "user_skills_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "favor_genres" ADD CONSTRAINT "favor_genres_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "favor_genres" ADD CONSTRAINT "favor_genres_genre_id_fkey" FOREIGN KEY ("genre_id") REFERENCES "genres"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "bands" ADD CONSTRAINT "bands_bm_id_fkey" FOREIGN KEY ("bm_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "band_join_requests" ADD CONSTRAINT "band_join_requests_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "band_join_requests" ADD CONSTRAINT "band_join_requests_band_id_fkey" FOREIGN KEY ("band_id") REFERENCES "bands"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "band_invitations" ADD CONSTRAINT "band_invitations_band_id_fkey" FOREIGN KEY ("band_id") REFERENCES "bands"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "band_invitations" ADD CONSTRAINT "band_invitations_inviter_user_id_fkey" FOREIGN KEY ("inviter_user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "band_invitations" ADD CONSTRAINT "band_invitations_invitee_user_id_fkey" FOREIGN KEY ("invitee_user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "band_members" ADD CONSTRAINT "band_members_band_id_fkey" FOREIGN KEY ("band_id") REFERENCES "bands"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "band_members" ADD CONSTRAINT "band_members_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "band_blacklists" ADD CONSTRAINT "band_blacklists_band_id_fkey" FOREIGN KEY ("band_id") REFERENCES "bands"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "band_blacklists" ADD CONSTRAINT "band_blacklists_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "places" ADD CONSTRAINT "places_band_id_fkey" FOREIGN KEY ("band_id") REFERENCES "bands"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "band_spaces" ADD CONSTRAINT "band_spaces_band_id_fkey" FOREIGN KEY ("band_id") REFERENCES "bands"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "band_spaces" ADD CONSTRAINT "band_spaces_created_by_user_id_fkey" FOREIGN KEY ("created_by_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "space_members" ADD CONSTRAINT "space_members_space_id_fkey" FOREIGN KEY ("space_id") REFERENCES "band_spaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "space_members" ADD CONSTRAINT "space_members_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "songs" ADD CONSTRAINT "songs_band_id_fkey" FOREIGN KEY ("band_id") REFERENCES "bands"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "songs" ADD CONSTRAINT "songs_created_by_user_id_fkey" FOREIGN KEY ("created_by_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "song_skills" ADD CONSTRAINT "song_skills_song_id_fkey" FOREIGN KEY ("song_id") REFERENCES "songs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "song_skills" ADD CONSTRAINT "song_skills_skill_type_id_fkey" FOREIGN KEY ("skill_type_id") REFERENCES "skill_types"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "schedules" ADD CONSTRAINT "schedules_band_space_id_fkey" FOREIGN KEY ("band_space_id") REFERENCES "band_spaces"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "schedules" ADD CONSTRAINT "schedules_place_id_fkey" FOREIGN KEY ("place_id") REFERENCES "places"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "schedules" ADD CONSTRAINT "schedules_created_by_user_id_fkey" FOREIGN KEY ("created_by_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "schedule_participants" ADD CONSTRAINT "schedule_participants_schedule_id_fkey" FOREIGN KEY ("schedule_id") REFERENCES "schedules"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "schedule_participants" ADD CONSTRAINT "schedule_participants_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "teams" ADD CONSTRAINT "teams_band_id_fkey" FOREIGN KEY ("band_id") REFERENCES "bands"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "teams" ADD CONSTRAINT "teams_target_schedule_id_fkey" FOREIGN KEY ("target_schedule_id") REFERENCES "schedules"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "teams" ADD CONSTRAINT "teams_team_leader_user_id_fkey" FOREIGN KEY ("team_leader_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "team_members" ADD CONSTRAINT "team_members_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "team_members" ADD CONSTRAINT "team_members_team_id_fkey" FOREIGN KEY ("team_id") REFERENCES "teams"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "team_songs" ADD CONSTRAINT "team_songs_team_id_fkey" FOREIGN KEY ("team_id") REFERENCES "teams"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "team_songs" ADD CONSTRAINT "team_songs_song_id_fkey" FOREIGN KEY ("song_id") REFERENCES "songs"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/migration_lock.toml
+++ b/backend/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,0 +1,802 @@
+import { PrismaClient } from '../src/generated/prisma';
+
+const prisma = new PrismaClient();
+
+const seedIds = {
+  users: {
+    minjun: '11111111-1111-1111-1111-111111111111',
+    seoyeon: '22222222-2222-2222-2222-222222222222',
+    jiho: '33333333-3333-3333-3333-333333333333',
+  },
+  band: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  place: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+  spaces: {
+    summerShow: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+    acousticSession: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+  },
+  schedules: {
+    summerPractice: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+    summerMeeting: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+    acousticPractice: '99999999-9999-9999-9999-999999999999',
+  },
+  teams: {
+    summerMain: 'abababab-abab-abab-abab-abababababab',
+    acousticUnit: 'cdcdcdcd-cdcd-cdcd-cdcd-cdcdcdcdcdcd',
+  },
+  songs: {
+    first: '12121212-1212-1212-1212-121212121212',
+    second: '34343434-3434-3434-3434-343434343434',
+    third: '56565656-5656-5656-5656-565656565656',
+  },
+  bandMembers: {
+    minjun: '78787878-7878-7878-7878-787878787878',
+    seoyeon: '89898989-8989-8989-8989-898989898989',
+    jiho: '90909090-9090-9090-9090-909090909090',
+  },
+  spaceMembers: {
+    summerLeader: 'abab1212-abab-1212-abab-1212abab1212',
+    summerMember: 'cdcd3434-cdcd-3434-cdcd-3434cdcd3434',
+    acousticLeader: 'efef5656-efef-5656-efef-5656efef5656',
+    acousticMember: '1212abab-1212-abab-1212-abab1212abab',
+  },
+  scheduleParticipants: {
+    summerLeader: '3434cdcd-3434-cdcd-3434-cdcd3434cdcd',
+    summerMember: '5656efef-5656-efef-5656-efef5656efef',
+    meetingLeader: '7878abab-7878-abab-7878-abab7878abab',
+    acousticLeader: '9090cdcd-9090-cdcd-9090-cdcd9090cdcd',
+  },
+  teamMembers: {
+    summerLeader: 'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+    summerMember: 'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+    acousticLeader: 'c3c3c3c3-c3c3-c3c3-c3c3-c3c3c3c3c3c3',
+  },
+  teamSongs: {
+    summerFirst: 'd4d4d4d4-d4d4-d4d4-d4d4-d4d4d4d4d4d4',
+    summerSecond: 'e5e5e5e5-e5e5-e5e5-e5e5-e5e5e5e5e5e5',
+    summerThird: 'f6f6f6f6-f6f6-f6f6-f6f6-f6f6f6f6f6f6',
+    acousticSecond: '17171717-1717-1717-1717-171717171717',
+  },
+} as const;
+
+/**
+ * 로컬 개발 환경에서 바로 화면과 API를 확인할 수 있도록
+ * 최소한의 데모 데이터를 고정 ID로 채운다.
+ *
+ * @returns {Promise<void>} 시드 데이터 생성이 끝나면 완료된다.
+ */
+async function seedLocalDemoData(): Promise<void> {
+  await upsertUsers();
+  await upsertProfiles();
+  await upsertBand();
+  await upsertBandMembers();
+  await upsertPlace();
+  await upsertSpaces();
+  await upsertSpaceMembers();
+  await upsertSongs();
+  await upsertSchedules();
+  await upsertScheduleParticipants();
+  await upsertTeams();
+  await upsertTeamMembers();
+  await upsertTeamSongs();
+}
+
+/**
+ * 로컬에서 공통으로 사용할 기본 사용자 데이터를 만든다.
+ *
+ * @returns {Promise<void>} 사용자 데이터가 준비되면 완료된다.
+ */
+async function upsertUsers(): Promise<void> {
+  await prisma.user.upsert({
+    where: { id: seedIds.users.minjun },
+    update: {
+      email: 'minjun@jamplay.local',
+      status: 'ACTIVE',
+    },
+    create: {
+      id: seedIds.users.minjun,
+      email: 'minjun@jamplay.local',
+      status: 'ACTIVE',
+    },
+  });
+
+  await prisma.user.upsert({
+    where: { id: seedIds.users.seoyeon },
+    update: {
+      email: 'seoyeon@jamplay.local',
+      status: 'ACTIVE',
+    },
+    create: {
+      id: seedIds.users.seoyeon,
+      email: 'seoyeon@jamplay.local',
+      status: 'ACTIVE',
+    },
+  });
+
+  await prisma.user.upsert({
+    where: { id: seedIds.users.jiho },
+    update: {
+      email: 'jiho@jamplay.local',
+      status: 'ACTIVE',
+    },
+    create: {
+      id: seedIds.users.jiho,
+      email: 'jiho@jamplay.local',
+      status: 'ACTIVE',
+    },
+  });
+}
+
+/**
+ * 사용자 목록 화면에서 바로 식별할 수 있도록 프로필을 연결한다.
+ *
+ * @returns {Promise<void>} 프로필 데이터가 준비되면 완료된다.
+ */
+async function upsertProfiles(): Promise<void> {
+  await prisma.userProfile.upsert({
+    where: { userId: seedIds.users.minjun },
+    update: {
+      nickname: '김민준',
+      selfDescription: '리드 기타와 밴드 운영을 맡고 있습니다.',
+    },
+    create: {
+      userId: seedIds.users.minjun,
+      nickname: '김민준',
+      selfDescription: '리드 기타와 밴드 운영을 맡고 있습니다.',
+    },
+  });
+
+  await prisma.userProfile.upsert({
+    where: { userId: seedIds.users.seoyeon },
+    update: {
+      nickname: '이서연',
+      selfDescription: '어쿠스틱 편곡과 보컬을 담당합니다.',
+    },
+    create: {
+      userId: seedIds.users.seoyeon,
+      nickname: '이서연',
+      selfDescription: '어쿠스틱 편곡과 보컬을 담당합니다.',
+    },
+  });
+
+  await prisma.userProfile.upsert({
+    where: { userId: seedIds.users.jiho },
+    update: {
+      nickname: '박지호',
+      selfDescription: '드럼과 리듬 파트를 정리합니다.',
+    },
+    create: {
+      userId: seedIds.users.jiho,
+      nickname: '박지호',
+      selfDescription: '드럼과 리듬 파트를 정리합니다.',
+    },
+  });
+}
+
+/**
+ * 시드 데이터의 기준이 되는 기본 밴드를 만든다.
+ *
+ * @returns {Promise<void>} 밴드 데이터가 준비되면 완료된다.
+ */
+async function upsertBand(): Promise<void> {
+  await prisma.band.upsert({
+    where: { id: seedIds.band },
+    update: {
+      name: 'Jamplay 밴드',
+      description: '로컬 개발 확인용 더미 밴드',
+      bandMasterUserId: seedIds.users.minjun,
+    },
+    create: {
+      id: seedIds.band,
+      name: 'Jamplay 밴드',
+      description: '로컬 개발 확인용 더미 밴드',
+      bandMasterUserId: seedIds.users.minjun,
+    },
+  });
+}
+
+/**
+ * 밴드 멤버 관계를 고정 데이터로 만든다.
+ *
+ * @returns {Promise<void>} 밴드 멤버 데이터가 준비되면 완료된다.
+ */
+async function upsertBandMembers(): Promise<void> {
+  await prisma.bandMember.upsert({
+    where: { id: seedIds.bandMembers.minjun },
+    update: {
+      bandId: seedIds.band,
+      userId: seedIds.users.minjun,
+      role: 'BM',
+    },
+    create: {
+      id: seedIds.bandMembers.minjun,
+      bandId: seedIds.band,
+      userId: seedIds.users.minjun,
+      role: 'BM',
+    },
+  });
+
+  await prisma.bandMember.upsert({
+    where: { id: seedIds.bandMembers.seoyeon },
+    update: {
+      bandId: seedIds.band,
+      userId: seedIds.users.seoyeon,
+      role: 'MEMBER',
+    },
+    create: {
+      id: seedIds.bandMembers.seoyeon,
+      bandId: seedIds.band,
+      userId: seedIds.users.seoyeon,
+      role: 'MEMBER',
+    },
+  });
+
+  await prisma.bandMember.upsert({
+    where: { id: seedIds.bandMembers.jiho },
+    update: {
+      bandId: seedIds.band,
+      userId: seedIds.users.jiho,
+      role: 'MEMBER',
+    },
+    create: {
+      id: seedIds.bandMembers.jiho,
+      bandId: seedIds.band,
+      userId: seedIds.users.jiho,
+      role: 'MEMBER',
+    },
+  });
+}
+
+/**
+ * 일정과 공간이 함께 참조할 기본 장소를 만든다.
+ *
+ * @returns {Promise<void>} 장소 데이터가 준비되면 완료된다.
+ */
+async function upsertPlace(): Promise<void> {
+  await prisma.place.upsert({
+    where: { id: seedIds.place },
+    update: {
+      bandId: seedIds.band,
+      name: '연습실 A',
+      address: '서울시 마포구 와우산로 00',
+      detailAddress: '3층 301호',
+      isActive: true,
+    },
+    create: {
+      id: seedIds.place,
+      bandId: seedIds.band,
+      name: '연습실 A',
+      address: '서울시 마포구 와우산로 00',
+      detailAddress: '3층 301호',
+      isActive: true,
+    },
+  });
+}
+
+/**
+ * 합주 공간 목록과 상세 조회에서 바로 사용할 공간 데이터를 만든다.
+ *
+ * @returns {Promise<void>} 공간 데이터가 준비되면 완료된다.
+ */
+async function upsertSpaces(): Promise<void> {
+  await prisma.bandSpace.upsert({
+    where: { id: seedIds.spaces.summerShow },
+    update: {
+      bandId: seedIds.band,
+      name: '2026 하계공연 준비',
+      description: '여름 축제 공연 준비 팀',
+      spaceType: 'STUDIO',
+      status: 'ACTIVE',
+      startDate: new Date('2026-08-01'),
+      endDate: new Date('2026-08-20'),
+      createdByUserId: seedIds.users.minjun,
+    },
+    create: {
+      id: seedIds.spaces.summerShow,
+      bandId: seedIds.band,
+      name: '2026 하계공연 준비',
+      description: '여름 축제 공연 준비 팀',
+      spaceType: 'STUDIO',
+      status: 'ACTIVE',
+      startDate: new Date('2026-08-01'),
+      endDate: new Date('2026-08-20'),
+      createdByUserId: seedIds.users.minjun,
+    },
+  });
+
+  await prisma.bandSpace.upsert({
+    where: { id: seedIds.spaces.acousticSession },
+    update: {
+      bandId: seedIds.band,
+      name: '봄 정기공연 어쿠스틱 세션',
+      description: '어쿠스틱 편성 연습 공간',
+      spaceType: 'PRACTICE_ROOM',
+      status: 'ACTIVE',
+      startDate: new Date('2026-03-01'),
+      endDate: new Date('2026-03-25'),
+      createdByUserId: seedIds.users.seoyeon,
+    },
+    create: {
+      id: seedIds.spaces.acousticSession,
+      bandId: seedIds.band,
+      name: '봄 정기공연 어쿠스틱 세션',
+      description: '어쿠스틱 편성 연습 공간',
+      spaceType: 'PRACTICE_ROOM',
+      status: 'ACTIVE',
+      startDate: new Date('2026-03-01'),
+      endDate: new Date('2026-03-25'),
+      createdByUserId: seedIds.users.seoyeon,
+    },
+  });
+}
+
+/**
+ * 공간 멤버 데이터를 만들어 목록과 상세 화면에서 관계를 확인할 수 있게 한다.
+ *
+ * @returns {Promise<void>} 공간 멤버 데이터가 준비되면 완료된다.
+ */
+async function upsertSpaceMembers(): Promise<void> {
+  await prisma.spaceMember.upsert({
+    where: { id: seedIds.spaceMembers.summerLeader },
+    update: {
+      spaceId: seedIds.spaces.summerShow,
+      userId: seedIds.users.minjun,
+      role: 'LEADER',
+      status: 'ACTIVE',
+    },
+    create: {
+      id: seedIds.spaceMembers.summerLeader,
+      spaceId: seedIds.spaces.summerShow,
+      userId: seedIds.users.minjun,
+      role: 'LEADER',
+      status: 'ACTIVE',
+    },
+  });
+
+  await prisma.spaceMember.upsert({
+    where: { id: seedIds.spaceMembers.summerMember },
+    update: {
+      spaceId: seedIds.spaces.summerShow,
+      userId: seedIds.users.seoyeon,
+      role: 'MEMBER',
+      status: 'ACTIVE',
+    },
+    create: {
+      id: seedIds.spaceMembers.summerMember,
+      spaceId: seedIds.spaces.summerShow,
+      userId: seedIds.users.seoyeon,
+      role: 'MEMBER',
+      status: 'ACTIVE',
+    },
+  });
+
+  await prisma.spaceMember.upsert({
+    where: { id: seedIds.spaceMembers.acousticLeader },
+    update: {
+      spaceId: seedIds.spaces.acousticSession,
+      userId: seedIds.users.seoyeon,
+      role: 'LEADER',
+      status: 'ACTIVE',
+    },
+    create: {
+      id: seedIds.spaceMembers.acousticLeader,
+      spaceId: seedIds.spaces.acousticSession,
+      userId: seedIds.users.seoyeon,
+      role: 'LEADER',
+      status: 'ACTIVE',
+    },
+  });
+
+  await prisma.spaceMember.upsert({
+    where: { id: seedIds.spaceMembers.acousticMember },
+    update: {
+      spaceId: seedIds.spaces.acousticSession,
+      userId: seedIds.users.minjun,
+      role: 'MEMBER',
+      status: 'ACTIVE',
+    },
+    create: {
+      id: seedIds.spaceMembers.acousticMember,
+      spaceId: seedIds.spaces.acousticSession,
+      userId: seedIds.users.minjun,
+      role: 'MEMBER',
+      status: 'ACTIVE',
+    },
+  });
+}
+
+/**
+ * 곡 목록과 팀 연결 확인용 기본 곡 데이터를 만든다.
+ *
+ * @returns {Promise<void>} 곡 데이터가 준비되면 완료된다.
+ */
+async function upsertSongs(): Promise<void> {
+  await prisma.song.upsert({
+    where: { id: seedIds.songs.first },
+    update: {
+      bandId: seedIds.band,
+      title: 'Summer Light',
+      artistName: 'Jamplay',
+      key: 'G',
+      bpm: 118,
+      createdByUserId: seedIds.users.minjun,
+    },
+    create: {
+      id: seedIds.songs.first,
+      bandId: seedIds.band,
+      title: 'Summer Light',
+      artistName: 'Jamplay',
+      key: 'G',
+      bpm: 118,
+      createdByUserId: seedIds.users.minjun,
+    },
+  });
+
+  await prisma.song.upsert({
+    where: { id: seedIds.songs.second },
+    update: {
+      bandId: seedIds.band,
+      title: 'Acoustic Bloom',
+      artistName: 'Jamplay',
+      key: 'C',
+      bpm: 92,
+      createdByUserId: seedIds.users.seoyeon,
+    },
+    create: {
+      id: seedIds.songs.second,
+      bandId: seedIds.band,
+      title: 'Acoustic Bloom',
+      artistName: 'Jamplay',
+      key: 'C',
+      bpm: 92,
+      createdByUserId: seedIds.users.seoyeon,
+    },
+  });
+
+  await prisma.song.upsert({
+    where: { id: seedIds.songs.third },
+    update: {
+      bandId: seedIds.band,
+      title: 'Night Ride',
+      artistName: 'Jamplay',
+      key: 'D',
+      bpm: 132,
+      createdByUserId: seedIds.users.jiho,
+    },
+    create: {
+      id: seedIds.songs.third,
+      bandId: seedIds.band,
+      title: 'Night Ride',
+      artistName: 'Jamplay',
+      key: 'D',
+      bpm: 132,
+      createdByUserId: seedIds.users.jiho,
+    },
+  });
+}
+
+/**
+ * 캘린더와 일정 상세 확인에 쓸 기본 일정을 만든다.
+ *
+ * @returns {Promise<void>} 일정 데이터가 준비되면 완료된다.
+ */
+async function upsertSchedules(): Promise<void> {
+  await prisma.schedule.upsert({
+    where: { id: seedIds.schedules.summerPractice },
+    update: {
+      bandSpaceId: seedIds.spaces.summerShow,
+      placeId: seedIds.place,
+      title: '메인 셋리스트 합주',
+      scheduleType: 'PRACTICE',
+      startAt: new Date('2026-08-03T10:00:00.000Z'),
+      endAt: new Date('2026-08-03T13:00:00.000Z'),
+      memo: '오프닝 두 곡 집중 점검',
+      status: 'SCHEDULED',
+      createdByUserId: seedIds.users.minjun,
+    },
+    create: {
+      id: seedIds.schedules.summerPractice,
+      bandSpaceId: seedIds.spaces.summerShow,
+      placeId: seedIds.place,
+      title: '메인 셋리스트 합주',
+      scheduleType: 'PRACTICE',
+      startAt: new Date('2026-08-03T10:00:00.000Z'),
+      endAt: new Date('2026-08-03T13:00:00.000Z'),
+      memo: '오프닝 두 곡 집중 점검',
+      status: 'SCHEDULED',
+      createdByUserId: seedIds.users.minjun,
+    },
+  });
+
+  await prisma.schedule.upsert({
+    where: { id: seedIds.schedules.summerMeeting },
+    update: {
+      bandSpaceId: seedIds.spaces.summerShow,
+      placeId: seedIds.place,
+      title: '무대 동선 미팅',
+      scheduleType: 'MEETING',
+      startAt: new Date('2026-08-05T11:00:00.000Z'),
+      endAt: new Date('2026-08-05T12:00:00.000Z'),
+      memo: '무대 진입 동선과 장비 체크',
+      status: 'SCHEDULED',
+      createdByUserId: seedIds.users.minjun,
+    },
+    create: {
+      id: seedIds.schedules.summerMeeting,
+      bandSpaceId: seedIds.spaces.summerShow,
+      placeId: seedIds.place,
+      title: '무대 동선 미팅',
+      scheduleType: 'MEETING',
+      startAt: new Date('2026-08-05T11:00:00.000Z'),
+      endAt: new Date('2026-08-05T12:00:00.000Z'),
+      memo: '무대 진입 동선과 장비 체크',
+      status: 'SCHEDULED',
+      createdByUserId: seedIds.users.minjun,
+    },
+  });
+
+  await prisma.schedule.upsert({
+    where: { id: seedIds.schedules.acousticPractice },
+    update: {
+      bandSpaceId: seedIds.spaces.acousticSession,
+      placeId: seedIds.place,
+      title: '어쿠스틱 편곡 리허설',
+      scheduleType: 'PRACTICE',
+      startAt: new Date('2026-03-05T19:00:00.000Z'),
+      endAt: new Date('2026-03-05T21:00:00.000Z'),
+      memo: '키 변경과 코러스 정리',
+      status: 'SCHEDULED',
+      createdByUserId: seedIds.users.seoyeon,
+    },
+    create: {
+      id: seedIds.schedules.acousticPractice,
+      bandSpaceId: seedIds.spaces.acousticSession,
+      placeId: seedIds.place,
+      title: '어쿠스틱 편곡 리허설',
+      scheduleType: 'PRACTICE',
+      startAt: new Date('2026-03-05T19:00:00.000Z'),
+      endAt: new Date('2026-03-05T21:00:00.000Z'),
+      memo: '키 변경과 코러스 정리',
+      status: 'SCHEDULED',
+      createdByUserId: seedIds.users.seoyeon,
+    },
+  });
+}
+
+/**
+ * 일정 참여 상태를 넣어 출석 관련 화면을 바로 붙일 수 있게 한다.
+ *
+ * @returns {Promise<void>} 일정 참여 데이터가 준비되면 완료된다.
+ */
+async function upsertScheduleParticipants(): Promise<void> {
+  await prisma.scheduleParticipant.upsert({
+    where: { id: seedIds.scheduleParticipants.summerLeader },
+    update: {
+      scheduleId: seedIds.schedules.summerPractice,
+      userId: seedIds.users.minjun,
+      attendanceStatus: 'ATTEND',
+      note: '장비 세팅 30분 전 도착 예정',
+    },
+    create: {
+      id: seedIds.scheduleParticipants.summerLeader,
+      scheduleId: seedIds.schedules.summerPractice,
+      userId: seedIds.users.minjun,
+      attendanceStatus: 'ATTEND',
+      note: '장비 세팅 30분 전 도착 예정',
+    },
+  });
+
+  await prisma.scheduleParticipant.upsert({
+    where: { id: seedIds.scheduleParticipants.summerMember },
+    update: {
+      scheduleId: seedIds.schedules.summerPractice,
+      userId: seedIds.users.seoyeon,
+      attendanceStatus: 'ATTEND',
+      note: '어쿠스틱 기타 지참',
+    },
+    create: {
+      id: seedIds.scheduleParticipants.summerMember,
+      scheduleId: seedIds.schedules.summerPractice,
+      userId: seedIds.users.seoyeon,
+      attendanceStatus: 'ATTEND',
+      note: '어쿠스틱 기타 지참',
+    },
+  });
+
+  await prisma.scheduleParticipant.upsert({
+    where: { id: seedIds.scheduleParticipants.meetingLeader },
+    update: {
+      scheduleId: seedIds.schedules.summerMeeting,
+      userId: seedIds.users.minjun,
+      attendanceStatus: 'ATTEND',
+      note: '진행표 초안 공유 예정',
+    },
+    create: {
+      id: seedIds.scheduleParticipants.meetingLeader,
+      scheduleId: seedIds.schedules.summerMeeting,
+      userId: seedIds.users.minjun,
+      attendanceStatus: 'ATTEND',
+      note: '진행표 초안 공유 예정',
+    },
+  });
+
+  await prisma.scheduleParticipant.upsert({
+    where: { id: seedIds.scheduleParticipants.acousticLeader },
+    update: {
+      scheduleId: seedIds.schedules.acousticPractice,
+      userId: seedIds.users.seoyeon,
+      attendanceStatus: 'ATTEND',
+      note: '편곡 버전 최종 확인',
+    },
+    create: {
+      id: seedIds.scheduleParticipants.acousticLeader,
+      scheduleId: seedIds.schedules.acousticPractice,
+      userId: seedIds.users.seoyeon,
+      attendanceStatus: 'ATTEND',
+      note: '편곡 버전 최종 확인',
+    },
+  });
+}
+
+/**
+ * 팀과 일정 연결을 만들어 연습 단위 데이터를 함께 확인할 수 있게 한다.
+ *
+ * @returns {Promise<void>} 팀 데이터가 준비되면 완료된다.
+ */
+async function upsertTeams(): Promise<void> {
+  await prisma.team.upsert({
+    where: { id: seedIds.teams.summerMain },
+    update: {
+      bandId: seedIds.band,
+      name: '하계공연 메인팀',
+      targetScheduleId: seedIds.schedules.summerPractice,
+      note: '여름 축제 메인 셋리스트 팀',
+      status: 'ACTIVE',
+      teamLeaderUserId: seedIds.users.minjun,
+    },
+    create: {
+      id: seedIds.teams.summerMain,
+      bandId: seedIds.band,
+      name: '하계공연 메인팀',
+      targetScheduleId: seedIds.schedules.summerPractice,
+      note: '여름 축제 메인 셋리스트 팀',
+      status: 'ACTIVE',
+      teamLeaderUserId: seedIds.users.minjun,
+    },
+  });
+
+  await prisma.team.upsert({
+    where: { id: seedIds.teams.acousticUnit },
+    update: {
+      bandId: seedIds.band,
+      name: '어쿠스틱 유닛',
+      targetScheduleId: seedIds.schedules.acousticPractice,
+      note: '소극장 편성 어쿠스틱 팀',
+      status: 'ACTIVE',
+      teamLeaderUserId: seedIds.users.seoyeon,
+    },
+    create: {
+      id: seedIds.teams.acousticUnit,
+      bandId: seedIds.band,
+      name: '어쿠스틱 유닛',
+      targetScheduleId: seedIds.schedules.acousticPractice,
+      note: '소극장 편성 어쿠스틱 팀',
+      status: 'ACTIVE',
+      teamLeaderUserId: seedIds.users.seoyeon,
+    },
+  });
+}
+
+/**
+ * 팀 멤버 구성을 넣어 팀 상세 확장에 대비한다.
+ *
+ * @returns {Promise<void>} 팀 멤버 데이터가 준비되면 완료된다.
+ */
+async function upsertTeamMembers(): Promise<void> {
+  await prisma.teamMember.upsert({
+    where: { id: seedIds.teamMembers.summerLeader },
+    update: {
+      teamId: seedIds.teams.summerMain,
+      userId: seedIds.users.minjun,
+    },
+    create: {
+      id: seedIds.teamMembers.summerLeader,
+      teamId: seedIds.teams.summerMain,
+      userId: seedIds.users.minjun,
+    },
+  });
+
+  await prisma.teamMember.upsert({
+    where: { id: seedIds.teamMembers.summerMember },
+    update: {
+      teamId: seedIds.teams.summerMain,
+      userId: seedIds.users.jiho,
+    },
+    create: {
+      id: seedIds.teamMembers.summerMember,
+      teamId: seedIds.teams.summerMain,
+      userId: seedIds.users.jiho,
+    },
+  });
+
+  await prisma.teamMember.upsert({
+    where: { id: seedIds.teamMembers.acousticLeader },
+    update: {
+      teamId: seedIds.teams.acousticUnit,
+      userId: seedIds.users.seoyeon,
+    },
+    create: {
+      id: seedIds.teamMembers.acousticLeader,
+      teamId: seedIds.teams.acousticUnit,
+      userId: seedIds.users.seoyeon,
+    },
+  });
+}
+
+/**
+ * 곡과 팀 연결을 넣어 팀별 레퍼토리를 바로 확인할 수 있게 한다.
+ *
+ * @returns {Promise<void>} 팀-곡 연결 데이터가 준비되면 완료된다.
+ */
+async function upsertTeamSongs(): Promise<void> {
+  await prisma.teamSong.upsert({
+    where: { id: seedIds.teamSongs.summerFirst },
+    update: {
+      teamId: seedIds.teams.summerMain,
+      songId: seedIds.songs.first,
+    },
+    create: {
+      id: seedIds.teamSongs.summerFirst,
+      teamId: seedIds.teams.summerMain,
+      songId: seedIds.songs.first,
+    },
+  });
+
+  await prisma.teamSong.upsert({
+    where: { id: seedIds.teamSongs.summerSecond },
+    update: {
+      teamId: seedIds.teams.summerMain,
+      songId: seedIds.songs.second,
+    },
+    create: {
+      id: seedIds.teamSongs.summerSecond,
+      teamId: seedIds.teams.summerMain,
+      songId: seedIds.songs.second,
+    },
+  });
+
+  await prisma.teamSong.upsert({
+    where: { id: seedIds.teamSongs.summerThird },
+    update: {
+      teamId: seedIds.teams.summerMain,
+      songId: seedIds.songs.third,
+    },
+    create: {
+      id: seedIds.teamSongs.summerThird,
+      teamId: seedIds.teams.summerMain,
+      songId: seedIds.songs.third,
+    },
+  });
+
+  await prisma.teamSong.upsert({
+    where: { id: seedIds.teamSongs.acousticSecond },
+    update: {
+      teamId: seedIds.teams.acousticUnit,
+      songId: seedIds.songs.second,
+    },
+    create: {
+      id: seedIds.teamSongs.acousticSecond,
+      teamId: seedIds.teams.acousticUnit,
+      songId: seedIds.songs.second,
+    },
+  });
+}
+
+seedLocalDemoData()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async error => {
+    console.error('로컬 더미 데이터 시딩에 실패했습니다.', error);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,3 +1,4 @@
+import { getConflictingSeedUserIds, type SeedUserDefinition } from '../src/database/prisma/seed-user-conflict.util';
 import { PrismaClient } from '../src/generated/prisma';
 
 const prisma = new PrismaClient();
@@ -58,6 +59,24 @@ const seedIds = {
   },
 } as const;
 
+const seedUsers: readonly SeedUserDefinition[] = [
+  {
+    id: seedIds.users.minjun,
+    email: 'minjun@jamplay.local',
+    status: 'ACTIVE',
+  },
+  {
+    id: seedIds.users.seoyeon,
+    email: 'seoyeon@jamplay.local',
+    status: 'ACTIVE',
+  },
+  {
+    id: seedIds.users.jiho,
+    email: 'jiho@jamplay.local',
+    status: 'ACTIVE',
+  },
+] as const;
+
 /**
  * 로컬 개발 환경에서 바로 화면과 API를 확인할 수 있도록
  * 최소한의 데모 데이터를 고정 ID로 채운다.
@@ -86,42 +105,65 @@ async function seedLocalDemoData(): Promise<void> {
  * @returns {Promise<void>} 사용자 데이터가 준비되면 완료된다.
  */
 async function upsertUsers(): Promise<void> {
-  await prisma.user.upsert({
-    where: { id: seedIds.users.minjun },
-    update: {
-      email: 'minjun@jamplay.local',
-      status: 'ACTIVE',
+  await clearEmailsFromConflictingUsers();
+
+  for (const seedUser of seedUsers) {
+    await prisma.user.upsert({
+      where: { id: seedUser.id },
+      update: {
+        email: seedUser.email,
+        status: seedUser.status,
+      },
+      create: {
+        id: seedUser.id,
+        email: seedUser.email,
+        status: seedUser.status,
+      },
+    });
+  }
+}
+
+/**
+ * 이전 시드 실행이나 수동 데이터 입력으로 남아 있는 사용자 중에서
+ * 현재 시드가 사용할 이메일과 같지만 ID가 다른 레코드의 이메일만 먼저 비운다.
+ *
+ * 시드는 다른 테이블에서 고정 사용자 ID를 참조하므로,
+ * 기존 사용자를 삭제하면 FK 제약이 걸릴 수 있다.
+ * 그래서 로컬 더미 데이터 시드에서는 참조 관계는 유지하고,
+ * 이메일 유니크 충돌만 해소하는 방식으로 정리한다.
+ *
+ * @returns {Promise<void>} 이메일 충돌 정리가 끝나면 완료된다.
+ */
+async function clearEmailsFromConflictingUsers(): Promise<void> {
+  const existingUsers = await prisma.user.findMany({
+    where: {
+      email: {
+        in: seedUsers.map(seedUser => seedUser.email),
+      },
     },
-    create: {
-      id: seedIds.users.minjun,
-      email: 'minjun@jamplay.local',
-      status: 'ACTIVE',
+    select: {
+      id: true,
+      email: true,
     },
   });
 
-  await prisma.user.upsert({
-    where: { id: seedIds.users.seoyeon },
-    update: {
-      email: 'seoyeon@jamplay.local',
-      status: 'ACTIVE',
-    },
-    create: {
-      id: seedIds.users.seoyeon,
-      email: 'seoyeon@jamplay.local',
-      status: 'ACTIVE',
-    },
+  const conflictingUserIds = getConflictingSeedUserIds({
+    seedUsers,
+    existingUsers,
   });
 
-  await prisma.user.upsert({
-    where: { id: seedIds.users.jiho },
-    update: {
-      email: 'jiho@jamplay.local',
-      status: 'ACTIVE',
+  if (conflictingUserIds.length === 0) {
+    return;
+  }
+
+  await prisma.user.updateMany({
+    where: {
+      id: {
+        in: conflictingUserIds,
+      },
     },
-    create: {
-      id: seedIds.users.jiho,
-      email: 'jiho@jamplay.local',
-      status: 'ACTIVE',
+    data: {
+      email: null,
     },
   });
 }

--- a/backend/src/config/database.config.spec.ts
+++ b/backend/src/config/database.config.spec.ts
@@ -6,10 +6,10 @@ import { getDatabaseConfig } from './database.config';
 
 test('DB 설정은 DATABASE_URL이 있으면 해당 값을 반환한다', () => {
   const config = getDatabaseConfig({
-    DATABASE_URL: 'postgresql://jamplay_app:change_me@localhost:5432/jamplay?schema=public',
+    DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/jamplay?schema=public',
   });
 
-  assert.equal(config.databaseUrl, 'postgresql://jamplay_app:change_me@localhost:5432/jamplay?schema=public');
+  assert.equal(config.databaseUrl, 'postgresql://postgres:postgres@localhost:5432/jamplay?schema=public');
 });
 
 test('DB 설정은 DATABASE_URL이 없으면 즉시 에러를 던진다', () => {

--- a/backend/src/database/prisma/seed-user-conflict.util.spec.ts
+++ b/backend/src/database/prisma/seed-user-conflict.util.spec.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+
+import test from 'node:test';
+
+import { getConflictingSeedUserIds } from './seed-user-conflict.util';
+
+test('시드 이메일과 같지만 ID가 다른 기존 사용자만 충돌 대상으로 고른다', () => {
+  const conflictingUserIds = getConflictingSeedUserIds({
+    seedUsers: [
+      {
+        id: 'seed-user-1',
+        email: 'minjun@jamplay.local',
+        status: 'ACTIVE',
+      },
+      {
+        id: 'seed-user-2',
+        email: 'seoyeon@jamplay.local',
+        status: 'ACTIVE',
+      },
+    ],
+    existingUsers: [
+      {
+        id: 'legacy-user-1',
+        email: 'minjun@jamplay.local',
+      },
+      {
+        id: 'seed-user-2',
+        email: 'seoyeon@jamplay.local',
+      },
+      {
+        id: 'another-user',
+        email: 'someone@jamplay.local',
+      },
+    ],
+  });
+
+  assert.deepEqual(conflictingUserIds, ['legacy-user-1']);
+});
+
+test('이메일이 없거나 시드 대상이 아닌 사용자는 충돌 대상에서 제외한다', () => {
+  const conflictingUserIds = getConflictingSeedUserIds({
+    seedUsers: [
+      {
+        id: 'seed-user-1',
+        email: 'minjun@jamplay.local',
+        status: 'ACTIVE',
+      },
+    ],
+    existingUsers: [
+      {
+        id: 'user-without-email',
+        email: null,
+      },
+      {
+        id: 'unrelated-user',
+        email: 'outside@jamplay.local',
+      },
+      {
+        id: 'seed-user-1',
+        email: 'minjun@jamplay.local',
+      },
+    ],
+  });
+
+  assert.deepEqual(conflictingUserIds, []);
+});

--- a/backend/src/database/prisma/seed-user-conflict.util.ts
+++ b/backend/src/database/prisma/seed-user-conflict.util.ts
@@ -1,0 +1,58 @@
+import type { UserStatus } from '../../generated/prisma';
+
+export interface SeedUserDefinition {
+  id: string;
+  email: string;
+  status: UserStatus;
+}
+
+export interface ExistingSeedUserCandidate {
+  id: string;
+  email: string | null;
+}
+
+interface SeedUserConflictResolutionInput {
+  seedUsers: readonly SeedUserDefinition[];
+  existingUsers: readonly ExistingSeedUserCandidate[];
+}
+
+/**
+ * 시드에 고정해 둔 이메일과 같은 값을 가진 기존 사용자 중에서
+ * 시드가 기대하는 ID와 다른 사용자만 골라낸다.
+ *
+ * 이렇게 분리해 두면 로컬 DB에 남아 있는 예전 더미 데이터와
+ * 현재 시드 데이터가 충돌할 때 어떤 레코드를 정리해야 하는지
+ * 명확하게 검증할 수 있다.
+ *
+ * @param {SeedUserConflictResolutionInput} input - 시드 사용자와 기존 사용자 목록
+ * @returns {string[]} 삭제 대상으로 판단된 기존 사용자 ID 목록
+ */
+export function getConflictingSeedUserIds(input: SeedUserConflictResolutionInput): string[] {
+  const seedUserIdByEmail = new Map<string, string>();
+
+  for (const seedUser of input.seedUsers) {
+    seedUserIdByEmail.set(seedUser.email, seedUser.id);
+  }
+
+  const conflictingUserIds: string[] = [];
+
+  for (const existingUser of input.existingUsers) {
+    if (existingUser.email === null) {
+      continue;
+    }
+
+    const expectedSeedUserId = seedUserIdByEmail.get(existingUser.email);
+
+    if (expectedSeedUserId === undefined) {
+      continue;
+    }
+
+    if (expectedSeedUserId === existingUser.id) {
+      continue;
+    }
+
+    conflictingUserIds.push(existingUser.id);
+  }
+
+  return conflictingUserIds;
+}

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist", "test", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "test", "prisma", "**/*.spec.ts"]
 }

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,4 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "rootDir": "./src"
+  },
   "exclude": ["node_modules", "dist", "test", "prisma", "**/*.spec.ts"]
 }

--- a/backend/tsconfig.eslint.json
+++ b/backend/tsconfig.eslint.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "prisma/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/generated/**"]
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,7 +9,7 @@
     "target": "ES2022",
     "sourceMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": ".",
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
@@ -18,6 +18,6 @@
     "moduleResolution": "node",
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "prisma/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,38 +16,12 @@ services:
       retries: 10
     networks:
       - jamplay_network
-  db-setup:
-    image: postgres:16.13
-    container_name: jamplay_db_setup
-    env_file:
-      - ./backend/.env.development
-    depends_on:
-      db:
-        condition: service_healthy
-    volumes:
-      - ./backend/prisma/sql/create-app-role.sql:/scripts/create-app-role.sql:ro
-    command: >
-      sh -c "
-      export PGPASSWORD=$${POSTGRES_PASSWORD} &&
-      psql
-      -h db
-      -p 5432
-      -U $${POSTGRES_USER}
-      -d $${POSTGRES_DB}
-      -v db_name=$${POSTGRES_DB}
-      -v db_app_user=$${DB_APP_USER}
-      -v db_app_password=$${DB_APP_PASSWORD}
-      -f /scripts/create-app-role.sql
-      "
-    restart: "no"
-    networks:
-      - jamplay_network
   backend:
     image: node:24
     container_name: jamplay_backend
     depends_on:
-      db-setup:
-        condition: service_completed_successfully
+      db:
+        condition: service_healthy
     env_file:
       - ./backend/.env.development
     ports:
@@ -58,7 +32,6 @@ services:
     working_dir: /app
     command: >
       sh -c "
-      export DATABASE_URL=postgresql://$${DB_APP_USER}:$${DB_APP_PASSWORD}@db:5432/$${POSTGRES_DB}?schema=public &&
       corepack enable &&
       pnpm install --force &&
       pnpm prisma:generate &&

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       corepack enable &&
       pnpm install --force &&
       pnpm prisma:generate &&
+      pnpm prisma:migrate:deploy &&
+      pnpm prisma:seed &&
       pnpm run start:dev
       "
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,9 +34,6 @@ services:
       sh -c "
       corepack enable &&
       pnpm install --force &&
-      pnpm prisma:generate &&
-      pnpm prisma:migrate:deploy &&
-      pnpm prisma:seed &&
       pnpm run start:dev
       "
     networks:


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 15분 ~ 20분

<br/>

## 📌 작업 요약

- Prisma ORM과 초기 DB 스키마를 구성했습니다.
- 로컬 개발환경에서 동일하게 실행할 수 있도록 migration, seed, 환경 설정 기준을 함께 정리했습니다.

<br/>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요 (이미지 첨부 가능)

1. `schema.prisma`에 현재 기획 기준의 핵심 도메인 테이블과 관계를 정의했습니다.
2. 초기 migration 파일을 생성해 로컬과 팀 개발환경에서 동일한 스키마를 재현할 수 있게 구성했습니다.
3. 로컬에서 바로 화면과 API를 확인할 수 있도록 Prisma seed 기반의 더미 데이터를 추가했습니다.
4. `nest-cli`를 적용하고 개발 서버 실행 방식을 `nest start --watch` 기준으로 정리했습니다.
5. 로컬 개발환경 세팅 순서는 아래 기준으로 맞췄습니다.

```bash
# 1. backend 루트에 환경 파일 준비
cp backend/.env.example backend/.env.development
cp backend/.env.example backend/.env

# 2. 프로젝트 루트에서 컨테이너 실행
docker compose up -d
```

`backend` 컨테이너는 앱 실행만 담당하도록 두었고, Prisma 관련 작업은 필요할 때만 수동으로 실행하도록 정리했습니다.

```bash
# Prisma Client 생성이 필요할 때
pnpm prisma:generate

# 로컬 DB 스키마를 schema.prisma 기준으로 맞출 때
pnpm prisma:push

# 로컬 더미 데이터가 필요할 때만
pnpm prisma:seed
```

즉, 컨테이너를 다시 띄울 때마다 migration이나 seed가 자동으로 실행되지는 않으며, 더미 데이터도 필요한 시점에만 명시적으로 넣는 방식으로 바꿨습니다.

6. 환경 파일은 아래 위치에 필요합니다.

```text
backend/.env.development
backend/.env
```

`.env.development`는 Docker Compose가 읽는 파일이고, `.env`는 Prisma CLI가 기본으로 읽는 파일입니다. 현재 Prisma 설정은 `prisma.config.ts`를 추가해서 관리하고 있으며, Prisma CLI 실행 시 `.env`, `.env.development`를 함께 읽도록 맞췄습니다.

7. 현재 기준으로 필요한 주요 환경 변수는 아래와 같습니다.

```env
BACKEND_PORT=3000
POSTGRES_USER=postgres
POSTGRES_PASSWORD=postgres
POSTGRES_DB=jamplay
POSTGRES_PORT=5432
DATABASE_URL="postgresql://postgres:postgres@localhost:5432/jamplay?schema=public"
```

로컬 개발환경은 DB 유저를 `postgres` 단일 계정으로 맞췄습니다. 앱 실행 계정과 migration 계정을 나누면 로컬에서는 `DATABASE_URL`을 계속 바꿔가며 작업해야 하고, 테이블 owner 차이로 migration 실패를 별도로 복구해야 하는 불편이 커서 개발 생산성이 떨어진다고 판단했습니다.

8. 로컬 Prisma 실행 기준은 아래처럼 정리했습니다.

```bash
# 스키마 검증
pnpm prisma:validate

# Prisma Client 재생성
pnpm prisma:generate

# 저장소에 있는 migration 반영
pnpm prisma:migrate:deploy

# schema 변경 후 새 migration 생성
pnpm prisma:migrate:dev --name <migration_name>

# 로컬 더미 데이터 적재
pnpm prisma:seed
```

현재 저장소에는 빈 migration 디렉터리가 남아 있어서 `migrate deploy`가 실패하는 문제가 있었고, 이번에 그 부분을 정리하면서 초기 migration 파일을 기준으로 다시 히스토리를 맞췄습니다. 이후 로컬 개발환경도 `db push`가 아니라 `migrate` 기준으로 관리하는 방향이 맞다고 판단했습니다.

추가한 seed 데이터는 `prisma/seed.ts`에서 관리하고, 고정 ID + `upsert` 기반으로 작성해 여러 번 실행해도 중복 데이터가 쌓이지 않도록 맞췄습니다. 또한 예전 더미 데이터가 남아 있어도 이메일 유니크 충돌 때문에 시드가 실패하지 않도록 충돌 정리 로직을 함께 넣었습니다.

9. `nest-cli`를 적용한 이유는 아래와 같습니다.

- 기존에는 `tsx` 기반으로 개발 서버를 실행하고 있었는데, Nest 표준 개발 실행 흐름과는 다르게 동작하고 있었습니다.
- 이 상태에서 Nest가 기대하는 데코레이터 메타데이터 처리와 Prisma generated client 경로가 개발 환경에서 안정적으로 맞지 않는 문제가 있었습니다.
- 특히 `dist` 기준으로 실행되는 파일과 Prisma generated 산출물 경로가 어긋나면 런타임에서 모듈을 찾지 못하는 문제가 발생할 수 있어서, Nest 표준 방식인 `nest start --watch`와 `nest-cli` 설정으로 정리했습니다.
- 결과적으로 개발 서버 실행 기준을 Nest 기본 흐름에 맞추고, generated asset 복사 경로도 함께 관리할 수 있게 했습니다.

<br/>

## 🚨 주요 고민 및 해결 과정

> 주요 고민이나 문제 해결 과정 공유

### 문제

- 로컬에서 앱 실행 계정과 migration 계정을 분리해 두면 `prisma migrate dev` 실행 시 권한과 owner 문제가 계속 생겼고, 이미 실패한 migration 상태를 정리하는 비용도 반복적으로 발생했습니다.
- 컨테이너 시작 시 migration과 seed를 자동 실행하면, 앱 재실행만 하고 싶을 때도 DB 상태가 함께 바뀌어서 개발 흐름이 불안정해졌습니다.

### 해결 과정

- 로컬 개발환경은 `postgres` 단일 계정으로 정리해 migration과 seed, 앱 실행이 모두 같은 기준으로 동작하도록 맞췄습니다.
- `docker compose up -d` 시 백엔드 컨테이너는 앱 실행만 담당하도록 바꾸고, `prisma generate`, `prisma push`, `prisma seed`는 필요 시 수동 실행하도록 분리했습니다.
- seed 데이터는 Prisma schema와 같은 코드베이스에서 관리할 수 있도록 `docker-entrypoint-initdb.d` 대신 `prisma/seed.ts`로 유지했습니다. 이렇게 해야 스키마 변경을 따라가기가 쉽고, 로컬 더미 데이터도 필요할 때만 통제해서 넣을 수 있다고 판단했습니다.
- 개발 서버는 `tsx` 대신 `nest start --watch`로 통일했습니다. 이렇게 해야 Nest가 기대하는 컴파일 흐름과 generated asset 처리 기준을 그대로 따라갈 수 있어서 런타임 오류를 줄일 수 있다고 판단했습니다.

<br/>

## 📑 참고 문서/ ADR

> 참고한 외부 문서, 레퍼런스, 기술 블로그, 공식 문서 등의 링크

- Prisma ORM 문서: https://www.prisma.io/docs/orm/overview/introduction
- Prisma Config Reference: https://www.prisma.io/docs/orm/reference/prisma-config-reference
- Nest CLI 문서: https://docs.nestjs.com/cli/overview

<br/>

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 로컬에서 `pnpm prisma:push`, `pnpm prisma:seed`를 수동 실행하는 흐름이 자연스러운지 확인해주세요.
- 시드 충돌 처리 로직이 과한지, 현재 로컬 개발 기준에서 적절한지 확인해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * 데이터베이스 인증 설정을 간소화했습니다.
  * 데모 데이터 자동 생성 기능을 추가했습니다.
  * 로컬 개발 환경 설정 및 빌드 프로세스를 최적화했습니다.
  * TypeScript 린팅 및 컴파일 구성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->