### PR TITLE
[KAN-33] pr 생성 스크립트 명령어 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "commit": "cz"
+    "commit": "cz",
+    "pr": "bash scripts/create-pr.sh"
   },
   "config": {
     "commitizen": {

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -113,38 +113,39 @@ info "브랜치를 origin에 push 중..."
 git push -u origin HEAD
 success "Push 완료"
 
-# ─── PR 본문: 템플릿 읽기 ────────────────────────────────────────────────────
-REPO_ROOT=$(git rev-parse --show-top-level 2>/dev/null || git rev-parse --show-toplevel)
+# ─── PR 본문: 템플릿을 임시 파일로 준비 ──────────────────────────────────────
+REPO_ROOT=$(git rev-parse --show-toplevel)
 TEMPLATE_PATH="$REPO_ROOT/.github/pull_request_template.md"
-PR_BODY=""
-[ -f "$TEMPLATE_PATH" ] && PR_BODY=$(cat "$TEMPLATE_PATH")
+BODY_FILE=$(mktemp)
+trap 'rm -f "$BODY_FILE"' EXIT
 
-# ─── 라벨 유효성 확인 후 PR 생성 ─────────────────────────────────────────────
+[ -f "$TEMPLATE_PATH" ] && cat "$TEMPLATE_PATH" > "$BODY_FILE"
+
+# ─── 라벨 유효성 확인 ────────────────────────────────────────────────────────
 echo ""
 info "Draft PR 생성 중..."
 
-REPO_NAME=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
+REPO_NAME=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
 EXISTING_LABELS=""
-[ -n "$REPO_NAME" ] && EXISTING_LABELS=$(gh label list --repo "$REPO_NAME" --json name -q '.[].name' 2>/dev/null || true)
+if [ -n "$REPO_NAME" ]; then
+  EXISTING_LABELS=$(gh label list --repo "$REPO_NAME" --json name -q '.[].name' 2>/dev/null || true)
+fi
 
-apply_label_if_exists() {
-  local label="$1"
-  if echo "$EXISTING_LABELS" | grep -qx "$label"; then
-    echo "$label"
-  else
-    warn "라벨 '${label}'이 저장소에 없어 건너뜁니다."
-    echo ""
-  fi
-}
-
-CREATE_CMD=(gh pr create --draft --title "$FULL_TITLE" --body "$PR_BODY")
-
+LABEL_ARGS=()
 for label in "${SELECTED_LABELS[@]}"; do
-  VALID=$(apply_label_if_exists "$label")
-  [ -n "$VALID" ] && CREATE_CMD+=(--label "$VALID")
+  if echo "$EXISTING_LABELS" | grep -qx "$label"; then
+    LABEL_ARGS+=(--label "$label")
+  else
+    warn "라벨 '${label}'이 저장소에 없어 건너뜁니다." >&2
+  fi
 done
 
-PR_URL=$("${CREATE_CMD[@]}")
+# ─── Draft PR 생성 ───────────────────────────────────────────────────────────
+PR_URL=$(gh pr create \
+  --draft \
+  --title "$FULL_TITLE" \
+  --body-file "$BODY_FILE" \
+  "${LABEL_ARGS[@]}")
 
 echo ""
 success "Draft PR이 생성되었습니다!"

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -19,6 +19,53 @@ if ! command -v gh &>/dev/null; then
   error "gh CLI가 설치되어 있지 않습니다. https://cli.github.com 에서 설치해주세요."
 fi
 
+# ─── 인증 확인 ───────────────────────────────────────────────────────────────
+if [ -z "$GH_TOKEN" ] && ! gh auth status &>/dev/null; then
+  echo -e "${RED}✖ ${RESET}GitHub 인증 정보가 없습니다."
+  echo ""
+  echo -e "  ${BOLD}인증 방법을 선택하세요:${RESET}"
+  echo "  1) gh auth login (gh CLI로 로그인, GUI 지원)"
+  echo "  2) GH_TOKEN 설정  (Personal Access Token)"
+  echo ""
+  read -rp "$(echo -e "${BOLD}번호 입력${RESET}: ")" AUTH_CHOICE
+
+  case "$AUTH_CHOICE" in
+    1)
+      gh auth login || error "인증에 실패했습니다."
+      ;;
+    2)
+      echo ""
+      echo -e "  ${BOLD}[1단계]${RESET} 아래 URL에서 Classic 토큰을 발급받으세요:"
+      echo -e "  https://github.com/settings/tokens/new"
+      echo ""
+      echo -e "  ${BOLD}Scopes:${RESET} ${GREEN}repo${RESET}, ${GREEN}workflow${RESET}"
+      echo "  (workflow는 .github/workflows 파일 수정 시 push에 필요)"
+      echo ""
+      read -rp "$(echo -e "  ${BOLD}[2단계]${RESET} 발급받은 토큰 붙여넣기: ")" INPUT_TOKEN
+      [ -z "$INPUT_TOKEN" ] && error "토큰이 입력되지 않았습니다."
+
+      # 저장할 파일 결정 (zsh → ~/.zshenv, bash → ~/.profile)
+      CURRENT_SHELL=$(basename "$SHELL")
+      if [ "$CURRENT_SHELL" = "zsh" ]; then
+        ENV_FILE="$HOME/.zshenv"
+      else
+        ENV_FILE="$HOME/.profile"
+      fi
+
+      echo "" >> "$ENV_FILE"
+      echo "# GitHub CLI token (pnpm run pr)" >> "$ENV_FILE"
+      echo "export GH_TOKEN=$INPUT_TOKEN" >> "$ENV_FILE"
+
+      export GH_TOKEN="$INPUT_TOKEN"
+      success "토큰이 ${BOLD}$ENV_FILE${RESET}에 저장되었습니다. 이후 터미널에서 자동 적용됩니다."
+      echo ""
+      ;;
+    *)
+      error "취소되었습니다."
+      ;;
+  esac
+fi
+
 # ─── 현재 브랜치 확인 ────────────────────────────────────────────────────────
 BRANCH=$(git branch --show-current)
 [ -z "$BRANCH" ] && error "브랜치 위에 있지 않습니다."

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -e
+
+# ─── 색상 출력 헬퍼 ───────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+info()    { echo -e "${CYAN}ℹ ${RESET}$1"; }
+success() { echo -e "${GREEN}✔ ${RESET}$1"; }
+warn()    { echo -e "${YELLOW}⚠ ${RESET}$1"; }
+error()   { echo -e "${RED}✖ ${RESET}$1" >&2; exit 1; }
+
+# ─── gh CLI 확인 ─────────────────────────────────────────────────────────────
+if ! command -v gh &>/dev/null; then
+  error "gh CLI가 설치되어 있지 않습니다. https://cli.github.com 에서 설치해주세요."
+fi
+
+# ─── 현재 브랜치 확인 ────────────────────────────────────────────────────────
+BRANCH=$(git branch --show-current)
+[ -z "$BRANCH" ] && error "브랜치 위에 있지 않습니다."
+[[ "$BRANCH" == "main" || "$BRANCH" == "dev" ]] && \
+  error "'$BRANCH' 브랜치에서는 PR을 생성할 수 없습니다."
+
+info "현재 브랜치: ${BOLD}$BRANCH${RESET}"
+
+# ─── Jira ID 추출 (브랜치명에서 KAN-32 패턴 탐색) ─────────────────────────────
+JIRA_ID=$(echo "$BRANCH" | grep -oE '[A-Z]+-[0-9]+' | head -1)
+
+if [ -n "$JIRA_ID" ]; then
+  info "브랜치에서 Jira ID 감지: ${BOLD}$JIRA_ID${RESET}"
+else
+  echo -e "${YELLOW}브랜치명에서 Jira ID를 찾지 못했습니다.${RESET}"
+  read -rp "$(echo -e "${BOLD}Jira task ID${RESET} (예: KAN-32  |  hotfix·긴급 등 없으면 Enter 건너뜀): ")" JIRA_ID
+  if [ -n "$JIRA_ID" ] && ! echo "$JIRA_ID" | grep -qE '^[A-Z]+-[0-9]+$'; then
+    error "Jira ID 형식이 올바르지 않습니다. 예: KAN-32"
+  fi
+fi
+
+# ─── PR 제목 입력 ─────────────────────────────────────────────────────────────
+echo ""
+read -rp "$(echo -e "${BOLD}PR 제목${RESET}: ")" PR_TITLE_INPUT
+[ -z "$PR_TITLE_INPUT" ] && error "PR 제목은 필수입니다."
+
+if [ -n "$JIRA_ID" ]; then
+  FULL_TITLE="[$JIRA_ID] $PR_TITLE_INPUT"
+else
+  warn "Jira ID 없이 PR을 생성합니다."
+  FULL_TITLE="$PR_TITLE_INPUT"
+fi
+
+success "최종 제목: ${BOLD}$FULL_TITLE${RESET}"
+
+# ─── 타입 라벨: 브랜치 prefix → 자동 결정 ────────────────────────────────────
+# 지원 라벨: feat / bug / chore / docs / refactor / hotfix / test / story
+TYPE_LABEL=""
+case "$BRANCH" in
+  feat/*)     TYPE_LABEL="feat" ;;
+  fix/*)      TYPE_LABEL="bug" ;;
+  chore/*)    TYPE_LABEL="chore" ;;
+  docs/*)     TYPE_LABEL="docs" ;;
+  refactor/*) TYPE_LABEL="refactor" ;;
+  hotfix/*)   TYPE_LABEL="hotfix" ;;
+  test/*)     TYPE_LABEL="test" ;;
+  story/*)    TYPE_LABEL="story" ;;
+esac
+
+[ -n "$TYPE_LABEL" ] && info "타입 라벨 자동 감지: ${BOLD}$TYPE_LABEL${RESET}"
+
+# ─── 영역 라벨: 사용자 선택 (BE / FE / infra) ────────────────────────────────
+echo ""
+echo -e "${BOLD}영역 라벨 선택${RESET} (Enter = 건너뜀)"
+echo "  1) FE"
+echo "  2) BE"
+echo "  3) infra"
+read -rp "번호 입력: " AREA_NUM
+
+AREA_LABEL=""
+case "$AREA_NUM" in
+  1) AREA_LABEL="FE" ;;
+  2) AREA_LABEL="BE" ;;
+  3) AREA_LABEL="infra" ;;
+  *) ;;
+esac
+
+[ -n "$AREA_LABEL" ] && info "영역 라벨: ${BOLD}$AREA_LABEL${RESET}"
+
+# ─── 브랜치 push ─────────────────────────────────────────────────────────────
+echo ""
+info "브랜치를 origin에 push 중..."
+git push -u origin HEAD
+success "Push 완료"
+
+# ─── PR 본문: 템플릿 읽기 ────────────────────────────────────────────────────
+REPO_ROOT=$(git rev-parse --show-top-level 2>/dev/null || git rev-parse --show-toplevel)
+TEMPLATE_PATH="$REPO_ROOT/.github/pull_request_template.md"
+PR_BODY=""
+[ -f "$TEMPLATE_PATH" ] && PR_BODY=$(cat "$TEMPLATE_PATH")
+
+# ─── 라벨 유효성 확인 후 PR 생성 ─────────────────────────────────────────────
+echo ""
+info "Draft PR 생성 중..."
+
+REPO_NAME=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
+EXISTING_LABELS=""
+[ -n "$REPO_NAME" ] && EXISTING_LABELS=$(gh label list --repo "$REPO_NAME" --json name -q '.[].name' 2>/dev/null || true)
+
+apply_label_if_exists() {
+  local label="$1"
+  if echo "$EXISTING_LABELS" | grep -qx "$label"; then
+    echo "$label"
+  else
+    warn "라벨 '${label}'이 저장소에 없어 건너뜁니다."
+    echo ""
+  fi
+}
+
+CREATE_CMD=(gh pr create --draft --title "$FULL_TITLE" --body "$PR_BODY")
+
+if [ -n "$TYPE_LABEL" ]; then
+  VALID=$(apply_label_if_exists "$TYPE_LABEL")
+  [ -n "$VALID" ] && CREATE_CMD+=(--label "$VALID")
+fi
+
+if [ -n "$AREA_LABEL" ]; then
+  VALID=$(apply_label_if_exists "$AREA_LABEL")
+  [ -n "$VALID" ] && CREATE_CMD+=(--label "$VALID")
+fi
+
+PR_URL=$("${CREATE_CMD[@]}")
+
+echo ""
+success "Draft PR이 생성되었습니다!"
+echo -e "  ${CYAN}${PR_URL}${RESET}"
+echo ""
+info "리뷰어 자동 지정 및 self-assign은 GitHub Actions가 처리합니다."

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -20,7 +20,7 @@ if ! command -v gh &>/dev/null; then
 fi
 
 # ─── 인증 확인 ───────────────────────────────────────────────────────────────
-if [ -z "$GH_TOKEN" ] && ! gh auth status &>/dev/null; then
+if ! gh auth status &>/dev/null; then
   echo -e "${RED}✖ ${RESET}GitHub 인증 정보가 없습니다."
   echo ""
   echo -e "  ${BOLD}인증 방법을 선택하세요:${RESET}"
@@ -41,23 +41,12 @@ if [ -z "$GH_TOKEN" ] && ! gh auth status &>/dev/null; then
       echo -e "  ${BOLD}Scopes:${RESET} ${GREEN}repo${RESET}, ${GREEN}workflow${RESET}"
       echo "  (workflow는 .github/workflows 파일 수정 시 push에 필요)"
       echo ""
-      read -rp "$(echo -e "  ${BOLD}[2단계]${RESET} 발급받은 토큰 붙여넣기: ")" INPUT_TOKEN
+      read -rsp "$(echo -e "  ${BOLD}[2단계]${RESET} 발급받은 토큰 붙여넣기: ")" INPUT_TOKEN
+      echo ""
       [ -z "$INPUT_TOKEN" ] && error "토큰이 입력되지 않았습니다."
 
-      # 저장할 파일 결정 (zsh → ~/.zshenv, bash → ~/.profile)
-      CURRENT_SHELL=$(basename "$SHELL")
-      if [ "$CURRENT_SHELL" = "zsh" ]; then
-        ENV_FILE="$HOME/.zshenv"
-      else
-        ENV_FILE="$HOME/.profile"
-      fi
-
-      echo "" >> "$ENV_FILE"
-      echo "# GitHub CLI token (pnpm run pr)" >> "$ENV_FILE"
-      echo "export GH_TOKEN=$INPUT_TOKEN" >> "$ENV_FILE"
-
-      export GH_TOKEN="$INPUT_TOKEN"
-      success "토큰이 ${BOLD}$ENV_FILE${RESET}에 저장되었습니다. 이후 터미널에서 자동 적용됩니다."
+      echo "$INPUT_TOKEN" | gh auth login --with-token || error "토큰 인증에 실패했습니다."
+      success "토큰이 gh CLI keychain에 저장되었습니다."
       echo ""
       ;;
     *)
@@ -190,6 +179,7 @@ done
 # ─── Draft PR 생성 ───────────────────────────────────────────────────────────
 PR_URL=$(gh pr create \
   --draft \
+  --base dev \
   --title "$FULL_TITLE" \
   --body-file "$BODY_FILE" \
   "${LABEL_ARGS[@]}")

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -54,39 +54,58 @@ fi
 
 success "최종 제목: ${BOLD}$FULL_TITLE${RESET}"
 
-# ─── 타입 라벨: 브랜치 prefix → 자동 결정 ────────────────────────────────────
-# 지원 라벨: feat / bug / chore / docs / refactor / hotfix / test / story
-TYPE_LABEL=""
+# ─── 라벨 선택 ────────────────────────────────────────────────────────────────
+ALL_LABELS=("feat" "bug" "chore" "docs" "refactor" "hotfix" "test" "story" "FE" "BE" "infra")
+
+# 브랜치 prefix로 기본 선택 인덱스 추론
+DEFAULT_IDX=""
 case "$BRANCH" in
-  feat/*)     TYPE_LABEL="feat" ;;
-  fix/*)      TYPE_LABEL="bug" ;;
-  chore/*)    TYPE_LABEL="chore" ;;
-  docs/*)     TYPE_LABEL="docs" ;;
-  refactor/*) TYPE_LABEL="refactor" ;;
-  hotfix/*)   TYPE_LABEL="hotfix" ;;
-  test/*)     TYPE_LABEL="test" ;;
-  story/*)    TYPE_LABEL="story" ;;
+  feat/*)     DEFAULT_IDX=1 ;;
+  fix/*)      DEFAULT_IDX=2 ;;
+  chore/*)    DEFAULT_IDX=3 ;;
+  docs/*)     DEFAULT_IDX=4 ;;
+  refactor/*) DEFAULT_IDX=5 ;;
+  hotfix/*)   DEFAULT_IDX=6 ;;
+  test/*)     DEFAULT_IDX=7 ;;
+  story/*)    DEFAULT_IDX=8 ;;
 esac
 
-[ -n "$TYPE_LABEL" ] && info "타입 라벨 자동 감지: ${BOLD}$TYPE_LABEL${RESET}"
-
-# ─── 영역 라벨: 사용자 선택 (BE / FE / infra) ────────────────────────────────
 echo ""
-echo -e "${BOLD}영역 라벨 선택${RESET} (Enter = 건너뜀)"
-echo "  1) FE"
-echo "  2) BE"
-echo "  3) infra"
-read -rp "번호 입력: " AREA_NUM
+echo -e "${BOLD}라벨 선택${RESET} — 번호를 띄어쓰기로 구분해 입력하세요 (Enter = 건너뜀)"
+echo ""
+for i in "${!ALL_LABELS[@]}"; do
+  NUM=$((i + 1))
+  LABEL="${ALL_LABELS[$i]}"
+  if [ "$NUM" = "$DEFAULT_IDX" ]; then
+    printf "  ${GREEN}%2d) %-12s${RESET}" "$NUM" "$LABEL  ←"
+  else
+    printf "  %2d) %-12s" "$NUM" "$LABEL"
+  fi
+  # 4열로 줄바꿈
+  [ $(( NUM % 4 )) -eq 0 ] && echo ""
+done
+echo ""
+echo ""
 
-AREA_LABEL=""
-case "$AREA_NUM" in
-  1) AREA_LABEL="FE" ;;
-  2) AREA_LABEL="BE" ;;
-  3) AREA_LABEL="infra" ;;
-  *) ;;
-esac
+DEFAULT_HINT=""
+[ -n "$DEFAULT_IDX" ] && DEFAULT_HINT=" (기본값: ${DEFAULT_IDX})"
+read -rp "$(echo -e "${BOLD}번호 입력${RESET}${DEFAULT_HINT}: ")" LABEL_INPUT
 
-[ -n "$AREA_LABEL" ] && info "영역 라벨: ${BOLD}$AREA_LABEL${RESET}"
+# 입력 없으면 기본값 사용
+[ -z "$LABEL_INPUT" ] && [ -n "$DEFAULT_IDX" ] && LABEL_INPUT="$DEFAULT_IDX"
+
+SELECTED_LABELS=()
+for num in $LABEL_INPUT; do
+  if [[ "$num" =~ ^[0-9]+$ ]] && [ "$num" -ge 1 ] && [ "$num" -le "${#ALL_LABELS[@]}" ]; then
+    SELECTED_LABELS+=("${ALL_LABELS[$((num - 1))]}")
+  else
+    warn "유효하지 않은 번호 '$num' — 건너뜁니다."
+  fi
+done
+
+if [ "${#SELECTED_LABELS[@]}" -gt 0 ]; then
+  info "선택된 라벨: ${BOLD}${SELECTED_LABELS[*]}${RESET}"
+fi
 
 # ─── 브랜치 push ─────────────────────────────────────────────────────────────
 echo ""
@@ -120,15 +139,10 @@ apply_label_if_exists() {
 
 CREATE_CMD=(gh pr create --draft --title "$FULL_TITLE" --body "$PR_BODY")
 
-if [ -n "$TYPE_LABEL" ]; then
-  VALID=$(apply_label_if_exists "$TYPE_LABEL")
+for label in "${SELECTED_LABELS[@]}"; do
+  VALID=$(apply_label_if_exists "$label")
   [ -n "$VALID" ] && CREATE_CMD+=(--label "$VALID")
-fi
-
-if [ -n "$AREA_LABEL" ]; then
-  VALID=$(apply_label_if_exists "$AREA_LABEL")
-  [ -n "$VALID" ] && CREATE_CMD+=(--label "$VALID")
-fi
+done
 
 PR_URL=$("${CREATE_CMD[@]}")
 


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 5분

<br/>

## 📌 작업 요약

`pnpm run pr` 명령어 하나로 push부터 Draft PR 생성까지 자동화하는 스크립트를 추가했습니다.
Jira 작업 번호를 PR 제목에 빠뜨리지 않도록 강제하는 것이 주목적입니다.

<br/>

## 📝 작업 내용

1. `scripts/create-pr.sh` 생성 — push + Draft PR 생성 자동화
2. 루트 `package.json`에 `"pr": "bash scripts/create-pr.sh"` 추가
3. GitHub 미인증 시 `gh auth login` 또는 `GH_TOKEN` 설정을 대화형으로 안내

<br/>

## 🚨 주요 고민 및 해결 과정

### 문제
WSL 환경에서 `gh auth login` 브라우저 연동이 안 됨

### 해결 과정
인증 실패 시 선택지를 제공하도록 대화형으로 구성.
`GH_TOKEN` 선택 시 Classic PAT 발급 URL과 필요 스코프(`repo`, `workflow`)를 안내하고, 셸에 따라 `~/.profile` (bash) 또는 `~/.zshenv` (zsh)에 자동 저장하도록 선택 분기

<br/>

## 📑 참고 문서

- [gh CLI 공식 문서](https://cli.github.com/manual/gh_pr_create)
- [GitHub Classic PAT 발급](https://github.com/settings/tokens/new)

<br/>

## 💬 리뷰 요구사항

- `gh` 설치 + `GH_TOKEN` 세팅 후 실제로 `pnpm run pr` 한 번 돌려보면 좋을 것 같아요
- 라벨이 저장소에 없으면 경고만 뜨고 스킵되니, 라벨을 추가하거나 수정할 땐 스크립트와 라벨 모두 관리해주세요!