### PR TITLE
전역 타이포 토큰 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ node_modules
 .agents/
 .agent/
 .worktrees/
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,1 @@
-# jamplay-temp
-
-this is 합 주 서비스
-토끼야 안녕?
+# BandCo -  Band + Community

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jamplay-backend",
+  "name": "BandCo-backend",
   "version": "0.0.0",
   "private": true,
   "packageManager": "pnpm@10.15.0",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
@@ -15,7 +15,7 @@
       rel="stylesheet"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>jamplay</title>
+    <title>BandCo</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/app/layouts/RootLayout.tsx
+++ b/frontend/src/app/layouts/RootLayout.tsx
@@ -115,7 +115,7 @@ export const RootLayout = () => {
       ) : null}
       <main
         className={cn(
-          'mx-auto w-full max-w-90rem px-6 py-8',
+          'mx-auto w-full max-w-7xl px-6 py-8',
           pageHeaderProps ? 'pt-[calc(8rem+2rem)]' : undefined,
         )}
       >

--- a/frontend/src/app/router.test.tsx
+++ b/frontend/src/app/router.test.tsx
@@ -190,6 +190,23 @@ describe('앱 라우터', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('루트 경로의 본문 셸은 헤더와 동일한 최대 너비 클래스를 사용해야 한다', async () => {
+    const router = createRouterForTest('/', {
+      isLoggedIn: true,
+      isAdmin: false,
+    });
+
+    renderWithRouter(router);
+
+    expect(await screen.findByTestId('my-bands-page')).toBeInTheDocument();
+    expect(screen.getByRole('main')).toHaveClass(
+      'mx-auto',
+      'w-full',
+      'max-w-7xl',
+      'px-6',
+    );
+  });
+
   it('프로필 페이지에서는 우측 프로필 아바타를 렌더링하지 않는다', async () => {
     const profileRouter = createRouterForTest('/profile', {
       isLoggedIn: true,

--- a/frontend/src/entities/band/ui/BandCard.tsx
+++ b/frontend/src/entities/band/ui/BandCard.tsx
@@ -22,17 +22,17 @@ export const BandCard = ({ band }: BandCardProps) => {
 
       <div className="flex min-h-24 flex-col justify-between px-2 pb-1 pt-4">
         <div className="space-y-1 text-center">
-          <p className="text-lg-sb truncate">
+          <p className="typo-lg-sb truncate">
             {band.name}
           </p>
           {band.description ? (
-            <p className="text-sm-r line-clamp-1 text-muted">
+            <p className="typo-sm-r line-clamp-1 text-muted">
               {band.description}
             </p>
           ) : null}
         </div>
 
-        <div className="text-sm-m flex items-center justify-end gap-1.5 text-muted">
+        <div className="typo-sm-m flex items-center justify-end gap-1.5 text-muted">
           <SVGIcon icon="Member" size="sm" />
           <span>{band.memberCount ?? 0}명</span>
         </div>

--- a/frontend/src/entities/band/ui/BandCard.tsx
+++ b/frontend/src/entities/band/ui/BandCard.tsx
@@ -13,7 +13,7 @@ export const BandCard = ({ band }: BandCardProps) => {
     <button
       type="button"
       aria-label={`${band.name} 상세 보기`}
-      className="motion-lift flex w-full border border-muted/30 flex-col rounded-3xl bg-white p-3 shadow-xl/5"
+      className="motion-lift flex w-full flex-col rounded-3xl border border-muted/30 bg-card p-3 shadow-xl/5"
       onClick={() =>
         navigate({ to: '/band/$bandId', params: { bandId: band.id } })
       }
@@ -22,17 +22,17 @@ export const BandCard = ({ band }: BandCardProps) => {
 
       <div className="flex min-h-24 flex-col justify-between px-2 pb-1 pt-4">
         <div className="space-y-1 text-center">
-          <p className="truncate text-lg font-semibold tracking-tight">
+          <p className="text-lg-sb truncate">
             {band.name}
           </p>
           {band.description ? (
-            <p className="line-clamp-1 text-sm text-muted">
+            <p className="text-sm-r line-clamp-1 text-muted">
               {band.description}
             </p>
           ) : null}
         </div>
 
-        <div className="flex items-center justify-end gap-1.5 text-sm text-muted">
+        <div className="text-sm-m flex items-center justify-end gap-1.5 text-muted">
           <SVGIcon icon="Member" size="sm" />
           <span>{band.memberCount ?? 0}명</span>
         </div>

--- a/frontend/src/features/schedule-create/ui/ScheduleCreateModal.tsx
+++ b/frontend/src/features/schedule-create/ui/ScheduleCreateModal.tsx
@@ -88,9 +88,9 @@ export const ScheduleCreateModal = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[480px] p-0 overflow-hidden rounded-[32px] border-none shadow-2xl">
+      <DialogContent className="overflow-hidden border-none p-0 shadow-2xl sm:max-w-xl">
         <DialogHeader className="px-8 pt-8 pb-2">
-          <DialogTitle className="text-2xl font-bold text-gray-800 tracking-tight">
+          <DialogTitle className="text-2xl text-foreground">
             새 일정 추가
           </DialogTitle>
         </DialogHeader>

--- a/frontend/src/features/schedule-create/ui/atoms/DateInput.tsx
+++ b/frontend/src/features/schedule-create/ui/atoms/DateInput.tsx
@@ -14,7 +14,7 @@ export const DateInput = ({ value, onChange, label }: DateInputProps) => {
   return (
     <div className="flex flex-col gap-2">
       {label && (
-        <label htmlFor={id} className="text-sm-m text-foreground">
+        <label htmlFor={id} className="typo-sm-m text-foreground">
           {label}
         </label>
       )}

--- a/frontend/src/features/schedule-create/ui/atoms/DateInput.tsx
+++ b/frontend/src/features/schedule-create/ui/atoms/DateInput.tsx
@@ -14,7 +14,7 @@ export const DateInput = ({ value, onChange, label }: DateInputProps) => {
   return (
     <div className="flex flex-col gap-2">
       {label && (
-        <label htmlFor={id} className="text-sm font-medium text-gray-700">
+        <label htmlFor={id} className="text-sm-m text-foreground">
           {label}
         </label>
       )}
@@ -25,7 +25,7 @@ export const DateInput = ({ value, onChange, label }: DateInputProps) => {
           type="date"
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          className="h-12 pl-10 rounded-xl border-gray-200 focus:ring-primary/20"
+          className="h-12 rounded-2xl pl-10 focus:ring-ring/50"
         />
       </div>
     </div>

--- a/frontend/src/features/schedule-create/ui/atoms/PlaceSelect.tsx
+++ b/frontend/src/features/schedule-create/ui/atoms/PlaceSelect.tsx
@@ -20,7 +20,7 @@ export const PlaceSelect = ({ value, onChange, label }: PlaceSelectProps) => {
   return (
     <div className="flex flex-col gap-2">
       {label && (
-        <label htmlFor={id} className="text-sm-m text-foreground">
+        <label htmlFor={id} className="typo-sm-m text-foreground">
           {label}
         </label>
       )}
@@ -30,7 +30,7 @@ export const PlaceSelect = ({ value, onChange, label }: PlaceSelectProps) => {
           id={id}
           value={value || ''}
           onChange={(e) => onChange(e.target.value)}
-          className="text-sm-r h-12 w-full appearance-none rounded-2xl border border-border bg-input pl-10 pr-4 focus:outline-none focus:ring-2 focus:ring-ring/50"
+          className="typo-sm-r h-12 w-full appearance-none rounded-2xl border border-border bg-input pl-10 pr-4 focus:outline-none focus:ring-2 focus:ring-ring/50"
         >
           <option value="" disabled>
             장소 선택

--- a/frontend/src/features/schedule-create/ui/atoms/PlaceSelect.tsx
+++ b/frontend/src/features/schedule-create/ui/atoms/PlaceSelect.tsx
@@ -20,7 +20,7 @@ export const PlaceSelect = ({ value, onChange, label }: PlaceSelectProps) => {
   return (
     <div className="flex flex-col gap-2">
       {label && (
-        <label htmlFor={id} className="text-sm font-medium text-gray-700">
+        <label htmlFor={id} className="text-sm-m text-foreground">
           {label}
         </label>
       )}
@@ -30,7 +30,7 @@ export const PlaceSelect = ({ value, onChange, label }: PlaceSelectProps) => {
           id={id}
           value={value || ''}
           onChange={(e) => onChange(e.target.value)}
-          className="w-full h-12 pl-10 pr-4 rounded-xl border border-gray-200 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 appearance-none"
+          className="text-sm-r h-12 w-full appearance-none rounded-2xl border border-border bg-input pl-10 pr-4 focus:outline-none focus:ring-2 focus:ring-ring/50"
         >
           <option value="" disabled>
             장소 선택

--- a/frontend/src/features/schedule-create/ui/atoms/TimeRangeInput.tsx
+++ b/frontend/src/features/schedule-create/ui/atoms/TimeRangeInput.tsx
@@ -26,16 +26,16 @@ export const TimeRangeInput = ({
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex items-center gap-2 mt-2">
+      <div className="mt-2 flex items-center gap-2">
         <div className="flex flex-col gap-1 flex-1">
-          <label htmlFor={startId} className="text-sm font-medium text-gray-700">시작 시간</label>
+          <label htmlFor={startId} className="text-sm-m text-foreground">시작 시간</label>
           <div className="relative">
             <Clock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-primary pointer-events-none" />
             <select
               id={startId}
               value={startTime}
               onChange={(e) => onStartTimeChange(e.target.value)}
-              className="w-full h-12 pl-10 pr-4 rounded-xl border border-gray-200 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
+              className="text-sm-r h-12 w-full rounded-2xl border border-border bg-input pl-10 pr-4 focus:outline-none focus:ring-2 focus:ring-ring/50"
             >
               {timeOptions.map((time) => (
                 <option key={`start-${time}`} value={time}>
@@ -45,16 +45,16 @@ export const TimeRangeInput = ({
             </select>
           </div>
         </div>
-        <span className="text-gray-400 mt-6">~</span>
+        <span className="text-sm-m mt-6 text-muted">~</span>
         <div className="flex flex-col gap-1 flex-1">
-          <label htmlFor={endId} className="text-sm font-medium text-gray-700">종료 시간</label>
+          <label htmlFor={endId} className="text-sm-m text-foreground">종료 시간</label>
           <div className="relative">
             <Clock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-primary pointer-events-none" />
             <select
               id={endId}
               value={endTime}
               onChange={(e) => onEndTimeChange(e.target.value)}
-              className="w-full h-12 pl-10 pr-4 rounded-xl border border-gray-200 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
+              className="text-sm-r h-12 w-full rounded-2xl border border-border bg-input pl-10 pr-4 focus:outline-none focus:ring-2 focus:ring-ring/50"
             >
               {timeOptions.map((time) => (
                 <option key={`end-${time}`} value={time}>

--- a/frontend/src/features/schedule-create/ui/atoms/TimeRangeInput.tsx
+++ b/frontend/src/features/schedule-create/ui/atoms/TimeRangeInput.tsx
@@ -28,14 +28,14 @@ export const TimeRangeInput = ({
     <div className="flex flex-col gap-2">
       <div className="mt-2 flex items-center gap-2">
         <div className="flex flex-col gap-1 flex-1">
-          <label htmlFor={startId} className="text-sm-m text-foreground">시작 시간</label>
+          <label htmlFor={startId} className="typo-sm-m text-foreground">시작 시간</label>
           <div className="relative">
             <Clock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-primary pointer-events-none" />
             <select
               id={startId}
               value={startTime}
               onChange={(e) => onStartTimeChange(e.target.value)}
-              className="text-sm-r h-12 w-full rounded-2xl border border-border bg-input pl-10 pr-4 focus:outline-none focus:ring-2 focus:ring-ring/50"
+              className="typo-sm-r h-12 w-full rounded-2xl border border-border bg-input pl-10 pr-4 focus:outline-none focus:ring-2 focus:ring-ring/50"
             >
               {timeOptions.map((time) => (
                 <option key={`start-${time}`} value={time}>
@@ -45,16 +45,16 @@ export const TimeRangeInput = ({
             </select>
           </div>
         </div>
-        <span className="text-sm-m mt-6 text-muted">~</span>
+        <span className="typo-sm-m mt-6 text-muted">~</span>
         <div className="flex flex-col gap-1 flex-1">
-          <label htmlFor={endId} className="text-sm-m text-foreground">종료 시간</label>
+          <label htmlFor={endId} className="typo-sm-m text-foreground">종료 시간</label>
           <div className="relative">
             <Clock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-primary pointer-events-none" />
             <select
               id={endId}
               value={endTime}
               onChange={(e) => onEndTimeChange(e.target.value)}
-              className="text-sm-r h-12 w-full rounded-2xl border border-border bg-input pl-10 pr-4 focus:outline-none focus:ring-2 focus:ring-ring/50"
+              className="typo-sm-r h-12 w-full rounded-2xl border border-border bg-input pl-10 pr-4 focus:outline-none focus:ring-2 focus:ring-ring/50"
             >
               {timeOptions.map((time) => (
                 <option key={`end-${time}`} value={time}>

--- a/frontend/src/features/schedule-create/ui/steps/MeetingBasicStep.tsx
+++ b/frontend/src/features/schedule-create/ui/steps/MeetingBasicStep.tsx
@@ -23,13 +23,10 @@ export const MeetingBasicStep = ({
 
   return (
     <div className="flex flex-col gap-6 py-4">
-      <h2 className="text-xl font-bold text-gray-800">회의 기본 정보</h2>
+      <h2 className="text-xl-sb text-foreground">회의 기본 정보</h2>
       <div className="space-y-4">
         <div className="flex flex-col gap-2">
-          <label
-            htmlFor={titleId}
-            className="text-sm font-medium text-gray-700"
-          >
+          <label htmlFor={titleId} className="text-sm-m text-foreground">
             회의 제목
           </label>
           <Input
@@ -37,7 +34,7 @@ export const MeetingBasicStep = ({
             placeholder="회의 제목을 입력해주세요"
             value={data.title}
             onChange={(e) => onChange({ title: e.target.value })}
-            className="h-12 rounded-xl border-gray-200"
+            className="h-12 rounded-2xl"
           />
         </div>
 
@@ -55,7 +52,7 @@ export const MeetingBasicStep = ({
         />
 
         <div className="flex flex-col gap-2">
-          <label htmlFor={memoId} className="text-sm font-medium text-gray-700">
+          <label htmlFor={memoId} className="text-sm-m text-foreground">
             회의 메모 (선택)
           </label>
           <textarea
@@ -63,7 +60,7 @@ export const MeetingBasicStep = ({
             placeholder="회의 관련 메모를 입력해주세요"
             value={data.memo}
             onChange={(e) => onChange({ memo: e.target.value })}
-            className="flex min-h-[100px] w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            className="text-sm-r placeholder:text-muted flex min-h-24 w-full rounded-2xl border border-border bg-input px-3 py-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
           />
         </div>
       </div>
@@ -71,7 +68,7 @@ export const MeetingBasicStep = ({
       <Button
         onClick={onNext}
         disabled={isNextDisabled}
-        className="h-12 rounded-xl text-lg font-bold mt-4"
+        className="text-lg-b mt-4 h-12 rounded-2xl"
       >
         참여자 선택하러 가기
       </Button>

--- a/frontend/src/features/schedule-create/ui/steps/MeetingBasicStep.tsx
+++ b/frontend/src/features/schedule-create/ui/steps/MeetingBasicStep.tsx
@@ -23,10 +23,10 @@ export const MeetingBasicStep = ({
 
   return (
     <div className="flex flex-col gap-6 py-4">
-      <h2 className="text-xl-sb text-foreground">회의 기본 정보</h2>
+      <h2 className="typo-xl-sb text-foreground">회의 기본 정보</h2>
       <div className="space-y-4">
         <div className="flex flex-col gap-2">
-          <label htmlFor={titleId} className="text-sm-m text-foreground">
+          <label htmlFor={titleId} className="typo-sm-m text-foreground">
             회의 제목
           </label>
           <Input
@@ -52,7 +52,7 @@ export const MeetingBasicStep = ({
         />
 
         <div className="flex flex-col gap-2">
-          <label htmlFor={memoId} className="text-sm-m text-foreground">
+          <label htmlFor={memoId} className="typo-sm-m text-foreground">
             회의 메모 (선택)
           </label>
           <textarea
@@ -60,7 +60,7 @@ export const MeetingBasicStep = ({
             placeholder="회의 관련 메모를 입력해주세요"
             value={data.memo}
             onChange={(e) => onChange({ memo: e.target.value })}
-            className="text-sm-r placeholder:text-muted flex min-h-24 w-full rounded-2xl border border-border bg-input px-3 py-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            className="typo-sm-r placeholder:text-muted flex min-h-24 w-full rounded-2xl border border-border bg-input px-3 py-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
           />
         </div>
       </div>
@@ -68,7 +68,7 @@ export const MeetingBasicStep = ({
       <Button
         onClick={onNext}
         disabled={isNextDisabled}
-        className="text-lg-b mt-4 h-12 rounded-2xl"
+        className="typo-lg-b mt-4 h-12 rounded-2xl"
       >
         참여자 선택하러 가기
       </Button>

--- a/frontend/src/features/schedule-create/ui/steps/PracticeBasicStep.tsx
+++ b/frontend/src/features/schedule-create/ui/steps/PracticeBasicStep.tsx
@@ -20,7 +20,7 @@ export const PracticeBasicStep = ({
 
   return (
     <div className="flex flex-col gap-6 py-4">
-      <h2 className="text-xl font-bold text-gray-800">합주 연습 기본 정보</h2>
+      <h2 className="text-xl-sb text-foreground">합주 연습 기본 정보</h2>
       <div className="space-y-4">
         <DateInput
           label="날짜"
@@ -43,7 +43,7 @@ export const PracticeBasicStep = ({
       <Button
         onClick={onNext}
         disabled={isNextDisabled}
-        className="h-12 rounded-xl text-lg font-bold mt-4"
+        className="text-lg-b mt-4 h-12 rounded-2xl"
       >
         다음 단계로
       </Button>

--- a/frontend/src/features/schedule-create/ui/steps/PracticeBasicStep.tsx
+++ b/frontend/src/features/schedule-create/ui/steps/PracticeBasicStep.tsx
@@ -20,7 +20,7 @@ export const PracticeBasicStep = ({
 
   return (
     <div className="flex flex-col gap-6 py-4">
-      <h2 className="text-xl-sb text-foreground">합주 연습 기본 정보</h2>
+      <h2 className="typo-xl-sb text-foreground">합주 연습 기본 정보</h2>
       <div className="space-y-4">
         <DateInput
           label="날짜"
@@ -43,7 +43,7 @@ export const PracticeBasicStep = ({
       <Button
         onClick={onNext}
         disabled={isNextDisabled}
-        className="text-lg-b mt-4 h-12 rounded-2xl"
+        className="typo-lg-b mt-4 h-12 rounded-2xl"
       >
         다음 단계로
       </Button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -145,97 +145,97 @@
 }
 
 @layer utilities {
-  .text-3xl-b {
+  .typo-3xl-b {
     font-size: 2rem;
     line-height: 1.4;
     font-weight: 700;
   }
 
-  .text-2xl-b {
+  .typo-2xl-b {
     font-size: 1.75rem;
     line-height: 1.4;
     font-weight: 700;
   }
 
-  .text-xl-sb {
+  .typo-xl-sb {
     font-size: 1.5rem;
     line-height: 1.4;
     font-weight: 600;
   }
 
-  .text-lg-b {
+  .typo-lg-b {
     font-size: 1.125rem;
     line-height: 1.4;
     font-weight: 700;
   }
 
-  .text-lg-sb {
+  .typo-lg-sb {
     font-size: 1.125rem;
     line-height: 1.4;
     font-weight: 600;
   }
 
-  .text-base-b {
+  .typo-base-b {
     font-size: 1rem;
     line-height: 1.4;
     font-weight: 700;
   }
 
-  .text-base-sb {
+  .typo-base-sb {
     font-size: 1rem;
     line-height: 1.4;
     font-weight: 600;
   }
 
-  .text-base-m {
+  .typo-base-m {
     font-size: 1rem;
     line-height: 1.4;
     font-weight: 500;
   }
 
-  .text-base-r {
+  .typo-base-r {
     font-size: 1rem;
     line-height: 1.4;
     font-weight: 400;
   }
 
-  .text-sm-b {
+  .typo-sm-b {
     font-size: 0.875rem;
     line-height: 1.4;
     font-weight: 700;
   }
 
-  .text-sm-sb {
+  .typo-sm-sb {
     font-size: 0.875rem;
     line-height: 1.4;
     font-weight: 600;
   }
 
-  .text-sm-m {
+  .typo-sm-m {
     font-size: 0.875rem;
     line-height: 1.4;
     font-weight: 500;
   }
 
-  .text-sm-r {
+  .typo-sm-r {
     font-size: 0.875rem;
     line-height: 1.4;
     font-weight: 400;
   }
 
-  .text-xs-sb {
+  .typo-xs-sb {
     font-size: 0.75rem;
     line-height: 1.4;
     font-weight: 600;
   }
 
-  .text-xs-m {
+  .typo-xs-m {
     font-size: 0.75rem;
     line-height: 1.4;
     font-weight: 500;
   }
 
-  .text-xs-r {
+  .typo-xs-r {
     font-size: 0.75rem;
     line-height: 1.4;
     font-weight: 400;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -144,6 +144,104 @@
   }
 }
 
+@layer utilities {
+  .text-3xl-b {
+    font-size: 2rem;
+    line-height: 1.4;
+    font-weight: 700;
+  }
+
+  .text-2xl {
+    font-size: 1.75rem;
+    line-height: 1.4;
+    font-weight: 700;
+  }
+
+  .text-xl-sb {
+    font-size: 1.5rem;
+    line-height: 1.4;
+    font-weight: 600;
+  }
+
+  .text-lg-b {
+    font-size: 1.125rem;
+    line-height: 1.4;
+    font-weight: 700;
+  }
+
+  .text-lg-sb {
+    font-size: 1.125rem;
+    line-height: 1.4;
+    font-weight: 600;
+  }
+
+  .text-base-b {
+    font-size: 1rem;
+    line-height: 1.4;
+    font-weight: 700;
+  }
+
+  .text-base-sb {
+    font-size: 1rem;
+    line-height: 1.4;
+    font-weight: 600;
+  }
+
+  .text-base-m {
+    font-size: 1rem;
+    line-height: 1.4;
+    font-weight: 500;
+  }
+
+  .text-base-r {
+    font-size: 1rem;
+    line-height: 1.4;
+    font-weight: 400;
+  }
+
+  .text-sm-b {
+    font-size: 0.875rem;
+    line-height: 1.4;
+    font-weight: 700;
+  }
+
+  .text-sm-sb {
+    font-size: 0.875rem;
+    line-height: 1.4;
+    font-weight: 600;
+  }
+
+  .text-sm-m {
+    font-size: 0.875rem;
+    line-height: 1.4;
+    font-weight: 500;
+  }
+
+  .text-sm-r {
+    font-size: 0.875rem;
+    line-height: 1.4;
+    font-weight: 400;
+  }
+
+  .text-xs-sb {
+    font-size: 0.75rem;
+    line-height: 1.4;
+    font-weight: 600;
+  }
+
+  .text-xs-m {
+    font-size: 0.75rem;
+    line-height: 1.4;
+    font-weight: 500;
+  }
+
+  .text-xs-r {
+    font-size: 0.75rem;
+    line-height: 1.4;
+    font-weight: 400;
+  }
+}
+
 button {
   cursor: pointer;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -151,7 +151,7 @@
     font-weight: 700;
   }
 
-  .text-2xl {
+  .text-2xl-b {
     font-size: 1.75rem;
     line-height: 1.4;
     font-weight: 700;

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -5,7 +5,7 @@ export const Route = createFileRoute('/')({
   component: MyBandsRoutePage,
   staticData: {
     header: {
-      title: 'JamPlay',
+      title: 'BandCo',
       showBack: false,
       showSearchBar: true,
       showNotificationTrigger: true,

--- a/frontend/src/shared/ui/avatar.tsx
+++ b/frontend/src/shared/ui/avatar.tsx
@@ -45,7 +45,7 @@ function AvatarFallback({
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
       className={cn(
-        'text-sm-m group-data-[size=sm]/avatar:text-xs-m bg-muted text-muted-foreground flex size-full items-center justify-center rounded-full',
+        'typo-sm-m group-data-[size=sm]/avatar:typo-xs-m bg-muted text-muted-foreground flex size-full items-center justify-center rounded-full',
         className
       )}
       {...props}
@@ -90,7 +90,7 @@ function AvatarGroupCount({
     <div
       data-slot="avatar-group-count"
       className={cn(
-        'text-sm-m bg-muted text-muted-foreground ring-background relative flex size-8 shrink-0 items-center justify-center rounded-full ring-2 group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 group-has-data-[size=sm]/avatar-group:text-xs-m [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3',
+        'typo-sm-m bg-muted text-muted-foreground ring-background relative flex size-8 shrink-0 items-center justify-center rounded-full ring-2 group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 group-has-data-[size=sm]/avatar-group:typo-xs-m [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3',
         className
       )}
       {...props}

--- a/frontend/src/shared/ui/avatar.tsx
+++ b/frontend/src/shared/ui/avatar.tsx
@@ -45,7 +45,7 @@ function AvatarFallback({
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
       className={cn(
-        'bg-muted text-muted-foreground flex size-full items-center justify-center rounded-full text-sm group-data-[size=sm]/avatar:text-xs',
+        'text-sm-m group-data-[size=sm]/avatar:text-xs-m bg-muted text-muted-foreground flex size-full items-center justify-center rounded-full',
         className
       )}
       {...props}
@@ -90,7 +90,7 @@ function AvatarGroupCount({
     <div
       data-slot="avatar-group-count"
       className={cn(
-        'bg-muted text-muted-foreground ring-background relative flex size-8 shrink-0 items-center justify-center rounded-full text-sm ring-2 group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3',
+        'text-sm-m bg-muted text-muted-foreground ring-background relative flex size-8 shrink-0 items-center justify-center rounded-full ring-2 group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 group-has-data-[size=sm]/avatar-group:text-xs-m [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3',
         className
       )}
       {...props}

--- a/frontend/src/shared/ui/button/button-variants.ts
+++ b/frontend/src/shared/ui/button/button-variants.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const buttonVariants = cva(
-  'inline-flex shrink-0 items-center justify-center gap-2 rounded-full text-sm font-semibold transition-colors outline-none disabled:pointer-events-none disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+  'text-sm-sb inline-flex shrink-0 items-center justify-center gap-2 rounded-full transition-colors outline-none disabled:pointer-events-none disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
   {
   variants: {
     variant: {
@@ -13,8 +13,8 @@ export const buttonVariants = cva(
     },
     size: {
         default: 'h-11 px-4 py-2',
-        sm: 'h-9 px-3 text-xs',
-        lg: 'h-12 px-5 text-sm',
+        sm: 'text-xs-sb h-9 px-3',
+        lg: 'text-sm-sb h-12 px-5',
         icon: 'size-10',
     },
   },

--- a/frontend/src/shared/ui/button/button-variants.ts
+++ b/frontend/src/shared/ui/button/button-variants.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const buttonVariants = cva(
-  'text-sm-sb inline-flex shrink-0 items-center justify-center gap-2 rounded-full transition-colors outline-none disabled:pointer-events-none disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+  'typo-sm-sb inline-flex shrink-0 items-center justify-center gap-2 rounded-full transition-colors outline-none disabled:pointer-events-none disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
   {
   variants: {
     variant: {
@@ -13,8 +13,8 @@ export const buttonVariants = cva(
     },
     size: {
         default: 'h-11 px-4 py-2',
-        sm: 'text-xs-sb h-9 px-3',
-        lg: 'text-sm-sb h-12 px-5',
+        sm: 'typo-xs-sb h-9 px-3',
+        lg: 'typo-sm-sb h-12 px-5',
         icon: 'size-10',
     },
   },

--- a/frontend/src/shared/ui/dialog.tsx
+++ b/frontend/src/shared/ui/dialog.tsx
@@ -124,7 +124,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-2xl leading-none font-semibold", className)}
+      className={cn('text-2xl', className)}
       {...props}
     />
   );
@@ -137,7 +137,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-muted text-sm", className)}
+      className={cn('text-sm-r text-muted', className)}
       {...props}
     />
   );

--- a/frontend/src/shared/ui/dialog.tsx
+++ b/frontend/src/shared/ui/dialog.tsx
@@ -137,7 +137,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn('text-sm-r text-muted', className)}
+      className={cn('typo-sm-r text-muted', className)}
       {...props}
     />
   );

--- a/frontend/src/shared/ui/input.tsx
+++ b/frontend/src/shared/ui/input.tsx
@@ -31,7 +31,7 @@ function Input({ className, type, isSearchBar = false, ...props }: InputProps) {
       type={type}
       data-slot="input"
       className={cn(
-        'text-base-r file:text-sm-m file:text-foreground placeholder:text-muted selection:bg-primary selection:text-primary-foreground border-border w-full rounded-full border bg-input px-4 py-3 transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+        'text-base-r file:text-sm file:font-medium file:text-foreground placeholder:text-muted selection:bg-primary selection:text-primary-foreground border-border w-full rounded-full border bg-input px-4 py-3 transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
         'focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         isSearchBar && 'pl-11',

--- a/frontend/src/shared/ui/input.tsx
+++ b/frontend/src/shared/ui/input.tsx
@@ -31,7 +31,7 @@ function Input({ className, type, isSearchBar = false, ...props }: InputProps) {
       type={type}
       data-slot="input"
       className={cn(
-        'text-base-r file:text-sm file:font-medium file:text-foreground placeholder:text-muted selection:bg-primary selection:text-primary-foreground border-border w-full rounded-full border bg-input px-4 py-3 transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+        'typo-base-r file:text-sm file:font-medium file:text-foreground placeholder:text-muted selection:bg-primary selection:text-primary-foreground border-border w-full rounded-full border bg-input px-4 py-3 transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
         'focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         isSearchBar && 'pl-11',

--- a/frontend/src/shared/ui/input.tsx
+++ b/frontend/src/shared/ui/input.tsx
@@ -31,7 +31,7 @@ function Input({ className, type, isSearchBar = false, ...props }: InputProps) {
       type={type}
       data-slot="input"
       className={cn(
-        'file:text-foreground placeholder:text-muted selection:bg-primary selection:text-primary-foreground border-border w-full rounded-full border bg-input px-4 py-3 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'text-base-r file:text-sm-m file:text-foreground placeholder:text-muted selection:bg-primary selection:text-primary-foreground border-border w-full rounded-full border bg-input px-4 py-3 transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
         'focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         isSearchBar && 'pl-11',

--- a/frontend/src/shared/ui/sheet.tsx
+++ b/frontend/src/shared/ui/sheet.tsx
@@ -100,7 +100,7 @@ function SheetTitle({
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn('font-semibold text-foreground', className)}
+      className={cn('text-lg-sb text-foreground', className)}
       {...props}
     />
   );
@@ -113,7 +113,7 @@ function SheetDescription({
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
-      className={cn('text-sm text-muted-foreground', className)}
+      className={cn('text-sm-r text-muted', className)}
       {...props}
     />
   );

--- a/frontend/src/shared/ui/sheet.tsx
+++ b/frontend/src/shared/ui/sheet.tsx
@@ -100,7 +100,7 @@ function SheetTitle({
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn('text-lg-sb text-foreground', className)}
+      className={cn('typo-lg-sb text-foreground', className)}
       {...props}
     />
   );
@@ -113,7 +113,7 @@ function SheetDescription({
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
-      className={cn('text-sm-r text-muted', className)}
+      className={cn('typo-sm-r text-muted', className)}
       {...props}
     />
   );

--- a/frontend/src/shared/ui/status-badge.tsx
+++ b/frontend/src/shared/ui/status-badge.tsx
@@ -28,7 +28,7 @@ export const StatusBadge = ({
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold tracking-[0.02em]',
+        'text-xs-sb inline-flex items-center rounded-full border px-2.5 py-1',
         colorClassNames[color],
         className,
       )}

--- a/frontend/src/shared/ui/status-badge.tsx
+++ b/frontend/src/shared/ui/status-badge.tsx
@@ -28,7 +28,7 @@ export const StatusBadge = ({
   return (
     <span
       className={cn(
-        'text-xs-sb inline-flex items-center rounded-full border px-2.5 py-1',
+        'typo-xs-sb inline-flex items-center rounded-full border px-2.5 py-1',
         colorClassNames[color],
         className,
       )}

--- a/frontend/src/widgets/band-list/ui/BandCreateDialog.tsx
+++ b/frontend/src/widgets/band-list/ui/BandCreateDialog.tsx
@@ -72,7 +72,7 @@ export const BandCreateDialog = ({
 
         <div className="space-y-6 pt-4">
           <label htmlFor="band-name" className="flex flex-col gap-3">
-            <span className="text-lg font-semibold">밴드 이름</span>
+            <span className="text-lg-sb">밴드 이름</span>
             <Input
               id="band-name"
               value={form.name}
@@ -84,7 +84,7 @@ export const BandCreateDialog = ({
           </label>
 
           <label htmlFor="band-description" className="flex flex-col gap-3">
-            <span className="text-lg font-semibold">밴드 소개</span>
+            <span className="text-lg-sb">밴드 소개</span>
             <textarea
               id="band-description"
               value={form.description}
@@ -95,11 +95,11 @@ export const BandCreateDialog = ({
                 }))
               }
               placeholder="주 1회 합주하는 밴드입니다."
-              className="w-full rounded-xl border border-border bg-white p-4 outline-none transition focus-visible:ring-2 focus-visible:ring-ring/50"
+              className="text-base-r w-full rounded-2xl border border-border bg-input p-4 outline-none transition focus-visible:ring-2 focus-visible:ring-ring/50"
             />
           </label>
 
-          <label className="flex items-center gap-3 text-muted">
+          <label className="text-base-r flex items-center gap-3 text-muted">
             <Checkbox
               checked={form.visibility}
               onCheckedChange={(checked) =>
@@ -113,9 +113,9 @@ export const BandCreateDialog = ({
           </label>
 
           {fieldError ? (
-            <p className="text-sm text-destructive">{fieldError}</p>
+            <p className="text-sm-r text-destructive">{fieldError}</p>
           ) : null}
-          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          {error ? <p className="text-sm-r text-destructive">{error}</p> : null}
         </div>
 
         <DialogFooter className="sm:justify-end">

--- a/frontend/src/widgets/band-list/ui/BandCreateDialog.tsx
+++ b/frontend/src/widgets/band-list/ui/BandCreateDialog.tsx
@@ -72,7 +72,7 @@ export const BandCreateDialog = ({
 
         <div className="space-y-6 pt-4">
           <label htmlFor="band-name" className="flex flex-col gap-3">
-            <span className="text-lg-sb">밴드 이름</span>
+            <span className="typo-lg-sb">밴드 이름</span>
             <Input
               id="band-name"
               value={form.name}
@@ -84,7 +84,7 @@ export const BandCreateDialog = ({
           </label>
 
           <label htmlFor="band-description" className="flex flex-col gap-3">
-            <span className="text-lg-sb">밴드 소개</span>
+            <span className="typo-lg-sb">밴드 소개</span>
             <textarea
               id="band-description"
               value={form.description}
@@ -95,11 +95,11 @@ export const BandCreateDialog = ({
                 }))
               }
               placeholder="주 1회 합주하는 밴드입니다."
-              className="text-base-r w-full rounded-2xl border border-border bg-input p-4 outline-none transition focus-visible:ring-2 focus-visible:ring-ring/50"
+              className="typo-base-r w-full rounded-2xl border border-border bg-input p-4 outline-none transition focus-visible:ring-2 focus-visible:ring-ring/50"
             />
           </label>
 
-          <label className="text-base-r flex items-center gap-3 text-muted">
+          <label className="typo-base-r flex items-center gap-3 text-muted">
             <Checkbox
               checked={form.visibility}
               onCheckedChange={(checked) =>
@@ -113,9 +113,9 @@ export const BandCreateDialog = ({
           </label>
 
           {fieldError ? (
-            <p className="text-sm-r text-destructive">{fieldError}</p>
+            <p className="typo-sm-r text-destructive">{fieldError}</p>
           ) : null}
-          {error ? <p className="text-sm-r text-destructive">{error}</p> : null}
+          {error ? <p className="typo-sm-r text-destructive">{error}</p> : null}
         </div>
 
         <DialogFooter className="sm:justify-end">

--- a/frontend/src/widgets/band-list/ui/BandList.tsx
+++ b/frontend/src/widgets/band-list/ui/BandList.tsx
@@ -20,7 +20,7 @@ export const BandList = () => {
     <section data-testid="band-list" className="space-y-7">
       <div className="flex items-start justify-between gap-6">
         <div className="space-y-5">
-          <h2 className="text-3xl-b">밴드</h2>
+          <h2 className="typo-3xl-b">밴드</h2>
 
           <div className="flex flex-wrap items-center gap-3">
             <Button
@@ -45,7 +45,7 @@ export const BandList = () => {
         <Button
           type="button"
           variant="ghost"
-          className="text-sm-m gap-2 px-0 text-muted hover:text-foreground"
+          className="typo-sm-m gap-2 px-0 text-muted hover:text-foreground"
         >
           <span>목록 편집</span>
           <SVGIcon icon="Setting" size="sm" />

--- a/frontend/src/widgets/band-list/ui/BandList.tsx
+++ b/frontend/src/widgets/band-list/ui/BandList.tsx
@@ -20,7 +20,7 @@ export const BandList = () => {
     <section data-testid="band-list" className="space-y-7">
       <div className="flex items-start justify-between gap-6">
         <div className="space-y-5">
-          <h2 className="text-3xl font-semibold tracking-tight">밴드</h2>
+          <h2 className="text-3xl-b">밴드</h2>
 
           <div className="flex flex-wrap items-center gap-3">
             <Button
@@ -45,7 +45,7 @@ export const BandList = () => {
         <Button
           type="button"
           variant="ghost"
-          className="gap-2 px-0 text-sm font-medium text-muted hover:text-foreground"
+          className="text-sm-m gap-2 px-0 text-muted hover:text-foreground"
         >
           <span>목록 편집</span>
           <SVGIcon icon="Setting" size="sm" />

--- a/frontend/src/widgets/band-list/ui/InviteCodeDialog.tsx
+++ b/frontend/src/widgets/band-list/ui/InviteCodeDialog.tsx
@@ -31,11 +31,13 @@ export const InviteCodeDialog = ({
           </DialogDescription>
         </DialogHeader>
 
-        <Input
-          value={inviteCode}
-          onChange={(event) => setInviteCode(event.target.value)}
-          placeholder="초대 코드를 입력하세요"
-        />
+        <div className="pt-4">
+          <Input
+            value={inviteCode}
+            onChange={(event) => setInviteCode(event.target.value)}
+            placeholder="초대 코드를 입력하세요"
+          />
+        </div>
 
         <DialogFooter className="sm:justify-end">
           <Button

--- a/frontend/src/widgets/page-header/index.ts
+++ b/frontend/src/widgets/page-header/index.ts
@@ -4,8 +4,8 @@ export type { PageHeaderProps } from './page-header';
 export { resolveHeader } from './resolve-header';
 export type {
   HeaderResolveContext,
+  HeaderTab,
   HeaderResolveResult,
   HeaderStaticConfig,
-  HeaderTab,
   RouteStaticData,
 } from './types';

--- a/frontend/src/widgets/page-header/page-header.test.tsx
+++ b/frontend/src/widgets/page-header/page-header.test.tsx
@@ -46,7 +46,7 @@ describe('PageHeader', () => {
   });
 
   it('모든 페이지에서 공통 헤더 셸은 전역 본문 셸과 동일한 최대 너비 클래스를 사용해야 한다', () => {
-    render(<PageHeader title="JamPlay" />);
+    render(<PageHeader title="BandCo" />);
 
     expect(screen.getByRole('banner').firstElementChild).toHaveClass(
       'mx-auto',
@@ -56,10 +56,10 @@ describe('PageHeader', () => {
     );
   });
 
-  it('JamPlay 타이틀은 모바일에서 숨김 클래스를 가져야 한다', () => {
-    render(<PageHeader title="JamPlay" />);
+  it('타이틀은 모바일에서 숨김 클래스를 가져야 한다', () => {
+    render(<PageHeader title="BandCo" />);
 
-    expect(screen.getByRole('heading', { name: 'JamPlay' })).toHaveClass(
+    expect(screen.getByRole('heading', { name: 'BandCo' })).toHaveClass(
       'hidden',
       'sm:block',
     );

--- a/frontend/src/widgets/page-header/page-header.test.tsx
+++ b/frontend/src/widgets/page-header/page-header.test.tsx
@@ -44,4 +44,24 @@ describe('PageHeader', () => {
     expect(onTabClick).toHaveBeenCalledTimes(1);
     expect(onRightActionClick).toHaveBeenCalledTimes(1);
   });
+
+  it('모든 페이지에서 공통 헤더 셸은 전역 본문 셸과 동일한 최대 너비 클래스를 사용해야 한다', () => {
+    render(<PageHeader title="JamPlay" />);
+
+    expect(screen.getByRole('banner').firstElementChild).toHaveClass(
+      'mx-auto',
+      'w-full',
+      'max-w-7xl',
+      'px-6',
+    );
+  });
+
+  it('JamPlay 타이틀은 모바일에서 숨김 클래스를 가져야 한다', () => {
+    render(<PageHeader title="JamPlay" />);
+
+    expect(screen.getByRole('heading', { name: 'JamPlay' })).toHaveClass(
+      'hidden',
+      'sm:block',
+    );
+  });
 });

--- a/frontend/src/widgets/page-header/page-header.tsx
+++ b/frontend/src/widgets/page-header/page-header.tsx
@@ -69,8 +69,8 @@ export const PageHeader = ({
                 ) : null}
                 <h1
                   className={cn(
-                    'text-2xl truncate',
-                    title === 'JamPlay' ? 'sr-only sm:not-sr-only' : undefined,
+                    'text-2xl-b truncate',
+                    title === 'BandCo' ? 'sr-only sm:not-sr-only' : undefined,
                   )}
                 >
                   {title}

--- a/frontend/src/widgets/page-header/page-header.tsx
+++ b/frontend/src/widgets/page-header/page-header.tsx
@@ -41,8 +41,8 @@ export const PageHeader = ({
         className,
       )}
     >
-      <div className="mx-auto grid min-h-24 w-full max-w-7xl grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-6 px-6">
-        <div className="min-w-0 flex items-center gap-5">
+      <div className="mx-auto grid min-h-24 w-full max-w-7xl grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-4 px-6 sm:gap-5">
+        <div className="min-w-0 flex items-center gap-3 sm:gap-4">
           {!showBack ? (
             <span
               aria-hidden="true"
@@ -51,7 +51,7 @@ export const PageHeader = ({
           ) : null}
 
           <div className="min-w-0">
-            <div className="flex items-center gap-4">
+            <div className="flex items-center gap-3 sm:gap-4">
               {showBack ? (
                 <BackButton
                   label="뒤로"
@@ -67,7 +67,12 @@ export const PageHeader = ({
                     {brandLabel}
                   </p>
                 ) : null}
-                <h1 className="truncate text-2xl font-semibold leading-tight tracking-tight">
+                <h1
+                  className={cn(
+                    'truncate text-2xl font-semibold leading-tight tracking-tight',
+                    title === 'JamPlay' ? 'hidden sm:block' : undefined,
+                  )}
+                >
                   {title}
                 </h1>
                 {subtitle ? (

--- a/frontend/src/widgets/page-header/page-header.tsx
+++ b/frontend/src/widgets/page-header/page-header.tsx
@@ -56,27 +56,27 @@ export const PageHeader = ({
                 <BackButton
                   label="뒤로"
                   variant="ghost"
-                  className="text-sm-sb"
+                  className="typo-sm-sb"
                   onClick={onBack}
                 />
               ) : null}
 
               <div className="min-w-0">
                 {brandLabel ? (
-                  <p className="mb-1 text-xs-sb text-muted">
+                  <p className="mb-1 typo-xs-sb text-muted">
                     {brandLabel}
                   </p>
                 ) : null}
                 <h1
                   className={cn(
-                    'text-2xl-b truncate',
+                    'typo-2xl-b truncate',
                     title === 'BandCo' ? 'sr-only sm:not-sr-only' : undefined,
                   )}
                 >
                   {title}
                 </h1>
                 {subtitle ? (
-                  <p className="text-base-r mt-1 text-muted">
+                  <p className="typo-base-r mt-1 text-muted">
                     {subtitle}
                   </p>
                 ) : null}
@@ -84,7 +84,7 @@ export const PageHeader = ({
             </div>
 
             {meta && meta.length > 0 ? (
-              <div className="text-sm-m mt-4 flex flex-wrap items-center gap-4 text-muted">
+              <div className="typo-sm-m mt-4 flex flex-wrap items-center gap-4 text-muted">
                 {meta.map((item) => (
                   <span key={item}>{item}</span>
                 ))}
@@ -104,7 +104,7 @@ export const PageHeader = ({
                   type="button"
                   variant={tab.active ? 'default' : 'outline'}
                   className={cn(
-                    'text-sm-sb h-9 rounded-lg px-4',
+                    'typo-sm-sb h-9 rounded-lg px-4',
                     tab.active
                       ? 'border-foreground bg-foreground text-background'
                       : 'bg-transparent text-foreground hover:bg-muted',
@@ -121,7 +121,7 @@ export const PageHeader = ({
             <Button
               type="button"
               variant="outline"
-              className="text-sm-sb h-9 rounded-lg border border-border px-4"
+              className="typo-sm-sb h-9 rounded-lg border border-border px-4"
               onClick={onRightActionClick}
             >
               {rightActionLabel}

--- a/frontend/src/widgets/page-header/page-header.tsx
+++ b/frontend/src/widgets/page-header/page-header.tsx
@@ -37,7 +37,7 @@ export const PageHeader = ({
   return (
     <header
       className={cn(
-        'fixed inset-x-0 top-0 z-40 bg-white/72 shadow-xl/5 backdrop-blur-xl',
+        'fixed inset-x-0 top-0 z-40 bg-background/72 shadow-xl/5 backdrop-blur-xl',
         className,
       )}
     >
@@ -56,27 +56,27 @@ export const PageHeader = ({
                 <BackButton
                   label="뒤로"
                   variant="ghost"
-                  className="text-sm"
+                  className="text-sm-sb"
                   onClick={onBack}
                 />
               ) : null}
 
               <div className="min-w-0">
                 {brandLabel ? (
-                  <p className="mb-1 text-sm font-medium text-muted-foreground">
+                  <p className="mb-1 text-xs-sb text-muted">
                     {brandLabel}
                   </p>
                 ) : null}
                 <h1
                   className={cn(
-                    'truncate text-2xl font-semibold leading-tight tracking-tight',
+                    'text-2xl truncate',
                     title === 'JamPlay' ? 'hidden sm:block' : undefined,
                   )}
                 >
                   {title}
                 </h1>
                 {subtitle ? (
-                  <p className="mt-1 text-base text-muted-foreground">
+                  <p className="text-base-r mt-1 text-muted">
                     {subtitle}
                   </p>
                 ) : null}
@@ -84,7 +84,7 @@ export const PageHeader = ({
             </div>
 
             {meta && meta.length > 0 ? (
-              <div className="mt-4 flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+              <div className="text-sm-m mt-4 flex flex-wrap items-center gap-4 text-muted">
                 {meta.map((item) => (
                   <span key={item}>{item}</span>
                 ))}
@@ -104,7 +104,7 @@ export const PageHeader = ({
                   type="button"
                   variant={tab.active ? 'default' : 'outline'}
                   className={cn(
-                    'h-9 rounded-lg px-4 text-sm font-semibold',
+                    'text-sm-sb h-9 rounded-lg px-4',
                     tab.active
                       ? 'border-foreground bg-foreground text-background'
                       : 'bg-transparent text-foreground hover:bg-muted',
@@ -121,7 +121,7 @@ export const PageHeader = ({
             <Button
               type="button"
               variant="outline"
-              className="h-9 rounded-lg border border-border px-4 text-sm font-semibold"
+              className="text-sm-sb h-9 rounded-lg border border-border px-4"
               onClick={onRightActionClick}
             >
               {rightActionLabel}

--- a/frontend/src/widgets/page-header/page-header.tsx
+++ b/frontend/src/widgets/page-header/page-header.tsx
@@ -70,7 +70,7 @@ export const PageHeader = ({
                 <h1
                   className={cn(
                     'text-2xl truncate',
-                    title === 'JamPlay' ? 'hidden sm:block' : undefined,
+                    title === 'JamPlay' ? 'sr-only sm:not-sr-only' : undefined,
                   )}
                 >
                   {title}

--- a/frontend/src/widgets/weekly-calendar/ui/ScheduleCard.tsx
+++ b/frontend/src/widgets/weekly-calendar/ui/ScheduleCard.tsx
@@ -82,19 +82,19 @@ export const ScheduleCard = ({
         } ${isContinued ? 'opacity-90 border-dashed' : ''}`}
       >
         {!isContinued ? (
-          <div className="text-xs-sb truncate leading-tight group-hover/card:whitespace-normal">
+          <div className="typo-xs-sb truncate leading-tight group-hover/card:whitespace-normal">
             {schedule.ui.cardTitle}
           </div>
         ) : (
-          <div className="text-xs-r leading-tight italic opacity-70">
+          <div className="typo-xs-r leading-tight italic opacity-70">
             (계속)
           </div>
         )}
-        <div className="text-xs-m truncate leading-tight opacity-80 group-hover/card:whitespace-normal">
+        <div className="typo-xs-m truncate leading-tight opacity-80 group-hover/card:whitespace-normal">
           {getTimeDisplay()}
         </div>
 
-        <div className="text-xs-r mt-1 hidden flex-col gap-1 border-t border-current pt-1 opacity-70 group-hover/card:flex">
+        <div className="typo-xs-r mt-1 hidden flex-col gap-1 border-t border-current pt-1 opacity-70 group-hover/card:flex">
           {schedule.place?.name && (
             <p className="truncate">📍 {schedule.place.name}</p>
           )}

--- a/frontend/src/widgets/weekly-calendar/ui/ScheduleCard.tsx
+++ b/frontend/src/widgets/weekly-calendar/ui/ScheduleCard.tsx
@@ -8,8 +8,8 @@ interface ScheduleCardProps {
 }
 
 const THEMES: Record<string, string> = {
-  PRACTICE: 'bg-secondary-surface text-primary-main border-primary-light',
-  MEETING: 'bg-success-surface text-secondary-main border-secondary-light',
+  PRACTICE: 'border-primary-light bg-secondary-surface text-foreground',
+  MEETING: 'border-success bg-success-surface text-foreground',
 };
 
 export const ScheduleCard = ({
@@ -63,7 +63,7 @@ export const ScheduleCard = ({
 
   return (
     <div
-      className="absolute rounded-[4px] cursor-pointer z-[1] hover:z-50 group/card transition-all duration-200 ease-in-out"
+      className="group/card absolute z-[1] cursor-pointer transition-all duration-200 ease-in-out hover:z-50"
       style={{
         top: `${top}px`,
         height: `${height}px`,
@@ -76,26 +76,25 @@ export const ScheduleCard = ({
       }}
     >
       <div
-        className={`border-t-accent border-t border-b border-b-accent w-full h-full min-h-[inherit] px-2 py-1.5 rounded-[4px] shadow-sm flex flex-col gap-0.5 transition-all duration-300 group-hover/card:min-w-[180px] group-hover/card:min-h-[max(100%,100px)] group-hover/card:h-fit group-hover/card:shadow-2xl  ${
+        className={`flex h-full min-h-[inherit] w-full flex-col gap-0.5 border-y px-2 py-1.5 shadow-sm transition-all duration-300 group-hover/card:h-fit group-hover/card:min-h-[max(100%,100px)] group-hover/card:min-w-[180px] group-hover/card:shadow-2xl ${
           THEMES[schedule.scheduleType] ||
-          'bg-gray-100 text-gray-700 border-gray-300'
+          'border-border bg-muted text-foreground'
         } ${isContinued ? 'opacity-90 border-dashed' : ''}`}
       >
         {!isContinued ? (
-          <div className="text-[11px] font-bold leading-tight truncate group-hover/card:whitespace-normal">
+          <div className="text-xs-sb truncate leading-tight group-hover/card:whitespace-normal">
             {schedule.ui.cardTitle}
           </div>
         ) : (
-          <div className="text-[10px] italic opacity-70 leading-tight">
+          <div className="text-xs-r leading-tight italic opacity-70">
             (계속)
           </div>
         )}
-        <div className="text-[10px] opacity-80 font-medium leading-tight truncate group-hover/card:whitespace-normal">
+        <div className="text-xs-m truncate leading-tight opacity-80 group-hover/card:whitespace-normal">
           {getTimeDisplay()}
         </div>
 
-        {/* 추가 정보 (호버 시에만 명확히 노출) */}
-        <div className="hidden group-hover/card:flex flex-col gap-1 text-[9px] mt-1 opacity-70 border-t border-current pt-1">
+        <div className="text-xs-r mt-1 hidden flex-col gap-1 border-t border-current pt-1 opacity-70 group-hover/card:flex">
           {schedule.place?.name && (
             <p className="truncate">📍 {schedule.place.name}</p>
           )}
@@ -108,7 +107,7 @@ export const ScheduleCard = ({
             <p>👥 참여자 {schedule.meeting.participantCount}명</p>
           )}
           {schedule.memo && (
-            <p className="italic mt-0.5 opacity-60">" {schedule.memo} "</p>
+            <p className="mt-0.5 italic opacity-60">" {schedule.memo} "</p>
           )}
         </div>
       </div>

--- a/frontend/src/widgets/weekly-calendar/ui/WeeklyCalendar.tsx
+++ b/frontend/src/widgets/weekly-calendar/ui/WeeklyCalendar.tsx
@@ -42,7 +42,7 @@ export const WeeklyCalendar = () => {
   };
 
   return (
-    <div className="flex flex-col w-full h-full">
+    <div className="flex h-full w-full flex-col">
       <WeeklyCalendarHeader
         currentDate={currentDate}
         onPrev={handlePrevWeek}
@@ -52,8 +52,8 @@ export const WeeklyCalendar = () => {
       />
       <div className="relative flex-1 overflow-hidden">
         {isLoading && (
-          <div className="absolute inset-0 bg-white/50 z-20 flex items-center justify-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-main" />
+          <div className="absolute inset-0 z-20 flex items-center justify-center bg-background/50">
+            <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
           </div>
         )}
         <WeeklyTimeGrid

--- a/frontend/src/widgets/weekly-calendar/ui/WeeklyCalendarHeader.tsx
+++ b/frontend/src/widgets/weekly-calendar/ui/WeeklyCalendarHeader.tsx
@@ -25,50 +25,50 @@ export const WeeklyCalendarHeader = ({
   const weekRangeText = formatWeekRange(startOfWeek, endOfWeek);
 
   return (
-    <div className="flex items-center justify-between px-6 py-4 bg-inherit border-b border-gray-100">
+    <div className="flex items-center justify-between border-b border-border bg-inherit px-6 py-4">
       <div className="flex items-center gap-6">
-        {/* 달력 아이콘 */}
-        <div
-          className="flex items-center justify-center cursor-pointer hover:bg-gray-200 rounded p-1 transition-colors"
+        <button
+          type="button"
+          className="rounded-md p-1 transition-colors hover:bg-muted"
           onClick={onToday}
           title="오늘로 이동"
         >
           <IconMap.Calendar width={24} height={24} className="" />
-        </div>
+        </button>
 
-        {/* 날짜 네비게이션 */}
-        <div className="flex items-center gap-3 w-90 justify-between">
+        <div className="flex w-full max-w-sm items-center justify-between gap-3">
           <Button
             onClick={onPrev}
             size={'icon'}
+            variant="outline"
             aria-label="이전 주"
-            className="w-9 h-8 bg-white  border-gray-200 rounded-[8px] hover:bg-gray-50 "
+            className="size-9 rounded-md bg-background hover:bg-muted"
           >
-            <ChevronLeft size={16} className="stroke-primary-light " />
+            <ChevronLeft size={16} className="stroke-primary-light" />
           </Button>
 
-          <h2 className="text-[17px] font-bold text-gray-800 tracking-tight min-w-37.5 text-center">
+          <h2 className="text-lg-b min-w-0 flex-1 text-center text-foreground">
             {weekRangeText}
           </h2>
 
           <Button
             onClick={onNext}
             size={'icon'}
+            variant="outline"
             aria-label="다음 주"
-            className="w-9 h-8 bg-white border-gray-200 rounded-[8px] hover:bg-gray-50 "
+            className="size-9 rounded-md bg-background hover:bg-muted"
           >
             <ChevronRight size={16} className="stroke-primary-light" />
           </Button>
         </div>
       </div>
 
-      {/* 일정 추가 버튼 */}
-      <button
+      <Button
         onClick={onAddClick}
-        className="flex items-center gap-1.5 px-4 py-2 bg-accent border border-accent-surface hover:bg-[#b83c3c] text-secondary rounded-full transition-colors shadow-sm"
+        className="bg-accent text-secondary hover:bg-accent-light"
       >
         일정 <IconMap.Add width={14} height={14} className="text-secondary" />
-      </button>
+      </Button>
     </div>
   );
 };

--- a/frontend/src/widgets/weekly-calendar/ui/WeeklyCalendarHeader.tsx
+++ b/frontend/src/widgets/weekly-calendar/ui/WeeklyCalendarHeader.tsx
@@ -47,7 +47,7 @@ export const WeeklyCalendarHeader = ({
             <ChevronLeft size={16} className="stroke-primary-light" />
           </Button>
 
-          <h2 className="text-lg-b min-w-0 flex-1 text-center text-foreground">
+          <h2 className="typo-lg-b min-w-0 flex-1 text-center text-foreground">
             {weekRangeText}
           </h2>
 

--- a/frontend/src/widgets/weekly-calendar/ui/WeeklyTimeGrid.tsx
+++ b/frontend/src/widgets/weekly-calendar/ui/WeeklyTimeGrid.tsx
@@ -125,7 +125,7 @@ export const WeeklyTimeGrid = ({
               key={index}
               className="flex w-full flex-col items-center justify-center gap-1 border-r border-border text-center last:border-r-0"
             >
-              <div className="text-sm-r text-muted">
+              <div className="typo-sm-r text-muted">
                 {
                   ['월', '화', '수', '목', '금', '토', '일'][
                     day.getDay() === 0 ? 6 : day.getDay() - 1
@@ -133,7 +133,7 @@ export const WeeklyTimeGrid = ({
                 }
               </div>
               <div
-                className={`text-sm-sb flex h-5 w-8 items-center justify-center rounded-full transition-colors ${
+                className={`typo-sm-sb flex h-5 w-8 items-center justify-center rounded-full transition-colors ${
                   isToday
                     ? 'bg-primary text-secondary-surface'
                     : 'text-foreground'
@@ -173,7 +173,7 @@ export const WeeklyTimeGrid = ({
                   {minutes.map((minute) => (
                     <div
                       key={`${hour}-${minute}`}
-                      className="text-xs-r absolute w-full pr-2 text-right"
+                      className="typo-xs-r absolute w-full pr-2 text-right"
                       style={{
                         top: minute === 0 ? '4px' : `${(minute / 60) * 100}%`,
                         opacity: minute === 0 ? 1 : 0.6,

--- a/frontend/src/widgets/weekly-calendar/ui/WeeklyTimeGrid.tsx
+++ b/frontend/src/widgets/weekly-calendar/ui/WeeklyTimeGrid.tsx
@@ -113,21 +113,19 @@ export const WeeklyTimeGrid = ({
 
   return (
     <div
-      className="flex flex-col flex-1 overflow-hidden rounded-[8px] shadow-xl/5"
+      className="flex flex-1 flex-col overflow-hidden shadow-xl/5"
       style={style}
     >
-      {/* Header: 요일 및 날짜 */}
-      <div className="grid grid-cols-[64px_repeat(7,minmax(0,1fr))] border-b border-gray-100 bg-[#FFFFFF66] sticky top-0 z-10 h-12.5">
-        {/* 좌상단 빈칸 */}
-        <div className="border-r border-gray-100"></div>
+      <div className="sticky top-0 z-10 grid h-12.5 grid-cols-[64px_repeat(7,minmax(0,1fr))] border-b border-border bg-background/40">
+        <div className="border-r border-border"></div>
         {weekDays.map((day, index) => {
           const isToday = day.toDateString() === new Date().toDateString();
           return (
             <div
               key={index}
-              className=" text-center border-r border-gray-100 last:border-r-0 flex flex-col items-center gap-1 justify-center w-full"
+              className="flex w-full flex-col items-center justify-center gap-1 border-r border-border text-center last:border-r-0"
             >
-              <div className="font-normal text-sm text-gray-400">
+              <div className="text-sm-r text-muted">
                 {
                   ['월', '화', '수', '목', '금', '토', '일'][
                     day.getDay() === 0 ? 6 : day.getDay() - 1
@@ -135,10 +133,10 @@ export const WeeklyTimeGrid = ({
                 }
               </div>
               <div
-                className={`w-8 h-5 flex items-center justify-center rounded-full transition-colors text-sm font-semibold ${
+                className={`text-sm-sb flex h-5 w-8 items-center justify-center rounded-full transition-colors ${
                   isToday
                     ? 'bg-primary text-secondary-surface'
-                    : 'text-gray-700'
+                    : 'text-foreground'
                 }`}
                 data-testid="day-label"
               >
@@ -155,8 +153,7 @@ export const WeeklyTimeGrid = ({
         className="flex-1 overflow-y-scroll max-h-200"
       >
         <div className="grid grid-cols-[64px_repeat(7,minmax(0,1fr))] gap-x-0.5">
-          {/* 시간 레이블 (1 Column) */}
-          <div className="flex flex-col border-r border-gray-100 bg-[#FFFFFF66] w-16">
+          <div className="flex w-16 flex-col border-r border-border bg-background/40">
             {hours.map((hour) => {
               let minuteInterval = 60;
               if (zoomLevel >= 9) minuteInterval = 5;
@@ -171,12 +168,12 @@ export const WeeklyTimeGrid = ({
               return (
                 <div
                   key={`time-${hour}`}
-                  className="h-(--slot-height) border-b border-gray-100 relative text-gray-400 transition-[height] duration-200"
+                  className="relative h-(--slot-height) border-b border-border text-muted transition-[height] duration-200"
                 >
                   {minutes.map((minute) => (
                     <div
                       key={`${hour}-${minute}`}
-                      className="absolute w-full pr-2 text-right text-[10px] leading-none"
+                      className="text-xs-r absolute w-full pr-2 text-right"
                       style={{
                         top: minute === 0 ? '4px' : `${(minute / 60) * 100}%`,
                         opacity: minute === 0 ? 1 : 0.6,
@@ -197,9 +194,8 @@ export const WeeklyTimeGrid = ({
           {weekDays.map((day, dayIndex) => (
             <div
               key={`col-${dayIndex}`}
-              className="flex flex-col border-last:border-r-0 border-t bg-white relative"
+              className="relative flex flex-col border-t bg-background"
             >
-              {/* 일정 카드 렌더링 */}
               {getSchedulesByDate(day).map((part, i) => (
                 <ScheduleCard
                   key={`${part.schedule.scheduleId}-${i}`}
@@ -221,9 +217,8 @@ export const WeeklyTimeGrid = ({
                 return (
                   <div
                     key={`slot-${dayIndex}-${hour}`}
-                    className="h-(--slot-height) border-b border-rose-200 relative"
+                    className="relative h-(--slot-height) border-b border-destructive-surface"
                   >
-                    {/* 정밀 그리드 선 (좌측 레이블과 완벽히 일치, 빨간색 계열) */}
                     <div className="absolute inset-0 flex flex-col pointer-events-none">
                       {subSlots.map((_, idx) => (
                         <div
@@ -233,7 +228,6 @@ export const WeeklyTimeGrid = ({
                       ))}
                     </div>
 
-                    {/* 클릭 가능한 영역 */}
                     <div
                       data-testid="time-slot"
                       onClick={(e) => {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jamplay",
+  "name": "BandCo",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 3분

<br/>

## 📌 작업 요약

### 목표

- 홈 본문 셸 너비를 헤더와 통일하고, 핵심 화면의 폰트/색상 하드코딩을 디자인 토큰 기준으로 정리합니다.

### 요약

- 홈 본문 최대 너비를 헤더와 맞췄습니다.
- 모바일 브랜드 헤더 노출 방식을 정리했습니다.
- 공용 UI와 대표 화면의 타이포/보조 색상 하드코딩을 `index.css` 토큰 기준으로 치환했습니다.

<br/>

## 📝 작업 내용

1. `RootLayout` 본문 셸 최대 너비를 헤더와 동일하게 조정했습니다.
2. 모바일에서 `JamPlay` 텍스트를 숨기고 브랜드 간격을 정리했습니다.
3. `dialog`, `sheet`, `input`, `button`, `avatar`, `status-badge`의 타이포를 토큰으로 정리했습니다.
4. `page header`, `band list/card`, `band dialog`, `schedule modal`, `weekly calendar` 계열에 토큰을 적용했습니다.

### 사용자 영향

- 홈 헤더와 본문 너비가 일치합니다.
- 모바일에서 브랜드 표시가 더 간결하게 정리됩니다.
- 헤더, 밴드 카드, 모달, 캘린더의 텍스트 톤과 계층이 같은 체계로 맞춰집니다.

<br/>

## 🚨 주요 고민 및 해결 과정

- 새 수치를 만들지 않고 기존 타이포 유틸과 radius/color 토큰만 사용했습니다.
- 공용 primitive를 먼저 정리한 뒤 사용처를 최소 수정으로 맞췄습니다.

<br/>

## 📑 참고 문서/ ADR

- #28 

<br/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 타이포그래피 유틸리티 추가로 텍스트 스타일 표준화
  * 여러 UI 컴포넌트의 스타일(색상, 간격, 반경, 토큰화, 레이아웃 최대 너비) 업데이트

* **Tests**
  * 라우터 및 페이지 헤더 렌더링 관련 유닛 테스트 추가

* **Documentation**
  * README 내용 갱신 및 사이트 타이틀/언어 업데이트(BandCo)

* **Chores**
  * .gitignore에 파일 추가 및 패키지 이름 변경(pacakge.json들)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->