### PR TITLE
[KAN-42] 밴드 도메인 API 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 
 import { AuthModule } from './auth/auth.module';
 import { PrismaModule } from './database/prisma';
+import { BandsModule } from './modules/bands/bands.module';
 import { NotificationsModule } from './modules/notifications/notifications.module';
 import { SongsModule } from './modules/songs/songs.module';
 import { SpacesModule } from './modules/spaces/spaces.module';
 import { UsersModule } from './modules/users/users.module';
 
 @Module({
-  imports: [PrismaModule, SpacesModule, AuthModule, NotificationsModule, SongsModule, UsersModule],
+  imports: [PrismaModule, SpacesModule, AuthModule, NotificationsModule, SongsModule, UsersModule, BandsModule],
 })
 export class AppModule {}

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -7,8 +7,10 @@ import type { User } from '../../generated/prisma';
 import { CreateBandBodyDto } from './dto/create-band.dto';
 import { GetBandMembersQueryDto } from './dto/get-band-members-query.dto';
 import { GetMyBandsQueryDto } from './dto/get-my-bands-query.dto';
+import { SearchBandsQueryDto } from './dto/search-bands-query.dto';
 import { UpdateBandMemberRoleBodyDto } from './dto/update-band-member-role.dto';
 import type { GetBandMembersResult } from './types/band-member-list.type';
+import type { SearchBandsResult } from './types/band-search-result.type';
 import type { CreateBandResult } from './types/create-band-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
@@ -45,6 +47,13 @@ export class BandsController {
     const bands = await this.bandsService.getMyBands(request.user.id, query);
 
     return createSuccessResponse('내 밴드 목록 조회 성공', bands);
+  }
+
+  @Get('search')
+  async searchBands(@Query() query: SearchBandsQueryDto): Promise<ApiSuccessResponse<SearchBandsResult>> {
+    const bands = await this.bandsService.searchBands(query);
+
+    return createSuccessResponse('밴드 검색 완료', bands);
   }
 
   @Get(':bandId/users')

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -14,6 +14,7 @@ import type { GetBandMembersResult } from './types/band-member-list.type';
 import type { SearchBandsResult } from './types/band-search-result.type';
 import type { CreateBandResult } from './types/create-band-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
+import type { LeaveBandResult } from './types/leave-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
 import type { UpdateBandMemberRoleResult } from './types/update-band-member-role-result.type';
 import type { UpdateBandResult } from './types/update-band-result.type';
@@ -33,6 +34,14 @@ export class BandsController {
     const createdBand = await this.bandsService.createBand(request.user.id, input);
 
     return createSuccessResponse('밴드 생성 성공', createdBand);
+  }
+
+  @Delete(':bandId/me')
+  @UseGuards(AccessTokenGuard)
+  async leaveBand(@Req() request: AuthenticatedRequest, @Param('bandId') bandId: string): Promise<ApiSuccessResponse<LeaveBandResult>> {
+    const leftBand = await this.bandsService.leaveBand(request.user.id, bandId);
+
+    return createSuccessResponse('밴드 나가기 완료', leftBand);
   }
 
   @Delete(':bandId')

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Param, Post, Req, UseGuards } from '@nestjs/common';
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
@@ -6,6 +6,7 @@ import type { User } from '../../generated/prisma';
 
 import { CreateBandBodyDto } from './dto/create-band.dto';
 import type { CreateBandResult } from './types/create-band-result.type';
+import type { DeleteBandResult } from './types/delete-band-result.type';
 import { BandsService } from './bands.service';
 
 interface AuthenticatedRequest {
@@ -22,5 +23,13 @@ export class BandsController {
     const createdBand = await this.bandsService.createBand(request.user.id, input);
 
     return createSuccessResponse('밴드 생성 성공', createdBand);
+  }
+
+  @Delete(':bandId')
+  @UseGuards(AccessTokenGuard)
+  async deleteBand(@Req() request: AuthenticatedRequest, @Param('bandId') bandId: string): Promise<ApiSuccessResponse<DeleteBandResult>> {
+    const deletedBand = await this.bandsService.deleteBand(request.user.id, bandId);
+
+    return createSuccessResponse('밴드가 삭제되었습니다.', deletedBand);
   }
 }

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -8,6 +8,7 @@ import { CreateBandBodyDto } from './dto/create-band.dto';
 import { GetBandMembersQueryDto } from './dto/get-band-members-query.dto';
 import { GetMyBandsQueryDto } from './dto/get-my-bands-query.dto';
 import { SearchBandsQueryDto } from './dto/search-bands-query.dto';
+import { UpdateBandBodyDto } from './dto/update-band.dto';
 import { UpdateBandMemberRoleBodyDto } from './dto/update-band-member-role.dto';
 import type { GetBandMembersResult } from './types/band-member-list.type';
 import type { SearchBandsResult } from './types/band-search-result.type';
@@ -15,6 +16,7 @@ import type { CreateBandResult } from './types/create-band-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
 import type { UpdateBandMemberRoleResult } from './types/update-band-member-role-result.type';
+import type { UpdateBandResult } from './types/update-band-result.type';
 import { BandsService } from './bands.service';
 
 interface AuthenticatedRequest {
@@ -54,6 +56,18 @@ export class BandsController {
     const bands = await this.bandsService.searchBands(query);
 
     return createSuccessResponse('밴드 검색 완료', bands);
+  }
+
+  @Patch(':bandId')
+  @UseGuards(AccessTokenGuard)
+  async updateBand(
+    @Req() request: AuthenticatedRequest,
+    @Param('bandId') bandId: string,
+    @Body() input: UpdateBandBodyDto,
+  ): Promise<ApiSuccessResponse<UpdateBandResult>> {
+    const updatedBand = await this.bandsService.updateBand(request.user.id, bandId, input);
+
+    return createSuccessResponse('밴드 정보 수정 완료', updatedBand);
   }
 
   @Get(':bandId/users')

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -80,13 +80,8 @@ export class BandsController {
   }
 
   @Get(':bandId/users')
-  @UseGuards(AccessTokenGuard)
-  async getBandMembers(
-    @Req() request: AuthenticatedRequest,
-    @Param('bandId') bandId: string,
-    @Query() query: GetBandMembersQueryDto,
-  ): Promise<ApiSuccessResponse<GetBandMembersResult>> {
-    const members = await this.bandsService.getBandMembers(request.user.id, bandId, query);
+  async getBandMembers(@Param('bandId') bandId: string, @Query() query: GetBandMembersQueryDto): Promise<ApiSuccessResponse<GetBandMembersResult>> {
+    const members = await this.bandsService.getBandMembers(bandId, query);
 
     return createSuccessResponse('밴드 내 멤버 조회 완료', members);
   }

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+
+import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
+import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
+import type { User } from '../../generated/prisma';
+
+import { CreateBandBodyDto } from './dto/create-band.dto';
+import type { CreateBandResult } from './types/create-band-result.type';
+import { BandsService } from './bands.service';
+
+interface AuthenticatedRequest {
+  user: User;
+}
+
+@Controller('bands')
+export class BandsController {
+  constructor(private readonly bandsService: BandsService) {}
+
+  @Post()
+  @UseGuards(AccessTokenGuard)
+  async createBand(@Req() request: AuthenticatedRequest, @Body() input: CreateBandBodyDto): Promise<ApiSuccessResponse<CreateBandResult>> {
+    const createdBand = await this.bandsService.createBand(request.user.id, input);
+
+    return createSuccessResponse('밴드 생성 성공', createdBand);
+  }
+}

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -1,13 +1,15 @@
-import { Body, Controller, Delete, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query, Req, UseGuards } from '@nestjs/common';
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
 import type { User } from '../../generated/prisma';
 
 import { CreateBandBodyDto } from './dto/create-band.dto';
+import { GetMyBandsQueryDto } from './dto/get-my-bands-query.dto';
 import { UpdateBandMemberRoleBodyDto } from './dto/update-band-member-role.dto';
 import type { CreateBandResult } from './types/create-band-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
+import type { GetMyBandsResult } from './types/my-band-list.type';
 import type { UpdateBandMemberRoleResult } from './types/update-band-member-role-result.type';
 import { BandsService } from './bands.service';
 
@@ -33,6 +35,14 @@ export class BandsController {
     const deletedBand = await this.bandsService.deleteBand(request.user.id, bandId);
 
     return createSuccessResponse('밴드가 삭제되었습니다.', deletedBand);
+  }
+
+  @Get('me')
+  @UseGuards(AccessTokenGuard)
+  async getMyBands(@Req() request: AuthenticatedRequest, @Query() query: GetMyBandsQueryDto): Promise<ApiSuccessResponse<GetMyBandsResult>> {
+    const bands = await this.bandsService.getMyBands(request.user.id, query);
+
+    return createSuccessResponse('내 밴드 목록 조회 성공', bands);
   }
 
   @Patch(':bandId/users/:userId')

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -1,12 +1,14 @@
-import { Body, Controller, Delete, Param, Post, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
 import type { User } from '../../generated/prisma';
 
 import { CreateBandBodyDto } from './dto/create-band.dto';
+import { UpdateBandMemberRoleBodyDto } from './dto/update-band-member-role.dto';
 import type { CreateBandResult } from './types/create-band-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
+import type { UpdateBandMemberRoleResult } from './types/update-band-member-role-result.type';
 import { BandsService } from './bands.service';
 
 interface AuthenticatedRequest {
@@ -31,5 +33,18 @@ export class BandsController {
     const deletedBand = await this.bandsService.deleteBand(request.user.id, bandId);
 
     return createSuccessResponse('밴드가 삭제되었습니다.', deletedBand);
+  }
+
+  @Patch(':bandId/users/:userId')
+  @UseGuards(AccessTokenGuard)
+  async updateBandMemberRole(
+    @Req() request: AuthenticatedRequest,
+    @Param('bandId') bandId: string,
+    @Param('userId') userId: string,
+    @Body() input: UpdateBandMemberRoleBodyDto,
+  ): Promise<ApiSuccessResponse<UpdateBandMemberRoleResult>> {
+    const updatedMember = await this.bandsService.updateBandMemberRole(request.user.id, bandId, userId, input);
+
+    return createSuccessResponse('밴드 멤버 권한이 변경되었습니다.', updatedMember);
   }
 }

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -5,8 +5,10 @@ import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api
 import type { User } from '../../generated/prisma';
 
 import { CreateBandBodyDto } from './dto/create-band.dto';
+import { GetBandMembersQueryDto } from './dto/get-band-members-query.dto';
 import { GetMyBandsQueryDto } from './dto/get-my-bands-query.dto';
 import { UpdateBandMemberRoleBodyDto } from './dto/update-band-member-role.dto';
+import type { GetBandMembersResult } from './types/band-member-list.type';
 import type { CreateBandResult } from './types/create-band-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
@@ -43,6 +45,18 @@ export class BandsController {
     const bands = await this.bandsService.getMyBands(request.user.id, query);
 
     return createSuccessResponse('내 밴드 목록 조회 성공', bands);
+  }
+
+  @Get(':bandId/users')
+  @UseGuards(AccessTokenGuard)
+  async getBandMembers(
+    @Req() request: AuthenticatedRequest,
+    @Param('bandId') bandId: string,
+    @Query() query: GetBandMembersQueryDto,
+  ): Promise<ApiSuccessResponse<GetBandMembersResult>> {
+    const members = await this.bandsService.getBandMembers(request.user.id, bandId, query);
+
+    return createSuccessResponse('밴드 내 멤버 조회 완료', members);
   }
 
   @Patch(':bandId/users/:userId')

--- a/backend/src/modules/bands/bands.module.ts
+++ b/backend/src/modules/bands/bands.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+
+import { AuthModule } from '../../auth/auth.module';
+import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
+import { UsersModule } from '../users/users.module';
+
+import { BandsPrismaRepository } from './repositories/bands.prisma-repository';
+import { BANDS_REPOSITORY } from './repositories/bands.repository';
+import { BandsController } from './bands.controller';
+import { BandsService } from './bands.service';
+
+@Module({
+  imports: [AuthModule, UsersModule],
+  controllers: [BandsController],
+  providers: [
+    AccessTokenGuard,
+    BandsService,
+    BandsPrismaRepository,
+    {
+      provide: BANDS_REPOSITORY,
+      useExisting: BandsPrismaRepository,
+    },
+  ],
+})
+export class BandsModule {}

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -5,6 +5,7 @@ import { BandMemberRole } from 'src/generated/prisma';
 import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
 import type { SearchBandsQuery } from './dto/search-bands-query.dto';
+import type { UpdateBandInput } from './dto/update-band.dto';
 import type { BandsRepository, CreateBandRepositoryInput } from './repositories/bands.repository';
 import { BandsService } from './bands.service';
 
@@ -29,6 +30,10 @@ function createBandsRepositoryStub(options?: {
     id: string;
     bandMasterUserId: string;
   } | null;
+  bandForUpdate?: {
+    id: string;
+    bandMasterUserId: string;
+  } | null;
   bandMemberForRoleUpdate?: {
     id: string;
     userId: string;
@@ -40,10 +45,12 @@ function createBandsRepositoryStub(options?: {
   onFindBandForRoleUpdate?: (tx: unknown) => void;
   onFindBandMemberForRoleUpdate?: (tx: unknown) => void;
   onFindBandMembers?: (bandId: string, query: GetBandMembersQuery, tx: unknown) => void;
+  onFindBandForUpdate?: (tx: unknown) => void;
   onFindExistingGenreIds?: (tx: unknown) => void;
   onFindExistingUserIds?: (tx: unknown) => void;
   onFindMyBands?: (userId: string, query: GetMyBandsQuery, tx: unknown) => void;
   onSearchBands?: (query: SearchBandsQuery, tx: unknown) => void;
+  onUpdateBand?: (bandId: string, input: UpdateBandInput, tx: unknown) => void;
   onUpdateBandMemberRole?: (bandMemberId: string, role: BandMemberRole, tx: unknown) => void;
 }): BandsRepository {
   return {
@@ -194,6 +201,30 @@ function createBandsRepositoryStub(options?: {
           },
           next: null,
         },
+      };
+    },
+    async findBandForUpdate(_bandId, tx) {
+      options?.onFindBandForUpdate?.(tx);
+
+      if (options?.bandForUpdate !== undefined) {
+        return options.bandForUpdate;
+      }
+
+      return {
+        id: 'band-001',
+        bandMasterUserId: BAND_MASTER_USER_ID,
+      };
+    },
+    async updateBand(bandId, input, tx) {
+      options?.onUpdateBand?.(bandId, input, tx);
+
+      return {
+        bandId,
+        name: input.name ?? '합주하자',
+        description: input.description ?? null,
+        visibility: input.visibility ?? true,
+        coverImgUrl: input.coverImgUrl ?? null,
+        updatedAt: '2026-04-10T12:00:00.000Z',
       };
     },
     async findBandForMemberRoleUpdate(_bandId, tx) {
@@ -756,6 +787,127 @@ describe('BandsService', () => {
       );
 
       expect(capturedTransaction).toBe(externalTx);
+    });
+  });
+
+  describe('updateBand', () => {
+    it('밴드장이 기본 정보를 수정할 수 있다', async () => {
+      let capturedInput: UpdateBandInput | undefined;
+      const repository = createBandsRepositoryStub({
+        onUpdateBand(_bandId, input) {
+          capturedInput = input;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.updateBand(BAND_MASTER_USER_ID, 'band-001', {
+        name: 'Rocking Stars',
+        description: '주 2회 합주하는 밴드',
+        visibility: true,
+        coverImgUrl: 'https://cdn.example.com/bands/cover.png',
+      });
+
+      expect(capturedInput?.name).toBe('Rocking Stars');
+      expect(result.bandId).toBe('band-001');
+      expect(result.name).toBe('Rocking Stars');
+      expect(result.description).toBe('주 2회 합주하는 밴드');
+      expect(result.coverImgUrl).toBe('https://cdn.example.com/bands/cover.png');
+    });
+
+    it('description과 coverImgUrl을 null로 제거할 수 있다', async () => {
+      let capturedInput: UpdateBandInput | undefined;
+      const repository = createBandsRepositoryStub({
+        onUpdateBand(_bandId, input) {
+          capturedInput = input;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.updateBand(BAND_MASTER_USER_ID, 'band-001', {
+        description: null,
+        coverImgUrl: null,
+      });
+
+      expect(capturedInput?.description).toBeNull();
+      expect(capturedInput?.coverImgUrl).toBeNull();
+      expect(result.description).toBeNull();
+      expect(result.coverImgUrl).toBeNull();
+    });
+
+    it('수정할 필드가 없으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.updateBand(BAND_MASTER_USER_ID, 'band-001', {})).rejects.toThrow(BadRequestException);
+    });
+
+    it('밴드 이름이 빈 문자열이면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.updateBand(BAND_MASTER_USER_ID, 'band-001', {
+          name: '',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('밴드가 없거나 삭제되었으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandForUpdate: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.updateBand(BAND_MASTER_USER_ID, 'band-missing', {
+          name: 'Rocking Stars',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('밴드장이 아니면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandForUpdate: {
+          id: 'band-001',
+          bandMasterUserId: '22222222-2222-4222-8222-222222222222',
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.updateBand(BAND_MASTER_USER_ID, 'band-001', {
+          name: 'Rocking Stars',
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindBandForUpdate(tx) {
+          capturedTransactions.push(tx);
+        },
+        onUpdateBand(_bandId, _input, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.updateBand(
+        BAND_MASTER_USER_ID,
+        'band-001',
+        {
+          name: 'Rocking Stars',
+        },
+        externalTx as never,
+      );
+
+      expect(capturedTransactions).toHaveLength(2);
+      expect(capturedTransactions[0]).toBe(externalTx);
+      expect(capturedTransactions[1]).toBe(externalTx);
     });
   });
 

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -1007,6 +1007,17 @@ describe('BandsService', () => {
       ).rejects.toThrow(BadRequestException);
     });
 
+    it('밴드장의 권한 변경을 허용하지 않는다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.updateBandMemberRole(BAND_MASTER_USER_ID, 'band-001', BAND_MASTER_USER_ID, {
+          role: BandMemberRole.ADMIN,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
     it('밴드가 없거나 삭제되었으면 예외를 던진다', async () => {
       const repository = createBandsRepositoryStub({
         activeBand: null,

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException, ForbiddenException, NotFoundException } from '@nes
 import type { PrismaService } from 'src/database/prisma';
 import { BandMemberRole } from 'src/generated/prisma';
 
+import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
 import type { BandsRepository, CreateBandRepositoryInput } from './repositories/bands.repository';
 import { BandsService } from './bands.service';
 
@@ -33,6 +34,7 @@ function createBandsRepositoryStub(options?: {
   onFindBandMemberForRoleUpdate?: (tx: unknown) => void;
   onFindExistingGenreIds?: (tx: unknown) => void;
   onFindExistingUserIds?: (tx: unknown) => void;
+  onFindMyBands?: (userId: string, query: GetMyBandsQuery, tx: unknown) => void;
   onUpdateBandMemberRole?: (bandMemberId: string, role: BandMemberRole, tx: unknown) => void;
 }): BandsRepository {
   return {
@@ -80,6 +82,33 @@ function createBandsRepositoryStub(options?: {
       return {
         id: 'band-001',
         bandMasterUserId: BAND_MASTER_USER_ID,
+      };
+    },
+    async findMyBands(userId, query, tx) {
+      options?.onFindMyBands?.(userId, query, tx);
+
+      return {
+        items: [
+          {
+            id: 'band-001',
+            name: '합주하자',
+            description: '주 1회 합주',
+            visibility: true,
+            myRole: BandMemberRole.BM,
+            joinedAt: '2026-03-01T12:10:00.000Z',
+            createdAt: '2026-03-01T12:00:00.000Z',
+            memberCount: 20,
+          },
+        ],
+        meta: {
+          count: 1,
+          take: query.take,
+          cursor: {
+            createdAt: '2026-03-01T12:00:00.000Z',
+            id: 'band-001',
+          },
+          next: null,
+        },
       };
     },
     async findBandForMemberRoleUpdate(_bandId, tx) {
@@ -343,6 +372,79 @@ describe('BandsService', () => {
       expect(capturedTransactions).toHaveLength(2);
       expect(capturedTransactions[0]).toBe(externalTx);
       expect(capturedTransactions[1]).toBe(externalTx);
+    });
+  });
+
+  describe('getMyBands', () => {
+    it('인증 사용자가 속한 밴드 목록을 조회한다', async () => {
+      let capturedUserId: string | undefined;
+      let capturedQuery: GetMyBandsQuery | undefined;
+      const query: GetMyBandsQuery = {
+        take: 20,
+      };
+      const repository = createBandsRepositoryStub({
+        onFindMyBands(userId, inputQuery) {
+          capturedUserId = userId;
+          capturedQuery = inputQuery;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.getMyBands(BAND_MASTER_USER_ID, query);
+
+      expect(capturedUserId).toBe(BAND_MASTER_USER_ID);
+      expect(capturedQuery).toBe(query);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].myRole).toBe(BandMemberRole.BM);
+      expect(result.meta.take).toBe(20);
+    });
+
+    it('커서 날짜와 ID는 함께 입력해야 한다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.getMyBands(BAND_MASTER_USER_ID, {
+          take: 20,
+          cursor__created_at: '2026-03-01T12:00:00.000Z',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('커서 날짜가 유효하지 않으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.getMyBands(BAND_MASTER_USER_ID, {
+          take: 20,
+          cursor__created_at: 'invalid-date',
+          cursor__id: '11111111-1111-4111-8111-111111111111',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('외부 transaction client를 repository로 전달한다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      let capturedTransaction: unknown;
+      const repository = createBandsRepositoryStub({
+        onFindMyBands(_userId, _query, tx) {
+          capturedTransaction = tx;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.getMyBands(
+        BAND_MASTER_USER_ID,
+        {
+          take: 20,
+        },
+        externalTx as never,
+      );
+
+      expect(capturedTransaction).toBe(externalTx);
     });
   });
 

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -1,9 +1,6 @@
-import assert from 'node:assert/strict';
-
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
-import test from 'node:test';
-
-import type { PrismaService } from '../../database/prisma';
+import type { PrismaService } from 'src/database/prisma';
+import { BandMemberRole } from 'src/generated/prisma';
 
 import type { BandsRepository, CreateBandRepositoryInput } from './repositories/bands.repository';
 import { BandsService } from './bands.service';
@@ -21,11 +18,22 @@ function createBandsRepositoryStub(options?: {
     id: string;
     bandMasterUserId: string;
   } | null;
+  bandForRoleUpdate?: {
+    id: string;
+    bandMasterUserId: string;
+  } | null;
+  bandMemberForRoleUpdate?: {
+    id: string;
+    userId: string;
+  } | null;
   onCreateBand?: (input: CreateBandRepositoryInput, tx: unknown) => void;
   onDeleteBand?: (bandId: string, deletedAt: Date, tx: unknown) => void;
   onFindBandForDelete?: (tx: unknown) => void;
+  onFindBandForRoleUpdate?: (tx: unknown) => void;
+  onFindBandMemberForRoleUpdate?: (tx: unknown) => void;
   onFindExistingGenreIds?: (tx: unknown) => void;
   onFindExistingUserIds?: (tx: unknown) => void;
+  onUpdateBandMemberRole?: (bandMemberId: string, role: BandMemberRole, tx: unknown) => void;
 }): BandsRepository {
   return {
     async createBand(input, tx) {
@@ -74,6 +82,30 @@ function createBandsRepositoryStub(options?: {
         bandMasterUserId: BAND_MASTER_USER_ID,
       };
     },
+    async findBandForMemberRoleUpdate(_bandId, tx) {
+      options?.onFindBandForRoleUpdate?.(tx);
+
+      if (options?.bandForRoleUpdate !== undefined) {
+        return options.bandForRoleUpdate;
+      }
+
+      return {
+        id: 'band-001',
+        bandMasterUserId: BAND_MASTER_USER_ID,
+      };
+    },
+    async findBandMemberForRoleUpdate(_bandId, userId, tx) {
+      options?.onFindBandMemberForRoleUpdate?.(tx);
+
+      if (options?.bandMemberForRoleUpdate !== undefined) {
+        return options.bandMemberForRoleUpdate;
+      }
+
+      return {
+        id: 'band-member-001',
+        userId,
+      };
+    },
     async findExistingGenreIds(genreIds, tx) {
       options?.onFindExistingGenreIds?.(tx);
 
@@ -83,6 +115,16 @@ function createBandsRepositoryStub(options?: {
       options?.onFindExistingUserIds?.(tx);
 
       return options?.existingUserIds ?? userIds;
+    },
+    async updateBandMemberRole(bandMemberId, input, tx) {
+      options?.onUpdateBandMemberRole?.(bandMemberId, input.role, tx);
+
+      return {
+        member: {
+          userId: 'target-user-001',
+          role: input.role,
+        },
+      };
     },
   };
 }
@@ -107,196 +149,307 @@ function createPrismaServiceFailingTransactionStub(): PrismaService {
   } as unknown as PrismaService;
 }
 
-test('밴드 생성 서비스는 인증 사용자를 밴드장으로 사용하고 생성 결과를 반환한다', async () => {
-  let capturedInput: CreateBandRepositoryInput | undefined;
-  const repository = createBandsRepositoryStub({
-    onCreateBand(input) {
-      capturedInput = input;
-    },
-  });
-  const service = new BandsService(repository, createPrismaServiceStub());
+describe('BandsService', () => {
+  describe('createBand', () => {
+    it('인증 사용자를 밴드장으로 사용하고 생성 결과를 반환한다', async () => {
+      let capturedInput: CreateBandRepositoryInput | undefined;
+      const repository = createBandsRepositoryStub({
+        onCreateBand(input) {
+          capturedInput = input;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
 
-  const result = await service.createBand(BAND_MASTER_USER_ID, {
-    name: '합주하자',
-    description: '주 1회 합주하는 밴드입니다.',
-    visibility: true,
-    coverImgUrl: 'https://cdn.example.com/bands/cover.png',
-    genreIds: [ROCK_GENRE_ID, ROCK_GENRE_ID, JAZZ_GENRE_ID],
-    inviteeUserIds: [INVITEE_USER_ID, INVITEE_USER_ID],
-  });
+      const result = await service.createBand(BAND_MASTER_USER_ID, {
+        name: '합주하자',
+        description: '주 1회 합주하는 밴드입니다.',
+        visibility: true,
+        coverImgUrl: 'https://cdn.example.com/bands/cover.png',
+        genreIds: [ROCK_GENRE_ID, ROCK_GENRE_ID, JAZZ_GENRE_ID],
+        inviteeUserIds: [INVITEE_USER_ID, INVITEE_USER_ID],
+      });
 
-  assert.equal(capturedInput?.bandMasterUserId, BAND_MASTER_USER_ID);
-  assert.deepEqual(capturedInput?.genreIds, [ROCK_GENRE_ID, JAZZ_GENRE_ID]);
-  assert.deepEqual(capturedInput?.inviteeUserIds, [INVITEE_USER_ID]);
-  assert.equal(result.band.name, '합주하자');
-  assert.equal(result.band.genres.length, 2);
-  assert.equal(result.band.invitations.success.length, 1);
-  assert.equal(result.band.invitations.failed.length, 0);
-});
+      expect(capturedInput?.bandMasterUserId).toBe(BAND_MASTER_USER_ID);
+      expect(capturedInput?.genreIds).toEqual([ROCK_GENRE_ID, JAZZ_GENRE_ID]);
+      expect(capturedInput?.inviteeUserIds).toEqual([INVITEE_USER_ID]);
+      expect(result.band.name).toBe('합주하자');
+      expect(result.band.genres).toHaveLength(2);
+      expect(result.band.invitations.success).toHaveLength(1);
+      expect(result.band.invitations.failed).toHaveLength(0);
+    });
 
-test('밴드 생성 서비스는 존재하지 않는 장르가 있으면 예외를 던진다', async () => {
-  const repository = createBandsRepositoryStub({
-    existingGenreIds: [ROCK_GENRE_ID],
-  });
-  const service = new BandsService(repository, createPrismaServiceStub());
+    it('존재하지 않는 장르가 있으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        existingGenreIds: [ROCK_GENRE_ID],
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
 
-  await assert.rejects(
-    async () =>
-      service.createBand(BAND_MASTER_USER_ID, {
+      await expect(
+        service.createBand(BAND_MASTER_USER_ID, {
+          name: '합주하자',
+          visibility: true,
+          genreIds: [ROCK_GENRE_ID, JAZZ_GENRE_ID],
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('초대할 수 없는 사용자를 실패 목록으로 분리한다', async () => {
+      const repository = createBandsRepositoryStub({
+        existingUserIds: [INVITEE_USER_ID],
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.createBand(BAND_MASTER_USER_ID, {
         name: '합주하자',
         visibility: true,
-        genreIds: [ROCK_GENRE_ID, JAZZ_GENRE_ID],
-      }),
-    BadRequestException,
-  );
-});
+        inviteeUserIds: [INVITEE_USER_ID, BAND_MASTER_USER_ID, MISSING_USER_ID],
+      });
 
-test('밴드 생성 서비스는 초대할 수 없는 사용자를 실패 목록으로 분리한다', async () => {
-  const repository = createBandsRepositoryStub({
-    existingUserIds: [INVITEE_USER_ID],
+      expect(result.band.invitations.success).toEqual([
+        {
+          userId: INVITEE_USER_ID,
+          invitationId: `invitation-${INVITEE_USER_ID}`,
+        },
+      ]);
+      expect(result.band.invitations.failed).toEqual([
+        {
+          userId: BAND_MASTER_USER_ID,
+          reason: '밴드 생성자는 초대 대상이 될 수 없습니다.',
+        },
+        {
+          userId: MISSING_USER_ID,
+          reason: '존재하지 않거나 비활성화된 사용자입니다.',
+        },
+      ]);
+    });
+
+    it('검증과 생성을 같은 transaction client로 실행한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindExistingGenreIds(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindExistingUserIds(tx) {
+          capturedTransactions.push(tx);
+        },
+        onCreateBand(_input, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await service.createBand(BAND_MASTER_USER_ID, {
+        name: '합주하자',
+        visibility: true,
+        genreIds: [ROCK_GENRE_ID],
+        inviteeUserIds: [INVITEE_USER_ID],
+      });
+
+      expect(capturedTransactions).toHaveLength(3);
+      expect(capturedTransactions[0]).toBe(capturedTransactions[1]);
+      expect(capturedTransactions[1]).toBe(capturedTransactions[2]);
+    });
+
+    it('외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindExistingGenreIds(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindExistingUserIds(tx) {
+          capturedTransactions.push(tx);
+        },
+        onCreateBand(_input, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.createBand(
+        BAND_MASTER_USER_ID,
+        {
+          name: '합주하자',
+          visibility: true,
+          genreIds: [ROCK_GENRE_ID],
+          inviteeUserIds: [INVITEE_USER_ID],
+        },
+        externalTx as never,
+      );
+
+      expect(capturedTransactions).toHaveLength(3);
+      expect(capturedTransactions[0]).toBe(externalTx);
+      expect(capturedTransactions[1]).toBe(externalTx);
+      expect(capturedTransactions[2]).toBe(externalTx);
+    });
   });
-  const service = new BandsService(repository, createPrismaServiceStub());
 
-  const result = await service.createBand(BAND_MASTER_USER_ID, {
-    name: '합주하자',
-    visibility: true,
-    inviteeUserIds: [INVITEE_USER_ID, BAND_MASTER_USER_ID, MISSING_USER_ID],
+  describe('deleteBand', () => {
+    it('밴드장이 요청하면 deletedAt을 설정한다', async () => {
+      let capturedDeletedAt: Date | undefined;
+      const repository = createBandsRepositoryStub({
+        onDeleteBand(_bandId, deletedAt) {
+          capturedDeletedAt = deletedAt;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.deleteBand(BAND_MASTER_USER_ID, 'band-001');
+
+      expect(result.bandId).toBe('band-001');
+      expect(result.deletedAt).toBe(capturedDeletedAt?.toISOString());
+    });
+
+    it('밴드가 없거나 이미 삭제되었으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandForDelete: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.deleteBand(BAND_MASTER_USER_ID, 'band-missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('밴드장이 아니면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandForDelete: {
+          id: 'band-001',
+          bandMasterUserId: '22222222-2222-4222-8222-222222222222',
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.deleteBand(BAND_MASTER_USER_ID, 'band-001')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindBandForDelete(tx) {
+          capturedTransactions.push(tx);
+        },
+        onDeleteBand(_bandId, _deletedAt, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.deleteBand(BAND_MASTER_USER_ID, 'band-001', externalTx as never);
+
+      expect(capturedTransactions).toHaveLength(2);
+      expect(capturedTransactions[0]).toBe(externalTx);
+      expect(capturedTransactions[1]).toBe(externalTx);
+    });
   });
 
-  assert.deepEqual(result.band.invitations.success, [
-    {
-      userId: INVITEE_USER_ID,
-      invitationId: `invitation-${INVITEE_USER_ID}`,
-    },
-  ]);
-  assert.deepEqual(result.band.invitations.failed, [
-    {
-      userId: BAND_MASTER_USER_ID,
-      reason: '밴드 생성자는 초대 대상이 될 수 없습니다.',
-    },
-    {
-      userId: MISSING_USER_ID,
-      reason: '존재하지 않거나 비활성화된 사용자입니다.',
-    },
-  ]);
-});
+  describe('updateBandMemberRole', () => {
+    it('밴드장이 ADMIN 또는 MEMBER로 변경할 수 있다', async () => {
+      let capturedRole: BandMemberRole | undefined;
+      const repository = createBandsRepositoryStub({
+        onUpdateBandMemberRole(_bandMemberId, role) {
+          capturedRole = role;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
 
-test('밴드 생성 서비스는 검증과 생성을 같은 transaction client로 실행한다', async () => {
-  const capturedTransactions: unknown[] = [];
-  const repository = createBandsRepositoryStub({
-    onFindExistingGenreIds(tx) {
-      capturedTransactions.push(tx);
-    },
-    onFindExistingUserIds(tx) {
-      capturedTransactions.push(tx);
-    },
-    onCreateBand(_input, tx) {
-      capturedTransactions.push(tx);
-    },
+      const result = await service.updateBandMemberRole(BAND_MASTER_USER_ID, 'band-001', 'target-user-001', {
+        role: BandMemberRole.ADMIN,
+      });
+
+      expect(capturedRole).toBe(BandMemberRole.ADMIN);
+      expect(result.member.userId).toBe('target-user-001');
+      expect(result.member.role).toBe(BandMemberRole.ADMIN);
+    });
+
+    it('BM 권한 부여를 허용하지 않는다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.updateBandMemberRole(BAND_MASTER_USER_ID, 'band-001', 'target-user-001', {
+          role: BandMemberRole.BM,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('밴드가 없거나 삭제되었으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandForRoleUpdate: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.updateBandMemberRole(BAND_MASTER_USER_ID, 'band-missing', 'target-user-001', {
+          role: BandMemberRole.MEMBER,
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('밴드장이 아니면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandForRoleUpdate: {
+          id: 'band-001',
+          bandMasterUserId: '22222222-2222-4222-8222-222222222222',
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.updateBandMemberRole(BAND_MASTER_USER_ID, 'band-001', 'target-user-001', {
+          role: BandMemberRole.MEMBER,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('대상 멤버가 밴드에 없으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandMemberForRoleUpdate: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.updateBandMemberRole(BAND_MASTER_USER_ID, 'band-001', 'target-user-missing', {
+          role: BandMemberRole.MEMBER,
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindBandForRoleUpdate(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandMemberForRoleUpdate(tx) {
+          capturedTransactions.push(tx);
+        },
+        onUpdateBandMemberRole(_bandMemberId, _role, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.updateBandMemberRole(
+        BAND_MASTER_USER_ID,
+        'band-001',
+        'target-user-001',
+        {
+          role: BandMemberRole.MEMBER,
+        },
+        externalTx as never,
+      );
+
+      expect(capturedTransactions).toHaveLength(3);
+      expect(capturedTransactions[0]).toBe(externalTx);
+      expect(capturedTransactions[1]).toBe(externalTx);
+      expect(capturedTransactions[2]).toBe(externalTx);
+    });
   });
-  const service = new BandsService(repository, createPrismaServiceStub());
-
-  await service.createBand(BAND_MASTER_USER_ID, {
-    name: '합주하자',
-    visibility: true,
-    genreIds: [ROCK_GENRE_ID],
-    inviteeUserIds: [INVITEE_USER_ID],
-  });
-
-  assert.equal(capturedTransactions.length, 3);
-  assert.equal(capturedTransactions[0], capturedTransactions[1]);
-  assert.equal(capturedTransactions[1], capturedTransactions[2]);
-});
-
-test('밴드 생성 서비스는 외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
-  const externalTx = {
-    transactionClient: true,
-  };
-  const capturedTransactions: unknown[] = [];
-  const repository = createBandsRepositoryStub({
-    onFindExistingGenreIds(tx) {
-      capturedTransactions.push(tx);
-    },
-    onFindExistingUserIds(tx) {
-      capturedTransactions.push(tx);
-    },
-    onCreateBand(_input, tx) {
-      capturedTransactions.push(tx);
-    },
-  });
-  const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
-
-  await service.createBand(
-    BAND_MASTER_USER_ID,
-    {
-      name: '합주하자',
-      visibility: true,
-      genreIds: [ROCK_GENRE_ID],
-      inviteeUserIds: [INVITEE_USER_ID],
-    },
-    externalTx as never,
-  );
-
-  assert.equal(capturedTransactions.length, 3);
-  assert.equal(capturedTransactions[0], externalTx);
-  assert.equal(capturedTransactions[1], externalTx);
-  assert.equal(capturedTransactions[2], externalTx);
-});
-
-test('밴드 삭제 서비스는 밴드장이 요청하면 deletedAt을 설정한다', async () => {
-  let capturedDeletedAt: Date | undefined;
-  const repository = createBandsRepositoryStub({
-    onDeleteBand(_bandId, deletedAt) {
-      capturedDeletedAt = deletedAt;
-    },
-  });
-  const service = new BandsService(repository, createPrismaServiceStub());
-
-  const result = await service.deleteBand(BAND_MASTER_USER_ID, 'band-001');
-
-  assert.equal(result.bandId, 'band-001');
-  assert.equal(result.deletedAt, capturedDeletedAt?.toISOString());
-});
-
-test('밴드 삭제 서비스는 밴드가 없거나 이미 삭제되었으면 예외를 던진다', async () => {
-  const repository = createBandsRepositoryStub({
-    bandForDelete: null,
-  });
-  const service = new BandsService(repository, createPrismaServiceStub());
-
-  await assert.rejects(async () => service.deleteBand(BAND_MASTER_USER_ID, 'band-missing'), NotFoundException);
-});
-
-test('밴드 삭제 서비스는 밴드장이 아니면 예외를 던진다', async () => {
-  const repository = createBandsRepositoryStub({
-    bandForDelete: {
-      id: 'band-001',
-      bandMasterUserId: '22222222-2222-4222-8222-222222222222',
-    },
-  });
-  const service = new BandsService(repository, createPrismaServiceStub());
-
-  await assert.rejects(async () => service.deleteBand(BAND_MASTER_USER_ID, 'band-001'), ForbiddenException);
-});
-
-test('밴드 삭제 서비스는 외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
-  const externalTx = {
-    transactionClient: true,
-  };
-  const capturedTransactions: unknown[] = [];
-  const repository = createBandsRepositoryStub({
-    onFindBandForDelete(tx) {
-      capturedTransactions.push(tx);
-    },
-    onDeleteBand(_bandId, _deletedAt, tx) {
-      capturedTransactions.push(tx);
-    },
-  });
-  const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
-
-  await service.deleteBand(BAND_MASTER_USER_ID, 'band-001', externalTx as never);
-
-  assert.equal(capturedTransactions.length, 2);
-  assert.equal(capturedTransactions[0], externalTx);
-  assert.equal(capturedTransactions[1], externalTx);
 });

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -18,7 +18,7 @@ const MISSING_USER_ID = '55555555-5555-4555-8555-555555555555';
 function createBandsRepositoryStub(options?: {
   existingGenreIds?: string[];
   existingUserIds?: string[];
-  bandForDelete?: {
+  activeBand?: {
     id: string;
     bandMasterUserId: string;
   } | null;
@@ -33,27 +33,17 @@ function createBandsRepositoryStub(options?: {
     id: string;
     requesterMemberId: string | null;
   } | null;
-  bandForRoleUpdate?: {
-    id: string;
-    bandMasterUserId: string;
-  } | null;
-  bandForUpdate?: {
-    id: string;
-    bandMasterUserId: string;
-  } | null;
   bandMemberForRoleUpdate?: {
     id: string;
     userId: string;
   } | null;
   onCreateBand?: (input: CreateBandRepositoryInput, tx: unknown) => void;
   onDeleteBand?: (bandId: string, deletedAt: Date, tx: unknown) => void;
-  onFindBandForDelete?: (tx: unknown) => void;
+  onFindActiveBandById?: (tx: unknown) => void;
   onFindBandForLeave?: (tx: unknown) => void;
   onFindBandForMemberList?: (bandId: string, requesterUserId: string, tx: unknown) => void;
-  onFindBandForRoleUpdate?: (tx: unknown) => void;
   onFindBandMemberForRoleUpdate?: (tx: unknown) => void;
   onFindBandMembers?: (bandId: string, query: GetBandMembersQuery, tx: unknown) => void;
-  onFindBandForUpdate?: (tx: unknown) => void;
   onFindExistingGenreIds?: (tx: unknown) => void;
   onFindExistingUserIds?: (tx: unknown) => void;
   onFindMyBands?: (userId: string, query: GetMyBandsQuery, tx: unknown) => void;
@@ -97,11 +87,11 @@ function createBandsRepositoryStub(options?: {
         deletedAt: deletedAt.toISOString(),
       };
     },
-    async findBandForDelete(_bandId, tx) {
-      options?.onFindBandForDelete?.(tx);
+    async findActiveBandById(_bandId, tx) {
+      options?.onFindActiveBandById?.(tx);
 
-      if (options?.bandForDelete !== undefined) {
-        return options.bandForDelete;
+      if (options?.activeBand !== undefined) {
+        return options.activeBand;
       }
 
       return {
@@ -235,18 +225,6 @@ function createBandsRepositoryStub(options?: {
         },
       };
     },
-    async findBandForUpdate(_bandId, tx) {
-      options?.onFindBandForUpdate?.(tx);
-
-      if (options?.bandForUpdate !== undefined) {
-        return options.bandForUpdate;
-      }
-
-      return {
-        id: 'band-001',
-        bandMasterUserId: BAND_MASTER_USER_ID,
-      };
-    },
     async updateBand(bandId, input, tx) {
       options?.onUpdateBand?.(bandId, input, tx);
 
@@ -257,18 +235,6 @@ function createBandsRepositoryStub(options?: {
         visibility: input.visibility ?? true,
         coverImgUrl: input.coverImgUrl ?? null,
         updatedAt: '2026-04-10T12:00:00.000Z',
-      };
-    },
-    async findBandForMemberRoleUpdate(_bandId, tx) {
-      options?.onFindBandForRoleUpdate?.(tx);
-
-      if (options?.bandForRoleUpdate !== undefined) {
-        return options.bandForRoleUpdate;
-      }
-
-      return {
-        id: 'band-001',
-        bandMasterUserId: BAND_MASTER_USER_ID,
       };
     },
     async findBandMemberForRoleUpdate(_bandId, userId, tx) {
@@ -507,7 +473,7 @@ describe('BandsService', () => {
 
     it('밴드가 없거나 이미 삭제되었으면 예외를 던진다', async () => {
       const repository = createBandsRepositoryStub({
-        bandForDelete: null,
+        activeBand: null,
       });
       const service = new BandsService(repository, createPrismaServiceStub());
 
@@ -516,7 +482,7 @@ describe('BandsService', () => {
 
     it('밴드장이 아니면 예외를 던진다', async () => {
       const repository = createBandsRepositoryStub({
-        bandForDelete: {
+        activeBand: {
           id: 'band-001',
           bandMasterUserId: '22222222-2222-4222-8222-222222222222',
         },
@@ -532,7 +498,7 @@ describe('BandsService', () => {
       };
       const capturedTransactions: unknown[] = [];
       const repository = createBandsRepositoryStub({
-        onFindBandForDelete(tx) {
+        onFindActiveBandById(tx) {
           capturedTransactions.push(tx);
         },
         onDeleteBand(_bandId, _deletedAt, tx) {
@@ -990,7 +956,7 @@ describe('BandsService', () => {
 
     it('밴드가 없거나 삭제되었으면 예외를 던진다', async () => {
       const repository = createBandsRepositoryStub({
-        bandForUpdate: null,
+        activeBand: null,
       });
       const service = new BandsService(repository, createPrismaServiceStub());
 
@@ -1003,7 +969,7 @@ describe('BandsService', () => {
 
     it('밴드장이 아니면 예외를 던진다', async () => {
       const repository = createBandsRepositoryStub({
-        bandForUpdate: {
+        activeBand: {
           id: 'band-001',
           bandMasterUserId: '22222222-2222-4222-8222-222222222222',
         },
@@ -1023,7 +989,7 @@ describe('BandsService', () => {
       };
       const capturedTransactions: unknown[] = [];
       const repository = createBandsRepositoryStub({
-        onFindBandForUpdate(tx) {
+        onFindActiveBandById(tx) {
           capturedTransactions.push(tx);
         },
         onUpdateBand(_bandId, _input, tx) {
@@ -1079,7 +1045,7 @@ describe('BandsService', () => {
 
     it('밴드가 없거나 삭제되었으면 예외를 던진다', async () => {
       const repository = createBandsRepositoryStub({
-        bandForRoleUpdate: null,
+        activeBand: null,
       });
       const service = new BandsService(repository, createPrismaServiceStub());
 
@@ -1092,7 +1058,7 @@ describe('BandsService', () => {
 
     it('밴드장이 아니면 예외를 던진다', async () => {
       const repository = createBandsRepositoryStub({
-        bandForRoleUpdate: {
+        activeBand: {
           id: 'band-001',
           bandMasterUserId: '22222222-2222-4222-8222-222222222222',
         },
@@ -1125,7 +1091,7 @@ describe('BandsService', () => {
       };
       const capturedTransactions: unknown[] = [];
       const repository = createBandsRepositoryStub({
-        onFindBandForRoleUpdate(tx) {
+        onFindActiveBandById(tx) {
           capturedTransactions.push(tx);
         },
         onFindBandMemberForRoleUpdate(tx) {

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException, ForbiddenException, NotFoundException } from '@nes
 import type { PrismaService } from 'src/database/prisma';
 import { BandMemberRole } from 'src/generated/prisma';
 
+import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
 import type { BandsRepository, CreateBandRepositoryInput } from './repositories/bands.repository';
 import { BandsService } from './bands.service';
@@ -19,6 +20,10 @@ function createBandsRepositoryStub(options?: {
     id: string;
     bandMasterUserId: string;
   } | null;
+  bandForMemberList?: {
+    id: string;
+    requesterMemberId: string | null;
+  } | null;
   bandForRoleUpdate?: {
     id: string;
     bandMasterUserId: string;
@@ -30,8 +35,10 @@ function createBandsRepositoryStub(options?: {
   onCreateBand?: (input: CreateBandRepositoryInput, tx: unknown) => void;
   onDeleteBand?: (bandId: string, deletedAt: Date, tx: unknown) => void;
   onFindBandForDelete?: (tx: unknown) => void;
+  onFindBandForMemberList?: (bandId: string, requesterUserId: string, tx: unknown) => void;
   onFindBandForRoleUpdate?: (tx: unknown) => void;
   onFindBandMemberForRoleUpdate?: (tx: unknown) => void;
+  onFindBandMembers?: (bandId: string, query: GetBandMembersQuery, tx: unknown) => void;
   onFindExistingGenreIds?: (tx: unknown) => void;
   onFindExistingUserIds?: (tx: unknown) => void;
   onFindMyBands?: (userId: string, query: GetMyBandsQuery, tx: unknown) => void;
@@ -82,6 +89,52 @@ function createBandsRepositoryStub(options?: {
       return {
         id: 'band-001',
         bandMasterUserId: BAND_MASTER_USER_ID,
+      };
+    },
+    async findBandForMemberList(bandId, requesterUserId, tx) {
+      options?.onFindBandForMemberList?.(bandId, requesterUserId, tx);
+
+      if (options?.bandForMemberList !== undefined) {
+        return options.bandForMemberList;
+      }
+
+      return {
+        id: bandId,
+        requesterMemberId: 'band-member-requester',
+      };
+    },
+    async findBandMembers(bandId, query, tx) {
+      options?.onFindBandMembers?.(bandId, query, tx);
+
+      return {
+        bandId,
+        members: [
+          {
+            bandMemberId: 'band-member-001',
+            userId: BAND_MASTER_USER_ID,
+            nickname: 'Jun',
+            avatarUrl: null,
+            role: BandMemberRole.BM,
+            joinedAt: '2026-04-10T00:00:00.000Z',
+            skills: [
+              {
+                skillTypeId: 'skill-type-001',
+                skillName: 'Guitar',
+                skillLevel: 'ADVANCED',
+                isPrimary: true,
+              },
+            ],
+          },
+        ],
+        meta: {
+          count: 1,
+          take: query.take,
+          cursor: {
+            joinedAt: '2026-04-10T00:00:00.000Z',
+            id: 'band-member-001',
+          },
+          next: null,
+        },
       };
     },
     async findMyBands(userId, query, tx) {
@@ -445,6 +498,140 @@ describe('BandsService', () => {
       );
 
       expect(capturedTransaction).toBe(externalTx);
+    });
+  });
+
+  describe('getBandMembers', () => {
+    it('밴드 멤버가 요청하면 밴드 멤버 목록을 조회한다', async () => {
+      let capturedBandId: string | undefined;
+      let capturedQuery: GetBandMembersQuery | undefined;
+      const query: GetBandMembersQuery = {
+        order__joined_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      };
+      const repository = createBandsRepositoryStub({
+        onFindBandMembers(bandId, inputQuery) {
+          capturedBandId = bandId;
+          capturedQuery = inputQuery;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.getBandMembers(BAND_MASTER_USER_ID, 'band-001', query);
+
+      expect(capturedBandId).toBe('band-001');
+      expect(capturedQuery).toBe(query);
+      expect(result.bandId).toBe('band-001');
+      expect(result.members).toHaveLength(1);
+      expect(result.members[0].skills[0].skillName).toBe('Guitar');
+      expect(result.meta.take).toBe(20);
+    });
+
+    it('밴드가 없거나 삭제되었으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandForMemberList: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.getBandMembers(BAND_MASTER_USER_ID, 'band-missing', {
+          order__joined_at: 'desc',
+          order__id: 'desc',
+          take: 20,
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('밴드 멤버가 아니면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandForMemberList: {
+          id: 'band-001',
+          requesterMemberId: null,
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.getBandMembers(BAND_MASTER_USER_ID, 'band-001', {
+          order__joined_at: 'desc',
+          order__id: 'desc',
+          take: 20,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('정렬 방향이 서로 다르면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.getBandMembers(BAND_MASTER_USER_ID, 'band-001', {
+          order__joined_at: 'desc',
+          order__id: 'asc',
+          take: 20,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('커서 가입일과 ID는 함께 입력해야 한다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.getBandMembers(BAND_MASTER_USER_ID, 'band-001', {
+          order__joined_at: 'desc',
+          order__id: 'desc',
+          take: 20,
+          cursor__joined_at: '2026-04-10T00:00:00.000Z',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('커서 가입일이 유효하지 않으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.getBandMembers(BAND_MASTER_USER_ID, 'band-001', {
+          order__joined_at: 'desc',
+          order__id: 'desc',
+          take: 20,
+          cursor__joined_at: 'invalid-date',
+          cursor__id: '11111111-1111-4111-8111-111111111111',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('외부 transaction client를 repository로 전달한다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindBandForMemberList(_bandId, _requesterUserId, tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandMembers(_bandId, _query, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.getBandMembers(
+        BAND_MASTER_USER_ID,
+        'band-001',
+        {
+          order__joined_at: 'desc',
+          order__id: 'desc',
+          take: 20,
+        },
+        externalTx as never,
+      );
+
+      expect(capturedTransactions).toHaveLength(2);
+      expect(capturedTransactions[0]).toBe(externalTx);
+      expect(capturedTransactions[1]).toBe(externalTx);
     });
   });
 

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -22,6 +22,13 @@ function createBandsRepositoryStub(options?: {
     id: string;
     bandMasterUserId: string;
   } | null;
+  bandForLeave?: {
+    id: string;
+    member: {
+      id: string;
+      role: BandMemberRole;
+    } | null;
+  } | null;
   bandForMemberList?: {
     id: string;
     requesterMemberId: string | null;
@@ -41,6 +48,7 @@ function createBandsRepositoryStub(options?: {
   onCreateBand?: (input: CreateBandRepositoryInput, tx: unknown) => void;
   onDeleteBand?: (bandId: string, deletedAt: Date, tx: unknown) => void;
   onFindBandForDelete?: (tx: unknown) => void;
+  onFindBandForLeave?: (tx: unknown) => void;
   onFindBandForMemberList?: (bandId: string, requesterUserId: string, tx: unknown) => void;
   onFindBandForRoleUpdate?: (tx: unknown) => void;
   onFindBandMemberForRoleUpdate?: (tx: unknown) => void;
@@ -49,6 +57,7 @@ function createBandsRepositoryStub(options?: {
   onFindExistingGenreIds?: (tx: unknown) => void;
   onFindExistingUserIds?: (tx: unknown) => void;
   onFindMyBands?: (userId: string, query: GetMyBandsQuery, tx: unknown) => void;
+  onLeaveBand?: (bandMemberId: string, tx: unknown) => void;
   onSearchBands?: (query: SearchBandsQuery, tx: unknown) => void;
   onUpdateBand?: (bandId: string, input: UpdateBandInput, tx: unknown) => void;
   onUpdateBandMemberRole?: (bandMemberId: string, role: BandMemberRole, tx: unknown) => void;
@@ -98,6 +107,29 @@ function createBandsRepositoryStub(options?: {
       return {
         id: 'band-001',
         bandMasterUserId: BAND_MASTER_USER_ID,
+      };
+    },
+    async findBandForLeave(_bandId, _userId, tx) {
+      options?.onFindBandForLeave?.(tx);
+
+      if (options?.bandForLeave !== undefined) {
+        return options.bandForLeave;
+      }
+
+      return {
+        id: 'band-001',
+        member: {
+          id: 'band-member-001',
+          role: BandMemberRole.MEMBER,
+        },
+      };
+    },
+    async leaveBand(bandMemberId, tx) {
+      options?.onLeaveBand?.(bandMemberId, tx);
+
+      return {
+        bandId: 'band-001',
+        userId: INVITEE_USER_ID,
       };
     },
     async findBandForMemberList(bandId, requesterUserId, tx) {
@@ -484,6 +516,84 @@ describe('BandsService', () => {
       const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
 
       await service.deleteBand(BAND_MASTER_USER_ID, 'band-001', externalTx as never);
+
+      expect(capturedTransactions).toHaveLength(2);
+      expect(capturedTransactions[0]).toBe(externalTx);
+      expect(capturedTransactions[1]).toBe(externalTx);
+    });
+  });
+
+  describe('leaveBand', () => {
+    it('일반 멤버가 밴드를 나가면 멤버십을 삭제한다', async () => {
+      let capturedBandMemberId: string | undefined;
+      const repository = createBandsRepositoryStub({
+        onLeaveBand(bandMemberId) {
+          capturedBandMemberId = bandMemberId;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.leaveBand(INVITEE_USER_ID, 'band-001');
+
+      expect(capturedBandMemberId).toBe('band-member-001');
+      expect(result).toEqual({
+        bandId: 'band-001',
+        userId: INVITEE_USER_ID,
+      });
+    });
+
+    it('밴드가 없거나 삭제되었으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandForLeave: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.leaveBand(INVITEE_USER_ID, 'band-missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('밴드 멤버가 아니면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandForLeave: {
+          id: 'band-001',
+          member: null,
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.leaveBand(INVITEE_USER_ID, 'band-001')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('밴드장은 이 API로 밴드를 나갈 수 없다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandForLeave: {
+          id: 'band-001',
+          member: {
+            id: 'band-member-001',
+            role: BandMemberRole.BM,
+          },
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.leaveBand(BAND_MASTER_USER_ID, 'band-001')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindBandForLeave(tx) {
+          capturedTransactions.push(tx);
+        },
+        onLeaveBand(_bandMemberId, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.leaveBand(INVITEE_USER_ID, 'band-001', externalTx as never);
 
       expect(capturedTransactions).toHaveLength(2);
       expect(capturedTransactions[0]).toBe(externalTx);

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -42,7 +42,7 @@ function createBandsRepositoryStub(options?: {
   onFindActiveBandById?: (tx: unknown) => void;
   onFindBandForLeave?: (tx: unknown) => void;
   onFindBandForMemberList?: (bandId: string, requesterUserId: string, tx: unknown) => void;
-  onFindBandMemberForRoleUpdate?: (tx: unknown) => void;
+  onFindBandMemberByBandIdAndUserId?: (tx: unknown) => void;
   onFindBandMembers?: (bandId: string, query: GetBandMembersQuery, tx: unknown) => void;
   onFindExistingGenreIds?: (tx: unknown) => void;
   onFindExistingUserIds?: (tx: unknown) => void;
@@ -237,8 +237,8 @@ function createBandsRepositoryStub(options?: {
         updatedAt: '2026-04-10T12:00:00.000Z',
       };
     },
-    async findBandMemberForRoleUpdate(_bandId, userId, tx) {
-      options?.onFindBandMemberForRoleUpdate?.(tx);
+    async findBandMemberByBandIdAndUserId(_bandId, userId, tx) {
+      options?.onFindBandMemberByBandIdAndUserId?.(tx);
 
       if (options?.bandMemberForRoleUpdate !== undefined) {
         return options.bandMemberForRoleUpdate;
@@ -1094,7 +1094,7 @@ describe('BandsService', () => {
         onFindActiveBandById(tx) {
           capturedTransactions.push(tx);
         },
-        onFindBandMemberForRoleUpdate(tx) {
+        onFindBandMemberByBandIdAndUserId(tx) {
           capturedTransactions.push(tx);
         },
         onUpdateBandMemberRole(_bandMemberId, _role, tx) {

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -342,8 +342,8 @@ describe('BandsService', () => {
         description: '주 1회 합주하는 밴드입니다.',
         visibility: true,
         coverImgUrl: 'https://cdn.example.com/bands/cover.png',
-        genreIds: [ROCK_GENRE_ID, ROCK_GENRE_ID, JAZZ_GENRE_ID],
-        inviteeUserIds: [INVITEE_USER_ID, INVITEE_USER_ID],
+        genreIds: [ROCK_GENRE_ID, JAZZ_GENRE_ID],
+        inviteeUserIds: [INVITEE_USER_ID],
       });
 
       expect(capturedInput?.bandMasterUserId).toBe(BAND_MASTER_USER_ID);
@@ -353,6 +353,32 @@ describe('BandsService', () => {
       expect(result.band.genres).toHaveLength(2);
       expect(result.band.invitations.success).toHaveLength(1);
       expect(result.band.invitations.failed).toHaveLength(0);
+    });
+
+    it('중복된 장르가 있으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.createBand(BAND_MASTER_USER_ID, {
+          name: '합주하자',
+          visibility: true,
+          genreIds: [ROCK_GENRE_ID, ROCK_GENRE_ID],
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('중복된 초대 대상이 있으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.createBand(BAND_MASTER_USER_ID, {
+          name: '합주하자',
+          visibility: true,
+          inviteeUserIds: [INVITEE_USER_ID, INVITEE_USER_ID],
+        }),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('존재하지 않는 장르가 있으면 예외를 던진다', async () => {

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -1,0 +1,218 @@
+import assert from 'node:assert/strict';
+
+import { BadRequestException } from '@nestjs/common';
+import test from 'node:test';
+
+import type { PrismaService } from '../../database/prisma';
+
+import type { BandsRepository, CreateBandRepositoryInput } from './repositories/bands.repository';
+import { BandsService } from './bands.service';
+
+const BAND_MASTER_USER_ID = '11111111-1111-4111-8111-111111111111';
+const ROCK_GENRE_ID = '22222222-2222-4222-8222-222222222222';
+const JAZZ_GENRE_ID = '33333333-3333-4333-8333-333333333333';
+const INVITEE_USER_ID = '44444444-4444-4444-8444-444444444444';
+const MISSING_USER_ID = '55555555-5555-4555-8555-555555555555';
+
+function createBandsRepositoryStub(options?: {
+  existingGenreIds?: string[];
+  existingUserIds?: string[];
+  onCreateBand?: (input: CreateBandRepositoryInput, tx: unknown) => void;
+  onFindExistingGenreIds?: (tx: unknown) => void;
+  onFindExistingUserIds?: (tx: unknown) => void;
+}): BandsRepository {
+  return {
+    async createBand(input, tx) {
+      options?.onCreateBand?.(input, tx);
+
+      return {
+        band: {
+          id: 'band-001',
+          name: input.name,
+          description: input.description ?? null,
+          visibility: input.visibility,
+          coverImgUrl: input.coverImgUrl ?? null,
+          genres: input.genreIds.map(genreId => ({
+            id: genreId,
+            name: genreId === ROCK_GENRE_ID ? 'rock' : 'jazz',
+          })),
+          bandMasterUserId: input.bandMasterUserId,
+          createdAt: '2026-03-03T09:20:10.123Z',
+          invitations: {
+            success: input.inviteeUserIds.map(userId => ({
+              userId,
+              invitationId: `invitation-${userId}`,
+            })),
+            failed: [],
+          },
+        },
+      };
+    },
+    async findExistingGenreIds(genreIds, tx) {
+      options?.onFindExistingGenreIds?.(tx);
+
+      return options?.existingGenreIds ?? genreIds;
+    },
+    async findExistingUserIds(userIds, tx) {
+      options?.onFindExistingUserIds?.(tx);
+
+      return options?.existingUserIds ?? userIds;
+    },
+  };
+}
+
+function createPrismaServiceStub(): PrismaService {
+  const tx = {
+    transactionClient: true,
+  };
+
+  return {
+    async $transaction(callback: (tx: unknown) => Promise<unknown>) {
+      return callback(tx);
+    },
+  } as PrismaService;
+}
+
+function createPrismaServiceFailingTransactionStub(): PrismaService {
+  return {
+    async $transaction() {
+      throw new Error('외부 tx가 있으면 새 transaction을 열지 않아야 합니다.');
+    },
+  } as unknown as PrismaService;
+}
+
+test('밴드 생성 서비스는 인증 사용자를 밴드장으로 사용하고 생성 결과를 반환한다', async () => {
+  let capturedInput: CreateBandRepositoryInput | undefined;
+  const repository = createBandsRepositoryStub({
+    onCreateBand(input) {
+      capturedInput = input;
+    },
+  });
+  const service = new BandsService(repository, createPrismaServiceStub());
+
+  const result = await service.createBand(BAND_MASTER_USER_ID, {
+    name: '합주하자',
+    description: '주 1회 합주하는 밴드입니다.',
+    visibility: true,
+    coverImgUrl: 'https://cdn.example.com/bands/cover.png',
+    genreIds: [ROCK_GENRE_ID, ROCK_GENRE_ID, JAZZ_GENRE_ID],
+    inviteeUserIds: [INVITEE_USER_ID, INVITEE_USER_ID],
+  });
+
+  assert.equal(capturedInput?.bandMasterUserId, BAND_MASTER_USER_ID);
+  assert.deepEqual(capturedInput?.genreIds, [ROCK_GENRE_ID, JAZZ_GENRE_ID]);
+  assert.deepEqual(capturedInput?.inviteeUserIds, [INVITEE_USER_ID]);
+  assert.equal(result.band.name, '합주하자');
+  assert.equal(result.band.genres.length, 2);
+  assert.equal(result.band.invitations.success.length, 1);
+  assert.equal(result.band.invitations.failed.length, 0);
+});
+
+test('밴드 생성 서비스는 존재하지 않는 장르가 있으면 예외를 던진다', async () => {
+  const repository = createBandsRepositoryStub({
+    existingGenreIds: [ROCK_GENRE_ID],
+  });
+  const service = new BandsService(repository, createPrismaServiceStub());
+
+  await assert.rejects(
+    async () =>
+      service.createBand(BAND_MASTER_USER_ID, {
+        name: '합주하자',
+        visibility: true,
+        genreIds: [ROCK_GENRE_ID, JAZZ_GENRE_ID],
+      }),
+    BadRequestException,
+  );
+});
+
+test('밴드 생성 서비스는 초대할 수 없는 사용자를 실패 목록으로 분리한다', async () => {
+  const repository = createBandsRepositoryStub({
+    existingUserIds: [INVITEE_USER_ID],
+  });
+  const service = new BandsService(repository, createPrismaServiceStub());
+
+  const result = await service.createBand(BAND_MASTER_USER_ID, {
+    name: '합주하자',
+    visibility: true,
+    inviteeUserIds: [INVITEE_USER_ID, BAND_MASTER_USER_ID, MISSING_USER_ID],
+  });
+
+  assert.deepEqual(result.band.invitations.success, [
+    {
+      userId: INVITEE_USER_ID,
+      invitationId: `invitation-${INVITEE_USER_ID}`,
+    },
+  ]);
+  assert.deepEqual(result.band.invitations.failed, [
+    {
+      userId: BAND_MASTER_USER_ID,
+      reason: '밴드 생성자는 초대 대상이 될 수 없습니다.',
+    },
+    {
+      userId: MISSING_USER_ID,
+      reason: '존재하지 않거나 비활성화된 사용자입니다.',
+    },
+  ]);
+});
+
+test('밴드 생성 서비스는 검증과 생성을 같은 transaction client로 실행한다', async () => {
+  const capturedTransactions: unknown[] = [];
+  const repository = createBandsRepositoryStub({
+    onFindExistingGenreIds(tx) {
+      capturedTransactions.push(tx);
+    },
+    onFindExistingUserIds(tx) {
+      capturedTransactions.push(tx);
+    },
+    onCreateBand(_input, tx) {
+      capturedTransactions.push(tx);
+    },
+  });
+  const service = new BandsService(repository, createPrismaServiceStub());
+
+  await service.createBand(BAND_MASTER_USER_ID, {
+    name: '합주하자',
+    visibility: true,
+    genreIds: [ROCK_GENRE_ID],
+    inviteeUserIds: [INVITEE_USER_ID],
+  });
+
+  assert.equal(capturedTransactions.length, 3);
+  assert.equal(capturedTransactions[0], capturedTransactions[1]);
+  assert.equal(capturedTransactions[1], capturedTransactions[2]);
+});
+
+test('밴드 생성 서비스는 외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
+  const externalTx = {
+    transactionClient: true,
+  };
+  const capturedTransactions: unknown[] = [];
+  const repository = createBandsRepositoryStub({
+    onFindExistingGenreIds(tx) {
+      capturedTransactions.push(tx);
+    },
+    onFindExistingUserIds(tx) {
+      capturedTransactions.push(tx);
+    },
+    onCreateBand(_input, tx) {
+      capturedTransactions.push(tx);
+    },
+  });
+  const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+  await service.createBand(
+    BAND_MASTER_USER_ID,
+    {
+      name: '합주하자',
+      visibility: true,
+      genreIds: [ROCK_GENRE_ID],
+      inviteeUserIds: [INVITEE_USER_ID],
+    },
+    externalTx as never,
+  );
+
+  assert.equal(capturedTransactions.length, 3);
+  assert.equal(capturedTransactions[0], externalTx);
+  assert.equal(capturedTransactions[1], externalTx);
+  assert.equal(capturedTransactions[2], externalTx);
+});

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import test from 'node:test';
 
 import type { PrismaService } from '../../database/prisma';
@@ -17,7 +17,13 @@ const MISSING_USER_ID = '55555555-5555-4555-8555-555555555555';
 function createBandsRepositoryStub(options?: {
   existingGenreIds?: string[];
   existingUserIds?: string[];
+  bandForDelete?: {
+    id: string;
+    bandMasterUserId: string;
+  } | null;
   onCreateBand?: (input: CreateBandRepositoryInput, tx: unknown) => void;
+  onDeleteBand?: (bandId: string, deletedAt: Date, tx: unknown) => void;
+  onFindBandForDelete?: (tx: unknown) => void;
   onFindExistingGenreIds?: (tx: unknown) => void;
   onFindExistingUserIds?: (tx: unknown) => void;
 }): BandsRepository {
@@ -46,6 +52,26 @@ function createBandsRepositoryStub(options?: {
             failed: [],
           },
         },
+      };
+    },
+    async deleteBand(bandId, deletedAt, tx) {
+      options?.onDeleteBand?.(bandId, deletedAt, tx);
+
+      return {
+        bandId,
+        deletedAt: deletedAt.toISOString(),
+      };
+    },
+    async findBandForDelete(_bandId, tx) {
+      options?.onFindBandForDelete?.(tx);
+
+      if (options?.bandForDelete !== undefined) {
+        return options.bandForDelete;
+      }
+
+      return {
+        id: 'band-001',
+        bandMasterUserId: BAND_MASTER_USER_ID,
       };
     },
     async findExistingGenreIds(genreIds, tx) {
@@ -215,4 +241,62 @@ test('밴드 생성 서비스는 외부 transaction client가 있으면 새 tran
   assert.equal(capturedTransactions[0], externalTx);
   assert.equal(capturedTransactions[1], externalTx);
   assert.equal(capturedTransactions[2], externalTx);
+});
+
+test('밴드 삭제 서비스는 밴드장이 요청하면 deletedAt을 설정한다', async () => {
+  let capturedDeletedAt: Date | undefined;
+  const repository = createBandsRepositoryStub({
+    onDeleteBand(_bandId, deletedAt) {
+      capturedDeletedAt = deletedAt;
+    },
+  });
+  const service = new BandsService(repository, createPrismaServiceStub());
+
+  const result = await service.deleteBand(BAND_MASTER_USER_ID, 'band-001');
+
+  assert.equal(result.bandId, 'band-001');
+  assert.equal(result.deletedAt, capturedDeletedAt?.toISOString());
+});
+
+test('밴드 삭제 서비스는 밴드가 없거나 이미 삭제되었으면 예외를 던진다', async () => {
+  const repository = createBandsRepositoryStub({
+    bandForDelete: null,
+  });
+  const service = new BandsService(repository, createPrismaServiceStub());
+
+  await assert.rejects(async () => service.deleteBand(BAND_MASTER_USER_ID, 'band-missing'), NotFoundException);
+});
+
+test('밴드 삭제 서비스는 밴드장이 아니면 예외를 던진다', async () => {
+  const repository = createBandsRepositoryStub({
+    bandForDelete: {
+      id: 'band-001',
+      bandMasterUserId: '22222222-2222-4222-8222-222222222222',
+    },
+  });
+  const service = new BandsService(repository, createPrismaServiceStub());
+
+  await assert.rejects(async () => service.deleteBand(BAND_MASTER_USER_ID, 'band-001'), ForbiddenException);
+});
+
+test('밴드 삭제 서비스는 외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
+  const externalTx = {
+    transactionClient: true,
+  };
+  const capturedTransactions: unknown[] = [];
+  const repository = createBandsRepositoryStub({
+    onFindBandForDelete(tx) {
+      capturedTransactions.push(tx);
+    },
+    onDeleteBand(_bandId, _deletedAt, tx) {
+      capturedTransactions.push(tx);
+    },
+  });
+  const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+  await service.deleteBand(BAND_MASTER_USER_ID, 'band-001', externalTx as never);
+
+  assert.equal(capturedTransactions.length, 2);
+  assert.equal(capturedTransactions[0], externalTx);
+  assert.equal(capturedTransactions[1], externalTx);
 });

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -4,6 +4,7 @@ import { BandMemberRole } from 'src/generated/prisma';
 
 import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
+import type { SearchBandsQuery } from './dto/search-bands-query.dto';
 import type { BandsRepository, CreateBandRepositoryInput } from './repositories/bands.repository';
 import { BandsService } from './bands.service';
 
@@ -42,6 +43,7 @@ function createBandsRepositoryStub(options?: {
   onFindExistingGenreIds?: (tx: unknown) => void;
   onFindExistingUserIds?: (tx: unknown) => void;
   onFindMyBands?: (userId: string, query: GetMyBandsQuery, tx: unknown) => void;
+  onSearchBands?: (query: SearchBandsQuery, tx: unknown) => void;
   onUpdateBandMemberRole?: (bandMemberId: string, role: BandMemberRole, tx: unknown) => void;
 }): BandsRepository {
   return {
@@ -158,6 +160,36 @@ function createBandsRepositoryStub(options?: {
           take: query.take,
           cursor: {
             createdAt: '2026-03-01T12:00:00.000Z',
+            id: 'band-001',
+          },
+          next: null,
+        },
+      };
+    },
+    async searchBands(query, tx) {
+      options?.onSearchBands?.(query, tx);
+
+      return {
+        keyword: query.where__name__contain ?? null,
+        items: [
+          {
+            bandId: 'band-001',
+            name: 'Rocking Stars',
+            description: '주 1회 합주하는 직장인 밴드',
+            visibility: true,
+            memberCount: 5,
+            bandMaster: {
+              userId: BAND_MASTER_USER_ID,
+              nickname: 'Jun',
+            },
+            createdAt: '2026-04-10T00:00:00.000Z',
+          },
+        ],
+        meta: {
+          count: 1,
+          take: query.take,
+          cursor: {
+            createdAt: '2026-04-10T00:00:00.000Z',
             id: 'band-001',
           },
           next: null,
@@ -632,6 +664,98 @@ describe('BandsService', () => {
       expect(capturedTransactions).toHaveLength(2);
       expect(capturedTransactions[0]).toBe(externalTx);
       expect(capturedTransactions[1]).toBe(externalTx);
+    });
+  });
+
+  describe('searchBands', () => {
+    it('공개 밴드를 이름 기준으로 검색한다', async () => {
+      let capturedQuery: SearchBandsQuery | undefined;
+      const query: SearchBandsQuery = {
+        where__name__contain: 'rock',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      };
+      const repository = createBandsRepositoryStub({
+        onSearchBands(inputQuery) {
+          capturedQuery = inputQuery;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.searchBands(query);
+
+      expect(capturedQuery).toBe(query);
+      expect(result.keyword).toBe('rock');
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].bandMaster.nickname).toBe('Jun');
+      expect(result.meta.take).toBe(20);
+    });
+
+    it('정렬 방향이 서로 다르면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.searchBands({
+          order__created_at: 'desc',
+          order__id: 'asc',
+          take: 20,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('커서 생성일과 ID는 함께 입력해야 한다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.searchBands({
+          order__created_at: 'desc',
+          order__id: 'desc',
+          take: 20,
+          cursor__created_at: '2026-04-10T00:00:00.000Z',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('커서 생성일이 유효하지 않으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.searchBands({
+          order__created_at: 'desc',
+          order__id: 'desc',
+          take: 20,
+          cursor__created_at: 'invalid-date',
+          cursor__id: '11111111-1111-4111-8111-111111111111',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('외부 transaction client를 repository로 전달한다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      let capturedTransaction: unknown;
+      const repository = createBandsRepositoryStub({
+        onSearchBands(_query, tx) {
+          capturedTransaction = tx;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.searchBands(
+        {
+          order__created_at: 'desc',
+          order__id: 'desc',
+          take: 20,
+        },
+        externalTx as never,
+      );
+
+      expect(capturedTransaction).toBe(externalTx);
     });
   });
 

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -29,10 +29,6 @@ function createBandsRepositoryStub(options?: {
       role: BandMemberRole;
     } | null;
   } | null;
-  bandForMemberList?: {
-    id: string;
-    requesterMemberId: string | null;
-  } | null;
   bandMemberForRoleUpdate?: {
     id: string;
     userId: string;
@@ -41,7 +37,6 @@ function createBandsRepositoryStub(options?: {
   onDeleteBand?: (bandId: string, deletedAt: Date, tx: unknown) => void;
   onFindActiveBandById?: (tx: unknown) => void;
   onFindBandForLeave?: (tx: unknown) => void;
-  onFindBandForMemberList?: (bandId: string, requesterUserId: string, tx: unknown) => void;
   onFindBandMemberByBandIdAndUserId?: (tx: unknown) => void;
   onFindBandMembers?: (bandId: string, query: GetBandMembersQuery, tx: unknown) => void;
   onFindExistingGenreIds?: (tx: unknown) => void;
@@ -120,18 +115,6 @@ function createBandsRepositoryStub(options?: {
       return {
         bandId: 'band-001',
         userId: INVITEE_USER_ID,
-      };
-    },
-    async findBandForMemberList(bandId, requesterUserId, tx) {
-      options?.onFindBandForMemberList?.(bandId, requesterUserId, tx);
-
-      if (options?.bandForMemberList !== undefined) {
-        return options.bandForMemberList;
-      }
-
-      return {
-        id: bandId,
-        requesterMemberId: 'band-member-requester',
       };
     },
     async findBandMembers(bandId, query, tx) {
@@ -667,7 +650,7 @@ describe('BandsService', () => {
   });
 
   describe('getBandMembers', () => {
-    it('밴드 멤버가 요청하면 밴드 멤버 목록을 조회한다', async () => {
+    it('삭제되지 않은 밴드의 멤버 목록을 조회한다', async () => {
       let capturedBandId: string | undefined;
       let capturedQuery: GetBandMembersQuery | undefined;
       const query: GetBandMembersQuery = {
@@ -683,7 +666,7 @@ describe('BandsService', () => {
       });
       const service = new BandsService(repository, createPrismaServiceStub());
 
-      const result = await service.getBandMembers(BAND_MASTER_USER_ID, 'band-001', query);
+      const result = await service.getBandMembers('band-001', query);
 
       expect(capturedBandId).toBe('band-001');
       expect(capturedQuery).toBe(query);
@@ -695,12 +678,12 @@ describe('BandsService', () => {
 
     it('밴드가 없거나 삭제되었으면 예외를 던진다', async () => {
       const repository = createBandsRepositoryStub({
-        bandForMemberList: null,
+        activeBand: null,
       });
       const service = new BandsService(repository, createPrismaServiceStub());
 
       await expect(
-        service.getBandMembers(BAND_MASTER_USER_ID, 'band-missing', {
+        service.getBandMembers('band-missing', {
           order__joined_at: 'desc',
           order__id: 'desc',
           take: 20,
@@ -708,30 +691,12 @@ describe('BandsService', () => {
       ).rejects.toThrow(NotFoundException);
     });
 
-    it('밴드 멤버가 아니면 예외를 던진다', async () => {
-      const repository = createBandsRepositoryStub({
-        bandForMemberList: {
-          id: 'band-001',
-          requesterMemberId: null,
-        },
-      });
-      const service = new BandsService(repository, createPrismaServiceStub());
-
-      await expect(
-        service.getBandMembers(BAND_MASTER_USER_ID, 'band-001', {
-          order__joined_at: 'desc',
-          order__id: 'desc',
-          take: 20,
-        }),
-      ).rejects.toThrow(ForbiddenException);
-    });
-
     it('정렬 방향이 서로 다르면 예외를 던진다', async () => {
       const repository = createBandsRepositoryStub();
       const service = new BandsService(repository, createPrismaServiceStub());
 
       await expect(
-        service.getBandMembers(BAND_MASTER_USER_ID, 'band-001', {
+        service.getBandMembers('band-001', {
           order__joined_at: 'desc',
           order__id: 'asc',
           take: 20,
@@ -744,7 +709,7 @@ describe('BandsService', () => {
       const service = new BandsService(repository, createPrismaServiceStub());
 
       await expect(
-        service.getBandMembers(BAND_MASTER_USER_ID, 'band-001', {
+        service.getBandMembers('band-001', {
           order__joined_at: 'desc',
           order__id: 'desc',
           take: 20,
@@ -758,7 +723,7 @@ describe('BandsService', () => {
       const service = new BandsService(repository, createPrismaServiceStub());
 
       await expect(
-        service.getBandMembers(BAND_MASTER_USER_ID, 'band-001', {
+        service.getBandMembers('band-001', {
           order__joined_at: 'desc',
           order__id: 'desc',
           take: 20,
@@ -774,7 +739,7 @@ describe('BandsService', () => {
       };
       const capturedTransactions: unknown[] = [];
       const repository = createBandsRepositoryStub({
-        onFindBandForMemberList(_bandId, _requesterUserId, tx) {
+        onFindActiveBandById(tx) {
           capturedTransactions.push(tx);
         },
         onFindBandMembers(_bandId, _query, tx) {
@@ -784,7 +749,6 @@ describe('BandsService', () => {
       const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
 
       await service.getBandMembers(
-        BAND_MASTER_USER_ID,
         'band-001',
         {
           order__joined_at: 'desc',

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -14,6 +14,7 @@ import type { GetBandMembersResult } from './types/band-member-list.type';
 import type { SearchBandsResult } from './types/band-search-result.type';
 import type { CreateBandInvitationFailedItem, CreateBandResult } from './types/create-band-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
+import type { LeaveBandResult } from './types/leave-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
 import type { UpdateBandMemberRoleResult } from './types/update-band-member-role-result.type';
 import type { UpdateBandResult } from './types/update-band-result.type';
@@ -90,6 +91,40 @@ export class BandsService {
       }
 
       return this.bandsRepository.deleteBand(bandId, new Date(), client);
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
+  /**
+   * 밴드장은 위임 없이 나갈 수 없고, 일반 밴드 멤버만 자신의 멤버십을 삭제할 수 있다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} bandId - 나갈 밴드 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<LeaveBandResult>} 밴드 나가기 처리 결과
+   */
+  async leaveBand(userId: string, bandId: string, tx?: Prisma.TransactionClient): Promise<LeaveBandResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<LeaveBandResult> => {
+      const band = await this.bandsRepository.findBandForLeave(bandId, userId, client);
+
+      if (band === null) {
+        throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
+      }
+
+      if (band.member === null) {
+        throw new ForbiddenException('밴드 멤버가 아닙니다.');
+      }
+
+      if (band.member.role === BandMemberRole.BM) {
+        throw new ForbiddenException('밴드장은 이 API로 밴드를 나갈 수 없습니다.');
+      }
+
+      return this.bandsRepository.leaveBand(band.member.id, client);
     };
 
     if (tx !== undefined) {

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -6,9 +6,11 @@ import { BandMemberRole, type Prisma } from '../../generated/prisma';
 import type { CreateBandInput } from './dto/create-band.dto';
 import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
+import type { SearchBandsQuery } from './dto/search-bands-query.dto';
 import type { UpdateBandMemberRoleInput } from './dto/update-band-member-role.dto';
 import { BANDS_REPOSITORY, type BandsRepository } from './repositories/bands.repository';
 import type { GetBandMembersResult } from './types/band-member-list.type';
+import type { SearchBandsResult } from './types/band-search-result.type';
 import type { CreateBandInvitationFailedItem, CreateBandResult } from './types/create-band-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
@@ -137,6 +139,19 @@ export class BandsService {
     }
 
     return this.bandsRepository.findBandMembers(bandId, query, tx);
+  }
+
+  /**
+   * 공개 밴드 검색은 인증 없이 이름 기준으로만 조회한다.
+   *
+   * @param {SearchBandsQuery} query - 검색어, 정렬, 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<SearchBandsResult>} 공개 밴드 검색 결과
+   */
+  async searchBands(query: SearchBandsQuery, tx?: Prisma.TransactionClient): Promise<SearchBandsResult> {
+    this.validateBandSearchQuery(query);
+
+    return this.bandsRepository.searchBands(query, tx);
   }
 
   /**
@@ -279,6 +294,29 @@ export class BandsService {
 
     if (Number.isNaN(cursorJoinedAt.getTime())) {
       throw new BadRequestException('cursor__joined_at은 유효한 날짜여야 합니다.');
+    }
+  }
+
+  private validateBandSearchQuery(query: SearchBandsQuery): void {
+    if (query.order__created_at !== query.order__id) {
+      throw new BadRequestException('order__created_at과 order__id는 같은 방향이어야 합니다.');
+    }
+
+    const hasCursorCreatedAt = query.cursor__created_at !== undefined;
+    const hasCursorId = query.cursor__id !== undefined;
+
+    if (hasCursorCreatedAt !== hasCursorId) {
+      throw new BadRequestException('커서 조회에는 cursor__created_at과 cursor__id가 함께 필요합니다.');
+    }
+
+    if (query.cursor__created_at === undefined) {
+      return;
+    }
+
+    const cursorCreatedAt = new Date(query.cursor__created_at);
+
+    if (Number.isNaN(cursorCreatedAt.getTime())) {
+      throw new BadRequestException('cursor__created_at은 유효한 날짜여야 합니다.');
     }
   }
 }

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -82,7 +82,7 @@ export class BandsService {
    */
   async deleteBand(userId: string, bandId: string, tx?: Prisma.TransactionClient): Promise<DeleteBandResult> {
     const run = async (client: Prisma.TransactionClient): Promise<DeleteBandResult> => {
-      const band = await this.bandsRepository.findBandForDelete(bandId, client);
+      const band = await this.bandsRepository.findActiveBandById(bandId, client);
 
       if (band === null) {
         throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
@@ -206,7 +206,7 @@ export class BandsService {
     const run = async (client: Prisma.TransactionClient): Promise<UpdateBandResult> => {
       this.validateUpdateBandInput(input);
 
-      const band = await this.bandsRepository.findBandForUpdate(bandId, client);
+      const band = await this.bandsRepository.findActiveBandById(bandId, client);
 
       if (band === null) {
         throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
@@ -248,7 +248,7 @@ export class BandsService {
         throw new BadRequestException('밴드장 권한은 이 API에서 부여할 수 없습니다.');
       }
 
-      const band = await this.bandsRepository.findBandForMemberRoleUpdate(bandId, client);
+      const band = await this.bandsRepository.findActiveBandById(bandId, client);
 
       if (band === null) {
         throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -258,7 +258,7 @@ export class BandsService {
         throw new ForbiddenException('밴드 멤버 권한 변경 권한이 없습니다.');
       }
 
-      const member = await this.bandsRepository.findBandMemberForRoleUpdate(bandId, targetUserId, client);
+      const member = await this.bandsRepository.findBandMemberByBandIdAndUserId(bandId, targetUserId, client);
 
       if (member === null) {
         throw new NotFoundException('요청한 밴드 멤버를 찾을 수 없습니다.');

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -1,0 +1,113 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+
+import { PrismaService } from '../../database/prisma';
+import type { Prisma } from '../../generated/prisma';
+
+import type { CreateBandInput } from './dto/create-band.dto';
+import { BANDS_REPOSITORY, type BandsRepository } from './repositories/bands.repository';
+import type { CreateBandInvitationFailedItem, CreateBandResult } from './types/create-band-result.type';
+
+@Injectable()
+export class BandsService {
+  constructor(
+    @Inject(BANDS_REPOSITORY) private readonly bandsRepository: BandsRepository,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  /**
+   * 인증 사용자를 밴드장으로 삼아 밴드 생성 정책을 검증하고 저장을 위임한다.
+   *
+   * @param {string} bandMasterUserId - 인증된 사용자 ID
+   * @param {CreateBandInput} input - 검증이 끝난 밴드 생성 요청값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<CreateBandResult>} 밴드 생성 응답 데이터
+   */
+  async createBand(bandMasterUserId: string, input: CreateBandInput, tx?: Prisma.TransactionClient): Promise<CreateBandResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<CreateBandResult> => {
+      const genreIds = this.removeDuplicatedIds(input.genreIds ?? []);
+      await this.validateGenres(genreIds, client);
+
+      const inviteeUserIds = this.removeDuplicatedIds(input.inviteeUserIds ?? []);
+      const invitationTarget = await this.createInvitationTarget(bandMasterUserId, inviteeUserIds, client);
+
+      const result = await this.bandsRepository.createBand(
+        {
+          ...input,
+          bandMasterUserId,
+          genreIds,
+          inviteeUserIds: invitationTarget.validUserIds,
+        },
+        client,
+      );
+
+      return {
+        band: {
+          ...result.band,
+          invitations: {
+            success: result.band.invitations.success,
+            failed: invitationTarget.failedItems,
+          },
+        },
+      };
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
+  private async validateGenres(genreIds: string[], tx: Prisma.TransactionClient): Promise<void> {
+    if (genreIds.length === 0) {
+      return;
+    }
+
+    const existingGenreIds = await this.bandsRepository.findExistingGenreIds(genreIds, tx);
+
+    if (existingGenreIds.length !== genreIds.length) {
+      throw new BadRequestException('존재하지 않는 장르가 포함되어 있습니다.');
+    }
+  }
+
+  private async createInvitationTarget(
+    bandMasterUserId: string,
+    inviteeUserIds: string[],
+    tx: Prisma.TransactionClient,
+  ): Promise<{
+    validUserIds: string[];
+    failedItems: CreateBandInvitationFailedItem[];
+  }> {
+    if (inviteeUserIds.length === 0) {
+      return {
+        validUserIds: [],
+        failedItems: [],
+      };
+    }
+
+    const selfInviteeUserIds = inviteeUserIds.filter(userId => userId === bandMasterUserId);
+    const userIdsToFind = inviteeUserIds.filter(userId => userId !== bandMasterUserId);
+    const existingUserIds = await this.bandsRepository.findExistingUserIds(userIdsToFind, tx);
+    const existingUserIdSet = new Set(existingUserIds);
+    const validUserIds = userIdsToFind.filter(userId => existingUserIdSet.has(userId));
+    const missingUserIds = userIdsToFind.filter(userId => !existingUserIdSet.has(userId));
+
+    return {
+      validUserIds,
+      failedItems: [
+        ...selfInviteeUserIds.map(userId => ({
+          userId,
+          reason: '밴드 생성자는 초대 대상이 될 수 없습니다.',
+        })),
+        ...missingUserIds.map(userId => ({
+          userId,
+          reason: '존재하지 않거나 비활성화된 사용자입니다.',
+        })),
+      ],
+    };
+  }
+
+  private removeDuplicatedIds(ids: string[]): string[] {
+    return [...new Set(ids)];
+  }
+}

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -1,12 +1,14 @@
 import { BadRequestException, ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 
 import { PrismaService } from '../../database/prisma';
-import type { Prisma } from '../../generated/prisma';
+import { BandMemberRole, type Prisma } from '../../generated/prisma';
 
 import type { CreateBandInput } from './dto/create-band.dto';
+import type { UpdateBandMemberRoleInput } from './dto/update-band-member-role.dto';
 import { BANDS_REPOSITORY, type BandsRepository } from './repositories/bands.repository';
 import type { CreateBandInvitationFailedItem, CreateBandResult } from './types/create-band-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
+import type { UpdateBandMemberRoleResult } from './types/update-band-member-role-result.type';
 
 @Injectable()
 export class BandsService {
@@ -80,6 +82,54 @@ export class BandsService {
       }
 
       return this.bandsRepository.deleteBand(bandId, new Date(), client);
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
+  /**
+   * 밴드장은 부리더와 일반 멤버 간 역할만 변경할 수 있다.
+   *
+   * @param {string} requesterUserId - 인증된 사용자 ID
+   * @param {string} bandId - 대상 밴드 ID
+   * @param {string} targetUserId - 역할을 변경할 사용자 ID
+   * @param {UpdateBandMemberRoleInput} input - 검증이 끝난 역할 변경 요청값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<UpdateBandMemberRoleResult>} 변경된 밴드 멤버 권한
+   */
+  async updateBandMemberRole(
+    requesterUserId: string,
+    bandId: string,
+    targetUserId: string,
+    input: UpdateBandMemberRoleInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<UpdateBandMemberRoleResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<UpdateBandMemberRoleResult> => {
+      if (input.role === BandMemberRole.BM) {
+        throw new BadRequestException('밴드장 권한은 이 API에서 부여할 수 없습니다.');
+      }
+
+      const band = await this.bandsRepository.findBandForMemberRoleUpdate(bandId, client);
+
+      if (band === null) {
+        throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
+      }
+
+      if (band.bandMasterUserId !== requesterUserId) {
+        throw new ForbiddenException('밴드 멤버 권한 변경 권한이 없습니다.');
+      }
+
+      const member = await this.bandsRepository.findBandMemberForRoleUpdate(bandId, targetUserId, client);
+
+      if (member === null) {
+        throw new NotFoundException('요청한 밴드 멤버를 찾을 수 없습니다.');
+      }
+
+      return this.bandsRepository.updateBandMemberRole(member.id, input, client);
     };
 
     if (tx !== undefined) {

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -151,30 +151,20 @@ export class BandsService {
   }
 
   /**
-   * 밴드 멤버만 같은 밴드의 멤버 목록을 조회할 수 있다.
+   * MVP에서는 가입 전 미리보기를 위해 삭제되지 않은 밴드의 멤버 목록을 공개 조회한다.
    *
-   * @param {string} requesterUserId - 인증된 사용자 ID
    * @param {string} bandId - 조회할 밴드 ID
    * @param {GetBandMembersQuery} query - 정렬과 커서 기반 목록 조회 조건
    * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
    * @returns {Promise<GetBandMembersResult>} 밴드 멤버 목록
    */
-  async getBandMembers(
-    requesterUserId: string,
-    bandId: string,
-    query: GetBandMembersQuery,
-    tx?: Prisma.TransactionClient,
-  ): Promise<GetBandMembersResult> {
+  async getBandMembers(bandId: string, query: GetBandMembersQuery, tx?: Prisma.TransactionClient): Promise<GetBandMembersResult> {
     this.validateBandMemberListQuery(query);
 
-    const band = await this.bandsRepository.findBandForMemberList(bandId, requesterUserId, tx);
+    const band = await this.bandsRepository.findActiveBandById(bandId, tx);
 
     if (band === null) {
       throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
-    }
-
-    if (band.requesterMemberId === null) {
-      throw new ForbiddenException('밴드 멤버 조회 권한이 없습니다.');
     }
 
     return this.bandsRepository.findBandMembers(bandId, query, tx);

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -4,10 +4,12 @@ import { PrismaService } from '../../database/prisma';
 import { BandMemberRole, type Prisma } from '../../generated/prisma';
 
 import type { CreateBandInput } from './dto/create-band.dto';
+import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
 import type { UpdateBandMemberRoleInput } from './dto/update-band-member-role.dto';
 import { BANDS_REPOSITORY, type BandsRepository } from './repositories/bands.repository';
 import type { CreateBandInvitationFailedItem, CreateBandResult } from './types/create-band-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
+import type { GetMyBandsResult } from './types/my-band-list.type';
 import type { UpdateBandMemberRoleResult } from './types/update-band-member-role-result.type';
 
 @Injectable()
@@ -89,6 +91,20 @@ export class BandsService {
     }
 
     return this.prisma.$transaction(run);
+  }
+
+  /**
+   * 인증 사용자가 멤버로 속한 삭제되지 않은 밴드 목록을 조회한다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {GetMyBandsQuery} query - 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetMyBandsResult>} 내가 속한 밴드 목록
+   */
+  async getMyBands(userId: string, query: GetMyBandsQuery, tx?: Prisma.TransactionClient): Promise<GetMyBandsResult> {
+    this.validateCursorPair(query);
+
+    return this.bandsRepository.findMyBands(userId, query, tx);
   }
 
   /**
@@ -190,5 +206,24 @@ export class BandsService {
 
   private removeDuplicatedIds(ids: string[]): string[] {
     return [...new Set(ids)];
+  }
+
+  private validateCursorPair(query: GetMyBandsQuery): void {
+    const hasCursorCreatedAt = query.cursor__created_at !== undefined;
+    const hasCursorId = query.cursor__id !== undefined;
+
+    if (hasCursorCreatedAt !== hasCursorId) {
+      throw new BadRequestException('커서 조회에는 cursor__created_at과 cursor__id가 함께 필요합니다.');
+    }
+
+    if (query.cursor__created_at === undefined) {
+      return;
+    }
+
+    const cursorCreatedAt = new Date(query.cursor__created_at);
+
+    if (Number.isNaN(cursorCreatedAt.getTime())) {
+      throw new BadRequestException('cursor__created_at은 유효한 날짜여야 합니다.');
+    }
   }
 }

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -4,9 +4,11 @@ import { PrismaService } from '../../database/prisma';
 import { BandMemberRole, type Prisma } from '../../generated/prisma';
 
 import type { CreateBandInput } from './dto/create-band.dto';
+import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
 import type { UpdateBandMemberRoleInput } from './dto/update-band-member-role.dto';
 import { BANDS_REPOSITORY, type BandsRepository } from './repositories/bands.repository';
+import type { GetBandMembersResult } from './types/band-member-list.type';
 import type { CreateBandInvitationFailedItem, CreateBandResult } from './types/create-band-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
@@ -105,6 +107,36 @@ export class BandsService {
     this.validateCursorPair(query);
 
     return this.bandsRepository.findMyBands(userId, query, tx);
+  }
+
+  /**
+   * 밴드 멤버만 같은 밴드의 멤버 목록을 조회할 수 있다.
+   *
+   * @param {string} requesterUserId - 인증된 사용자 ID
+   * @param {string} bandId - 조회할 밴드 ID
+   * @param {GetBandMembersQuery} query - 정렬과 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetBandMembersResult>} 밴드 멤버 목록
+   */
+  async getBandMembers(
+    requesterUserId: string,
+    bandId: string,
+    query: GetBandMembersQuery,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetBandMembersResult> {
+    this.validateBandMemberListQuery(query);
+
+    const band = await this.bandsRepository.findBandForMemberList(bandId, requesterUserId, tx);
+
+    if (band === null) {
+      throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
+    }
+
+    if (band.requesterMemberId === null) {
+      throw new ForbiddenException('밴드 멤버 조회 권한이 없습니다.');
+    }
+
+    return this.bandsRepository.findBandMembers(bandId, query, tx);
   }
 
   /**
@@ -224,6 +256,29 @@ export class BandsService {
 
     if (Number.isNaN(cursorCreatedAt.getTime())) {
       throw new BadRequestException('cursor__created_at은 유효한 날짜여야 합니다.');
+    }
+  }
+
+  private validateBandMemberListQuery(query: GetBandMembersQuery): void {
+    if (query.order__joined_at !== query.order__id) {
+      throw new BadRequestException('order__joined_at과 order__id는 같은 방향이어야 합니다.');
+    }
+
+    const hasCursorJoinedAt = query.cursor__joined_at !== undefined;
+    const hasCursorId = query.cursor__id !== undefined;
+
+    if (hasCursorJoinedAt !== hasCursorId) {
+      throw new BadRequestException('커서 조회에는 cursor__joined_at과 cursor__id가 함께 필요합니다.');
+    }
+
+    if (query.cursor__joined_at === undefined) {
+      return;
+    }
+
+    const cursorJoinedAt = new Date(query.cursor__joined_at);
+
+    if (Number.isNaN(cursorJoinedAt.getTime())) {
+      throw new BadRequestException('cursor__joined_at은 유효한 날짜여야 합니다.');
     }
   }
 }

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -248,6 +248,10 @@ export class BandsService {
         throw new ForbiddenException('밴드 멤버 권한 변경 권한이 없습니다.');
       }
 
+      if (targetUserId === band.bandMasterUserId) {
+        throw new BadRequestException('밴드장 권한은 이 API에서 변경할 수 없습니다.');
+      }
+
       const member = await this.bandsRepository.findBandMemberByBandIdAndUserId(bandId, targetUserId, client);
 
       if (member === null) {

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -7,6 +7,7 @@ import type { CreateBandInput } from './dto/create-band.dto';
 import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
 import type { SearchBandsQuery } from './dto/search-bands-query.dto';
+import type { UpdateBandInput } from './dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from './dto/update-band-member-role.dto';
 import { BANDS_REPOSITORY, type BandsRepository } from './repositories/bands.repository';
 import type { GetBandMembersResult } from './types/band-member-list.type';
@@ -15,6 +16,7 @@ import type { CreateBandInvitationFailedItem, CreateBandResult } from './types/c
 import type { DeleteBandResult } from './types/delete-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
 import type { UpdateBandMemberRoleResult } from './types/update-band-member-role-result.type';
+import type { UpdateBandResult } from './types/update-band-result.type';
 
 @Injectable()
 export class BandsService {
@@ -152,6 +154,39 @@ export class BandsService {
     this.validateBandSearchQuery(query);
 
     return this.bandsRepository.searchBands(query, tx);
+  }
+
+  /**
+   * 밴드장만 밴드의 기본 정보를 수정할 수 있다.
+   *
+   * @param {string} requesterUserId - 인증된 사용자 ID
+   * @param {string} bandId - 수정할 밴드 ID
+   * @param {UpdateBandInput} input - 검증이 끝난 밴드 수정 요청값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<UpdateBandResult>} 수정된 밴드 정보
+   */
+  async updateBand(requesterUserId: string, bandId: string, input: UpdateBandInput, tx?: Prisma.TransactionClient): Promise<UpdateBandResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<UpdateBandResult> => {
+      this.validateUpdateBandInput(input);
+
+      const band = await this.bandsRepository.findBandForUpdate(bandId, client);
+
+      if (band === null) {
+        throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
+      }
+
+      if (band.bandMasterUserId !== requesterUserId) {
+        throw new ForbiddenException('밴드 정보 수정 권한이 없습니다.');
+      }
+
+      return this.bandsRepository.updateBand(bandId, input, client);
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
   }
 
   /**
@@ -317,6 +352,21 @@ export class BandsService {
 
     if (Number.isNaN(cursorCreatedAt.getTime())) {
       throw new BadRequestException('cursor__created_at은 유효한 날짜여야 합니다.');
+    }
+  }
+
+  private validateUpdateBandInput(input: UpdateBandInput): void {
+    const hasName = input.name !== undefined;
+    const hasDescription = input.description !== undefined;
+    const hasVisibility = input.visibility !== undefined;
+    const hasCoverImgUrl = input.coverImgUrl !== undefined;
+
+    if (!hasName && !hasDescription && !hasVisibility && !hasCoverImgUrl) {
+      throw new BadRequestException('수정할 밴드 정보가 필요합니다.');
+    }
+
+    if (input.name !== undefined && input.name.trim().length === 0) {
+      throw new BadRequestException('밴드 이름은 비어 있을 수 없습니다.');
     }
   }
 }

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 
 import { PrismaService } from '../../database/prisma';
 import type { Prisma } from '../../generated/prisma';
@@ -6,6 +6,7 @@ import type { Prisma } from '../../generated/prisma';
 import type { CreateBandInput } from './dto/create-band.dto';
 import { BANDS_REPOSITORY, type BandsRepository } from './repositories/bands.repository';
 import type { CreateBandInvitationFailedItem, CreateBandResult } from './types/create-band-result.type';
+import type { DeleteBandResult } from './types/delete-band-result.type';
 
 @Injectable()
 export class BandsService {
@@ -49,6 +50,36 @@ export class BandsService {
           },
         },
       };
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
+  /**
+   * 밴드 하위 데이터를 보존하기 위해 deletedAt을 채워 삭제 상태로 표시한다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} bandId - 삭제할 밴드 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<DeleteBandResult>} 삭제 처리 결과
+   */
+  async deleteBand(userId: string, bandId: string, tx?: Prisma.TransactionClient): Promise<DeleteBandResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<DeleteBandResult> => {
+      const band = await this.bandsRepository.findBandForDelete(bandId, client);
+
+      if (band === null) {
+        throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
+      }
+
+      if (band.bandMasterUserId !== userId) {
+        throw new ForbiddenException('밴드 삭제 권한이 없습니다.');
+      }
+
+      return this.bandsRepository.deleteBand(bandId, new Date(), client);
     };
 
     if (tx !== undefined) {

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -36,10 +36,12 @@ export class BandsService {
    */
   async createBand(bandMasterUserId: string, input: CreateBandInput, tx?: Prisma.TransactionClient): Promise<CreateBandResult> {
     const run = async (client: Prisma.TransactionClient): Promise<CreateBandResult> => {
-      const genreIds = this.removeDuplicatedIds(input.genreIds ?? []);
+      const genreIds = input.genreIds ?? [];
+      this.validateDuplicatedIds(genreIds, '중복된 장르가 포함되어 있습니다.');
       await this.validateGenres(genreIds, client);
 
-      const inviteeUserIds = this.removeDuplicatedIds(input.inviteeUserIds ?? []);
+      const inviteeUserIds = input.inviteeUserIds ?? [];
+      this.validateDuplicatedIds(inviteeUserIds, '중복된 초대 대상이 포함되어 있습니다.');
       const invitationTarget = await this.createInvitationTarget(bandMasterUserId, inviteeUserIds, client);
 
       const result = await this.bandsRepository.createBand(
@@ -321,8 +323,12 @@ export class BandsService {
     };
   }
 
-  private removeDuplicatedIds(ids: string[]): string[] {
-    return [...new Set(ids)];
+  private validateDuplicatedIds(ids: string[], message: string): void {
+    const uniqueIds = new Set(ids);
+
+    if (uniqueIds.size !== ids.length) {
+      throw new BadRequestException(message);
+    }
   }
 
   private validateCursorPair(query: GetMyBandsQuery): void {

--- a/backend/src/modules/bands/dto/create-band.dto.ts
+++ b/backend/src/modules/bands/dto/create-band.dto.ts
@@ -1,0 +1,63 @@
+import { Transform } from 'class-transformer';
+import { IsArray, IsBoolean, IsNotEmpty, IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
+
+import { normalizeOptionalStringValue, trimStringValue } from '../../../common/validation/transform.util';
+import { booleanValidationMessage } from '../../../common/validation-message/boolean-validation.message';
+import { lengthValidationMessage } from '../../../common/validation-message/length-validation.message';
+import { notemptyValidationMessage } from '../../../common/validation-message/notempty-validation.message';
+import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
+import { uuidValidationMessage } from '../../../common/validation-message/uuid-validation.message';
+
+/**
+ * 밴드 생성 요청 본문을 검증한다.
+ */
+export class CreateBandBodyDto {
+  @Transform(trimStringValue)
+  @IsString({
+    message: stringValidationMessage,
+  })
+  @IsNotEmpty({
+    message: notemptyValidationMessage,
+  })
+  @MaxLength(40, {
+    message: lengthValidationMessage,
+  })
+  name!: string;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({
+    message: stringValidationMessage,
+  })
+  description?: string;
+
+  @IsBoolean({
+    message: booleanValidationMessage,
+  })
+  visibility!: boolean;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({
+    message: stringValidationMessage,
+  })
+  coverImgUrl?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', {
+    each: true,
+    message: uuidValidationMessage,
+  })
+  genreIds?: string[];
+
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', {
+    each: true,
+    message: uuidValidationMessage,
+  })
+  inviteeUserIds?: string[];
+}
+
+export type CreateBandInput = CreateBandBodyDto;

--- a/backend/src/modules/bands/dto/get-band-members-query.dto.ts
+++ b/backend/src/modules/bands/dto/get-band-members-query.dto.ts
@@ -1,0 +1,38 @@
+import { Transform } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, IsUUID, Min } from 'class-validator';
+import { normalizeOptionalStringValue, parseOptionalPositiveIntegerValue } from 'src/common/validation/transform.util';
+import { enumValidationMessage } from 'src/common/validation-message/enum-validation.message';
+import { intValidationMessage } from 'src/common/validation-message/int-validation.message';
+import { minValidationMessage } from 'src/common/validation-message/min-validation.message';
+import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
+import { uuidValidationMessage } from 'src/common/validation-message/uuid-validation.message';
+
+const ORDER_DIRECTIONS = ['asc', 'desc'] as const;
+export type BandMemberOrderDirection = (typeof ORDER_DIRECTIONS)[number];
+
+export class GetBandMembersQueryDto {
+  @IsOptional()
+  @IsEnum(ORDER_DIRECTIONS, { message: enumValidationMessage })
+  order__joined_at: BandMemberOrderDirection = 'desc';
+
+  @IsOptional()
+  @IsEnum(ORDER_DIRECTIONS, { message: enumValidationMessage })
+  order__id: BandMemberOrderDirection = 'desc';
+
+  @Transform(parseOptionalPositiveIntegerValue)
+  @IsInt({ message: intValidationMessage })
+  @Min(1, { message: minValidationMessage })
+  take: number = 20;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  cursor__joined_at?: string;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  cursor__id?: string;
+}
+
+export type GetBandMembersQuery = GetBandMembersQueryDto;

--- a/backend/src/modules/bands/dto/get-my-bands-query.dto.ts
+++ b/backend/src/modules/bands/dto/get-my-bands-query.dto.ts
@@ -1,0 +1,27 @@
+import { Transform } from 'class-transformer';
+import { IsInt, IsOptional, IsString, IsUUID, Min } from 'class-validator';
+import { intValidationMessage } from 'src/common/validation-message/int-validation.message';
+import { minValidationMessage } from 'src/common/validation-message/min-validation.message';
+import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
+import { uuidValidationMessage } from 'src/common/validation-message/uuid-validation.message';
+
+import { normalizeOptionalStringValue, parseOptionalPositiveIntegerValue } from '../../../common/validation/transform.util';
+
+export class GetMyBandsQueryDto {
+  @Transform(parseOptionalPositiveIntegerValue)
+  @IsInt({ message: intValidationMessage })
+  @Min(1, { message: minValidationMessage })
+  take: number = 20;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  cursor__created_at?: string;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  cursor__id?: string;
+}
+
+export type GetMyBandsQuery = GetMyBandsQueryDto;

--- a/backend/src/modules/bands/dto/search-bands-query.dto.ts
+++ b/backend/src/modules/bands/dto/search-bands-query.dto.ts
@@ -1,0 +1,43 @@
+import { Transform } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, IsUUID, Min } from 'class-validator';
+import { normalizeOptionalStringValue, parseOptionalPositiveIntegerValue } from 'src/common/validation/transform.util';
+import { enumValidationMessage } from 'src/common/validation-message/enum-validation.message';
+import { intValidationMessage } from 'src/common/validation-message/int-validation.message';
+import { minValidationMessage } from 'src/common/validation-message/min-validation.message';
+import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
+import { uuidValidationMessage } from 'src/common/validation-message/uuid-validation.message';
+
+const ORDER_DIRECTIONS = ['asc', 'desc'] as const;
+export type BandSearchOrderDirection = (typeof ORDER_DIRECTIONS)[number];
+
+export class SearchBandsQueryDto {
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  where__name__contain?: string;
+
+  @IsOptional()
+  @IsEnum(ORDER_DIRECTIONS, { message: enumValidationMessage })
+  order__created_at: BandSearchOrderDirection = 'desc';
+
+  @IsOptional()
+  @IsEnum(ORDER_DIRECTIONS, { message: enumValidationMessage })
+  order__id: BandSearchOrderDirection = 'desc';
+
+  @Transform(parseOptionalPositiveIntegerValue)
+  @IsInt({ message: intValidationMessage })
+  @Min(1, { message: minValidationMessage })
+  take: number = 20;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  cursor__created_at?: string;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  cursor__id?: string;
+}
+
+export type SearchBandsQuery = SearchBandsQueryDto;

--- a/backend/src/modules/bands/dto/update-band-member-role.dto.ts
+++ b/backend/src/modules/bands/dto/update-band-member-role.dto.ts
@@ -1,0 +1,20 @@
+import { IsEnum, IsString } from 'class-validator';
+
+import { enumValidationMessage } from '../../../common/validation-message/enum-validation.message';
+import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
+import { BandMemberRole } from '../../../generated/prisma';
+
+/**
+ * 밴드 멤버 권한 변경 요청 본문을 검증한다.
+ */
+export class UpdateBandMemberRoleBodyDto {
+  @IsString({
+    message: stringValidationMessage,
+  })
+  @IsEnum(BandMemberRole, {
+    message: enumValidationMessage,
+  })
+  role!: BandMemberRole;
+}
+
+export type UpdateBandMemberRoleInput = UpdateBandMemberRoleBodyDto;

--- a/backend/src/modules/bands/dto/update-band.dto.ts
+++ b/backend/src/modules/bands/dto/update-band.dto.ts
@@ -1,0 +1,31 @@
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator';
+import { booleanValidationMessage } from 'src/common/validation-message/boolean-validation.message';
+import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
+
+import { normalizeOptionalStringValue, trimStringValue } from '../../../common/validation/transform.util';
+import { lengthValidationMessage } from '../../../common/validation-message/length-validation.message';
+
+export class UpdateBandBodyDto {
+  @Transform(trimStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  @MaxLength(40, { message: lengthValidationMessage })
+  name?: string;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  description?: string | null;
+
+  @IsOptional()
+  @IsBoolean({ message: booleanValidationMessage })
+  visibility?: boolean;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  coverImgUrl?: string | null;
+}
+
+export type UpdateBandInput = UpdateBandBodyDto;

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../../database/prisma';
 import type { Prisma } from '../../../generated/prisma';
 import type { BandGenreItem, CreateBandInvitationSuccessItem } from '../types/create-band-result.type';
+import type { DeleteBandResult } from '../types/delete-band-result.type';
 
 import type { BandsRepository, CreateBandRepositoryInput, CreateBandRepositoryResult } from './bands.repository';
 
@@ -91,6 +92,64 @@ export class BandsPrismaRepository implements BandsRepository {
         },
       },
     };
+  }
+
+  /**
+   * 하위 데이터를 보존해야 하므로 Band.deletedAt만 채워 soft delete 한다.
+   *
+   * @param {string} bandId - 삭제할 밴드 ID
+   * @param {Date} deletedAt - 삭제 처리 시각
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<DeleteBandResult>} 삭제 처리 결과
+   */
+  async deleteBand(bandId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteBandResult> {
+    const client = tx ?? this.prisma;
+
+    const deletedBand = await client.band.update({
+      where: {
+        id: bandId,
+      },
+      data: {
+        deletedAt,
+      },
+      select: {
+        id: true,
+        deletedAt: true,
+      },
+    });
+
+    return {
+      bandId: deletedBand.id,
+      deletedAt: (deletedBand.deletedAt ?? deletedAt).toISOString(),
+    };
+  }
+
+  /**
+   * 삭제 가능 여부 판단에 필요한 최소 밴드 정보만 조회한다.
+   *
+   * @param {string} bandId - 확인할 밴드 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string; bandMasterUserId: string } | null>} 삭제되지 않은 밴드 정보
+   */
+  async findBandForDelete(
+    bandId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    bandMasterUserId: string;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    return client.band.findFirst({
+      where: {
+        id: bandId,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        bandMasterUserId: true,
+      },
+    });
   }
 
   /**

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -5,6 +5,7 @@ import type { Prisma } from '../../../generated/prisma';
 import type { BandMemberOrderDirection, GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { BandSearchOrderDirection, SearchBandsQuery } from '../dto/search-bands-query.dto';
+import type { UpdateBandInput } from '../dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
 import type { BandMemberListItem, GetBandMembersResult } from '../types/band-member-list.type';
 import type { BandSearchListItem, SearchBandsResult } from '../types/band-search-result.type';
@@ -12,6 +13,7 @@ import type { BandGenreItem, CreateBandInvitationSuccessItem } from '../types/cr
 import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { GetMyBandsResult, MyBandListItem } from '../types/my-band-list.type';
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
+import type { UpdateBandResult } from '../types/update-band-result.type';
 
 import type { BandsRepository, CreateBandRepositoryInput, CreateBandRepositoryResult } from './bands.repository';
 
@@ -292,6 +294,70 @@ export class BandsPrismaRepository implements BandsRepository {
         cursor,
         next,
       },
+    };
+  }
+
+  /**
+   * 밴드 수정 권한 판단에 필요한 최소 밴드 정보만 조회한다.
+   *
+   * @param {string} bandId - 수정할 밴드 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string; bandMasterUserId: string } | null>} 삭제되지 않은 밴드 정보
+   */
+  async findBandForUpdate(
+    bandId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    bandMasterUserId: string;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    return client.band.findFirst({
+      where: {
+        id: bandId,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        bandMasterUserId: true,
+      },
+    });
+  }
+
+  /**
+   * 밴드장 변경과 장르 변경을 제외한 기본 정보만 수정한다.
+   *
+   * @param {string} bandId - 수정할 밴드 ID
+   * @param {UpdateBandInput} input - Service 검증이 끝난 수정 입력값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<UpdateBandResult>} 수정된 밴드 정보
+   */
+  async updateBand(bandId: string, input: UpdateBandInput, tx?: Prisma.TransactionClient): Promise<UpdateBandResult> {
+    const client = tx ?? this.prisma;
+
+    const updatedBand = await client.band.update({
+      where: {
+        id: bandId,
+      },
+      data: this.createUpdateBandData(input),
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        visibility: true,
+        coverImgUrl: true,
+        updatedAt: true,
+      },
+    });
+
+    return {
+      bandId: updatedBand.id,
+      name: updatedBand.name ?? '',
+      description: updatedBand.description,
+      visibility: updatedBand.visibility ?? true,
+      coverImgUrl: updatedBand.coverImgUrl,
+      updatedAt: updatedBand.updatedAt.toISOString(),
     };
   }
 
@@ -618,6 +684,28 @@ export class BandsPrismaRepository implements BandsRepository {
         },
       ],
     };
+  }
+
+  private createUpdateBandData(input: UpdateBandInput): Prisma.BandUpdateInput {
+    const data: Prisma.BandUpdateInput = {};
+
+    if (input.name !== undefined) {
+      data.name = input.name;
+    }
+
+    if (input.description !== undefined) {
+      data.description = input.description;
+    }
+
+    if (input.visibility !== undefined) {
+      data.visibility = input.visibility;
+    }
+
+    if (input.coverImgUrl !== undefined) {
+      data.coverImgUrl = input.coverImgUrl;
+    }
+
+    return data;
   }
 
   private getCursorOperator(orderDirection: BandMemberOrderDirection): 'lt' | 'gt' {

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from '../../../database/prisma';
-import type { Prisma } from '../../../generated/prisma';
+import type { BandMemberRole, Prisma } from '../../../generated/prisma';
 import type { BandMemberOrderDirection, GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { BandSearchOrderDirection, SearchBandsQuery } from '../dto/search-bands-query.dto';
@@ -11,6 +11,7 @@ import type { BandMemberListItem, GetBandMembersResult } from '../types/band-mem
 import type { BandSearchListItem, SearchBandsResult } from '../types/band-search-result.type';
 import type { BandGenreItem, CreateBandInvitationSuccessItem } from '../types/create-band-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
+import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult, MyBandListItem } from '../types/my-band-list.type';
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
 import type { UpdateBandResult } from '../types/update-band-result.type';
@@ -131,6 +132,83 @@ export class BandsPrismaRepository implements BandsRepository {
     return {
       bandId: deletedBand.id,
       deletedAt: (deletedBand.deletedAt ?? deletedAt).toISOString(),
+    };
+  }
+
+  /**
+   * 밴드 나가기 정책 판단에 필요한 밴드와 요청자 멤버 정보를 조회한다.
+   *
+   * @param {string} bandId - 나갈 밴드 ID
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string; member: { id: string; role: BandMemberRole } | null } | null>} 삭제되지 않은 밴드와 요청자 멤버 정보
+   */
+  async findBandForLeave(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    member: {
+      id: string;
+      role: BandMemberRole;
+    } | null;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    const band = await client.band.findFirst({
+      where: {
+        id: bandId,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        members: {
+          where: {
+            userId,
+          },
+          select: {
+            id: true,
+            role: true,
+          },
+          take: 1,
+        },
+      },
+    });
+
+    if (band === null) {
+      return null;
+    }
+
+    return {
+      id: band.id,
+      member: band.members[0] ?? null,
+    };
+  }
+
+  /**
+   * BandMember에는 탈퇴 시각 컬럼이 없으므로 멤버십 row를 삭제한다.
+   *
+   * @param {string} bandMemberId - 삭제할 밴드 멤버 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<LeaveBandResult>} 삭제된 멤버십의 밴드와 사용자 ID
+   */
+  async leaveBand(bandMemberId: string, tx?: Prisma.TransactionClient): Promise<LeaveBandResult> {
+    const client = tx ?? this.prisma;
+
+    const deletedMember = await client.bandMember.delete({
+      where: {
+        id: bandMemberId,
+      },
+      select: {
+        bandId: true,
+        userId: true,
+      },
+    });
+
+    return {
+      bandId: deletedMember.bandId,
+      userId: deletedMember.userId,
     };
   }
 

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -2,8 +2,10 @@ import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from '../../../database/prisma';
 import type { Prisma } from '../../../generated/prisma';
+import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
 import type { BandGenreItem, CreateBandInvitationSuccessItem } from '../types/create-band-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
+import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
 
 import type { BandsRepository, CreateBandRepositoryInput, CreateBandRepositoryResult } from './bands.repository';
 
@@ -125,6 +127,64 @@ export class BandsPrismaRepository implements BandsRepository {
   }
 
   /**
+   * 권한 변경 권한 판단에 필요한 최소 밴드 정보만 조회한다.
+   *
+   * @param {string} bandId - 확인할 밴드 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string; bandMasterUserId: string } | null>} 삭제되지 않은 밴드 정보
+   */
+  async findBandForMemberRoleUpdate(
+    bandId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    bandMasterUserId: string;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    return client.band.findFirst({
+      where: {
+        id: bandId,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        bandMasterUserId: true,
+      },
+    });
+  }
+
+  /**
+   * 권한을 변경할 밴드 멤버를 밴드와 사용자 기준으로 조회한다.
+   *
+   * @param {string} bandId - 대상 밴드 ID
+   * @param {string} userId - 대상 사용자 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string; userId: string } | null>} 밴드 멤버 정보
+   */
+  async findBandMemberForRoleUpdate(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    userId: string;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    return client.bandMember.findFirst({
+      where: {
+        bandId,
+        userId,
+      },
+      select: {
+        id: true,
+        userId: true,
+      },
+    });
+  }
+
+  /**
    * 삭제 가능 여부 판단에 필요한 최소 밴드 정보만 조회한다.
    *
    * @param {string} bandId - 확인할 밴드 ID
@@ -150,6 +210,42 @@ export class BandsPrismaRepository implements BandsRepository {
         bandMasterUserId: true,
       },
     });
+  }
+
+  /**
+   * 밴드 멤버 역할을 ADMIN 또는 MEMBER로 변경한다.
+   *
+   * @param {string} bandMemberId - 권한을 변경할 밴드 멤버 ID
+   * @param {UpdateBandMemberRoleInput} input - 검증이 끝난 권한 변경 입력값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<UpdateBandMemberRoleResult>} 변경된 밴드 멤버 권한
+   */
+  async updateBandMemberRole(
+    bandMemberId: string,
+    input: UpdateBandMemberRoleInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<UpdateBandMemberRoleResult> {
+    const client = tx ?? this.prisma;
+
+    const member = await client.bandMember.update({
+      where: {
+        id: bandMemberId,
+      },
+      data: {
+        role: input.role,
+      },
+      select: {
+        userId: true,
+        role: true,
+      },
+    });
+
+    return {
+      member: {
+        userId: member.userId,
+        role: member.role,
+      },
+    };
   }
 
   /**

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -213,53 +213,6 @@ export class BandsPrismaRepository implements BandsRepository {
   }
 
   /**
-   * 밴드 존재 여부와 요청자의 밴드 멤버 여부 판단에 필요한 정보만 조회한다.
-   *
-   * @param {string} bandId - 조회할 밴드 ID
-   * @param {string} requesterUserId - 인증된 사용자 ID
-   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
-   * @returns {Promise<{ id: string; requesterMemberId: string | null } | null>} 삭제되지 않은 밴드와 요청자 멤버 ID
-   */
-  async findBandForMemberList(
-    bandId: string,
-    requesterUserId: string,
-    tx?: Prisma.TransactionClient,
-  ): Promise<{
-    id: string;
-    requesterMemberId: string | null;
-  } | null> {
-    const client = tx ?? this.prisma;
-
-    const band = await client.band.findFirst({
-      where: {
-        id: bandId,
-        deletedAt: null,
-      },
-      select: {
-        id: true,
-        members: {
-          where: {
-            userId: requesterUserId,
-          },
-          select: {
-            id: true,
-          },
-          take: 1,
-        },
-      },
-    });
-
-    if (band === null) {
-      return null;
-    }
-
-    return {
-      id: band.id,
-      requesterMemberId: band.members[0]?.id ?? null,
-    };
-  }
-
-  /**
    * 밴드 멤버를 가입 시점과 ID 기준으로 정렬해 조회한다.
    *
    * @param {string} bandId - 조회할 밴드 ID

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -498,14 +498,14 @@ export class BandsPrismaRepository implements BandsRepository {
   }
 
   /**
-   * 권한을 변경할 밴드 멤버를 밴드와 사용자 기준으로 조회한다.
+   * 밴드와 사용자 기준으로 밴드 멤버를 조회한다.
    *
    * @param {string} bandId - 대상 밴드 ID
    * @param {string} userId - 대상 사용자 ID
    * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
    * @returns {Promise<{ id: string; userId: string } | null>} 밴드 멤버 정보
    */
-  async findBandMemberForRoleUpdate(
+  async findBandMemberByBandIdAndUserId(
     bandId: string,
     userId: string,
     tx?: Prisma.TransactionClient,

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -4,8 +4,10 @@ import { PrismaService } from '../../../database/prisma';
 import type { Prisma } from '../../../generated/prisma';
 import type { BandMemberOrderDirection, GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
+import type { BandSearchOrderDirection, SearchBandsQuery } from '../dto/search-bands-query.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
 import type { BandMemberListItem, GetBandMembersResult } from '../types/band-member-list.type';
+import type { BandSearchListItem, SearchBandsResult } from '../types/band-search-result.type';
 import type { BandGenreItem, CreateBandInvitationSuccessItem } from '../types/create-band-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { GetMyBandsResult, MyBandListItem } from '../types/my-band-list.type';
@@ -230,6 +232,60 @@ export class BandsPrismaRepository implements BandsRepository {
     return {
       bandId,
       members,
+      meta: {
+        count,
+        take: query.take,
+        cursor,
+        next,
+      },
+    };
+  }
+
+  /**
+   * 공개 밴드를 이름 기준으로 검색한다.
+   *
+   * @param {SearchBandsQuery} query - 검색어, 정렬, 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<SearchBandsResult>} 공개 밴드 검색 결과
+   */
+  async searchBands(query: SearchBandsQuery, tx?: Prisma.TransactionClient): Promise<SearchBandsResult> {
+    const client = tx ?? this.prisma;
+
+    const bands = await client.band.findMany({
+      where: {
+        deletedAt: null,
+        visibility: true,
+        ...this.createBandSearchKeywordWhere(query),
+        ...this.createBandSearchCursorWhere(query),
+      },
+      include: {
+        bandMasterUser: {
+          include: {
+            profile: {
+              select: {
+                nickname: true,
+              },
+            },
+          },
+        },
+        _count: {
+          select: {
+            members: true,
+          },
+        },
+      },
+      orderBy: [{ createdAt: query.order__created_at }, { id: query.order__id }],
+      take: query.take,
+    });
+
+    const items = bands.map(band => this.mapBandSearchListItem(band));
+    const count = items.length;
+    const cursor = count > 0 ? { createdAt: items[0].createdAt, id: items[0].bandId } : null;
+    const next = count === query.take ? { createdAt: items[count - 1].createdAt, id: items[count - 1].bandId } : null;
+
+    return {
+      keyword: query.where__name__contain ?? null,
+      items,
       meta: {
         count,
         take: query.take,
@@ -526,7 +582,53 @@ export class BandsPrismaRepository implements BandsRepository {
     };
   }
 
+  private createBandSearchKeywordWhere(query: SearchBandsQuery): Prisma.BandWhereInput {
+    if (query.where__name__contain === undefined) {
+      return {};
+    }
+
+    return {
+      name: {
+        contains: query.where__name__contain,
+        mode: 'insensitive',
+      },
+    };
+  }
+
+  private createBandSearchCursorWhere(query: SearchBandsQuery): Prisma.BandWhereInput {
+    if (query.cursor__created_at === undefined || query.cursor__id === undefined) {
+      return {};
+    }
+
+    const cursorCreatedAt = new Date(query.cursor__created_at);
+    const cursorOperator = this.getBandSearchCursorOperator(query.order__created_at);
+
+    return {
+      OR: [
+        {
+          createdAt: {
+            [cursorOperator]: cursorCreatedAt,
+          },
+        },
+        {
+          createdAt: cursorCreatedAt,
+          id: {
+            [cursorOperator]: query.cursor__id,
+          },
+        },
+      ],
+    };
+  }
+
   private getCursorOperator(orderDirection: BandMemberOrderDirection): 'lt' | 'gt' {
+    if (orderDirection === 'desc') {
+      return 'lt';
+    }
+
+    return 'gt';
+  }
+
+  private getBandSearchCursorOperator(orderDirection: BandSearchOrderDirection): 'lt' | 'gt' {
     if (orderDirection === 'desc') {
       return 'lt';
     }
@@ -572,6 +674,40 @@ export class BandsPrismaRepository implements BandsRepository {
         skillLevel: skill.skillLevel,
         isPrimary: skill.isPrimary,
       })),
+    };
+  }
+
+  private mapBandSearchListItem(
+    band: Prisma.BandGetPayload<{
+      include: {
+        bandMasterUser: {
+          include: {
+            profile: {
+              select: {
+                nickname: true;
+              };
+            };
+          };
+        };
+        _count: {
+          select: {
+            members: true;
+          };
+        };
+      };
+    }>,
+  ): BandSearchListItem {
+    return {
+      bandId: band.id,
+      name: band.name ?? '',
+      description: band.description,
+      visibility: band.visibility ?? true,
+      memberCount: band._count.members,
+      bandMaster: {
+        userId: band.bandMasterUserId,
+        nickname: band.bandMasterUser.profile?.nickname ?? '',
+      },
+      createdAt: band.createdAt.toISOString(),
     };
   }
 

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -376,13 +376,13 @@ export class BandsPrismaRepository implements BandsRepository {
   }
 
   /**
-   * 밴드 수정 권한 판단에 필요한 최소 밴드 정보만 조회한다.
+   * 권한 판단에 필요한 삭제되지 않은 밴드 정보를 조회한다.
    *
-   * @param {string} bandId - 수정할 밴드 ID
+   * @param {string} bandId - 확인할 밴드 ID
    * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
    * @returns {Promise<{ id: string; bandMasterUserId: string } | null>} 삭제되지 않은 밴드 정보
    */
-  async findBandForUpdate(
+  async findActiveBandById(
     bandId: string,
     tx?: Prisma.TransactionClient,
   ): Promise<{
@@ -498,34 +498,6 @@ export class BandsPrismaRepository implements BandsRepository {
   }
 
   /**
-   * 권한 변경 권한 판단에 필요한 최소 밴드 정보만 조회한다.
-   *
-   * @param {string} bandId - 확인할 밴드 ID
-   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
-   * @returns {Promise<{ id: string; bandMasterUserId: string } | null>} 삭제되지 않은 밴드 정보
-   */
-  async findBandForMemberRoleUpdate(
-    bandId: string,
-    tx?: Prisma.TransactionClient,
-  ): Promise<{
-    id: string;
-    bandMasterUserId: string;
-  } | null> {
-    const client = tx ?? this.prisma;
-
-    return client.band.findFirst({
-      where: {
-        id: bandId,
-        deletedAt: null,
-      },
-      select: {
-        id: true,
-        bandMasterUserId: true,
-      },
-    });
-  }
-
-  /**
    * 권한을 변경할 밴드 멤버를 밴드와 사용자 기준으로 조회한다.
    *
    * @param {string} bandId - 대상 밴드 ID
@@ -551,34 +523,6 @@ export class BandsPrismaRepository implements BandsRepository {
       select: {
         id: true,
         userId: true,
-      },
-    });
-  }
-
-  /**
-   * 삭제 가능 여부 판단에 필요한 최소 밴드 정보만 조회한다.
-   *
-   * @param {string} bandId - 확인할 밴드 ID
-   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
-   * @returns {Promise<{ id: string; bandMasterUserId: string } | null>} 삭제되지 않은 밴드 정보
-   */
-  async findBandForDelete(
-    bandId: string,
-    tx?: Prisma.TransactionClient,
-  ): Promise<{
-    id: string;
-    bandMasterUserId: string;
-  } | null> {
-    const client = tx ?? this.prisma;
-
-    return client.band.findFirst({
-      where: {
-        id: bandId,
-        deletedAt: null,
-      },
-      select: {
-        id: true,
-        bandMasterUserId: true,
       },
     });
   }

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -2,8 +2,10 @@ import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from '../../../database/prisma';
 import type { Prisma } from '../../../generated/prisma';
+import type { BandMemberOrderDirection, GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
+import type { BandMemberListItem, GetBandMembersResult } from '../types/band-member-list.type';
 import type { BandGenreItem, CreateBandInvitationSuccessItem } from '../types/create-band-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { GetMyBandsResult, MyBandListItem } from '../types/my-band-list.type';
@@ -125,6 +127,115 @@ export class BandsPrismaRepository implements BandsRepository {
     return {
       bandId: deletedBand.id,
       deletedAt: (deletedBand.deletedAt ?? deletedAt).toISOString(),
+    };
+  }
+
+  /**
+   * 밴드 존재 여부와 요청자의 밴드 멤버 여부 판단에 필요한 정보만 조회한다.
+   *
+   * @param {string} bandId - 조회할 밴드 ID
+   * @param {string} requesterUserId - 인증된 사용자 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string; requesterMemberId: string | null } | null>} 삭제되지 않은 밴드와 요청자 멤버 ID
+   */
+  async findBandForMemberList(
+    bandId: string,
+    requesterUserId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    requesterMemberId: string | null;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    const band = await client.band.findFirst({
+      where: {
+        id: bandId,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        members: {
+          where: {
+            userId: requesterUserId,
+          },
+          select: {
+            id: true,
+          },
+          take: 1,
+        },
+      },
+    });
+
+    if (band === null) {
+      return null;
+    }
+
+    return {
+      id: band.id,
+      requesterMemberId: band.members[0]?.id ?? null,
+    };
+  }
+
+  /**
+   * 밴드 멤버를 가입 시점과 ID 기준으로 정렬해 조회한다.
+   *
+   * @param {string} bandId - 조회할 밴드 ID
+   * @param {GetBandMembersQuery} query - 정렬과 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetBandMembersResult>} 밴드 멤버 목록
+   */
+  async findBandMembers(bandId: string, query: GetBandMembersQuery, tx?: Prisma.TransactionClient): Promise<GetBandMembersResult> {
+    const client = tx ?? this.prisma;
+
+    const bandMembers = await client.bandMember.findMany({
+      where: {
+        bandId,
+        user: {
+          deletedAt: null,
+        },
+        ...this.createBandMembersCursorWhere(query),
+      },
+      include: {
+        user: {
+          include: {
+            profile: {
+              select: {
+                nickname: true,
+                avatarUrl: true,
+              },
+            },
+            userSkills: {
+              include: {
+                skillType: {
+                  select: {
+                    name: true,
+                  },
+                },
+              },
+              orderBy: [{ isPrimary: 'desc' }, { createdAt: 'asc' }, { id: 'asc' }],
+            },
+          },
+        },
+      },
+      orderBy: [{ joinedAt: query.order__joined_at }, { id: query.order__id }],
+      take: query.take,
+    });
+
+    const members = bandMembers.map(member => this.mapBandMemberListItem(member));
+    const count = members.length;
+    const cursor = count > 0 ? { joinedAt: members[0].joinedAt, id: members[0].bandMemberId } : null;
+    const next = count === query.take ? { joinedAt: members[count - 1].joinedAt, id: members[count - 1].bandMemberId } : null;
+
+    return {
+      bandId,
+      members,
+      meta: {
+        count,
+        take: query.take,
+        cursor,
+        next,
+      },
     };
   }
 
@@ -387,6 +498,80 @@ export class BandsPrismaRepository implements BandsRepository {
           },
         },
       ],
+    };
+  }
+
+  private createBandMembersCursorWhere(query: GetBandMembersQuery): Prisma.BandMemberWhereInput {
+    if (query.cursor__joined_at === undefined || query.cursor__id === undefined) {
+      return {};
+    }
+
+    const cursorJoinedAt = new Date(query.cursor__joined_at);
+    const cursorOperator = this.getCursorOperator(query.order__joined_at);
+
+    return {
+      OR: [
+        {
+          joinedAt: {
+            [cursorOperator]: cursorJoinedAt,
+          },
+        },
+        {
+          joinedAt: cursorJoinedAt,
+          id: {
+            [cursorOperator]: query.cursor__id,
+          },
+        },
+      ],
+    };
+  }
+
+  private getCursorOperator(orderDirection: BandMemberOrderDirection): 'lt' | 'gt' {
+    if (orderDirection === 'desc') {
+      return 'lt';
+    }
+
+    return 'gt';
+  }
+
+  private mapBandMemberListItem(
+    member: Prisma.BandMemberGetPayload<{
+      include: {
+        user: {
+          include: {
+            profile: {
+              select: {
+                nickname: true;
+                avatarUrl: true;
+              };
+            };
+            userSkills: {
+              include: {
+                skillType: {
+                  select: {
+                    name: true;
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    }>,
+  ): BandMemberListItem {
+    return {
+      bandMemberId: member.id,
+      userId: member.userId,
+      nickname: member.user.profile?.nickname ?? '',
+      avatarUrl: member.user.profile?.avatarUrl ?? null,
+      role: member.role,
+      joinedAt: member.joinedAt.toISOString(),
+      skills: member.user.userSkills.map(skill => ({
+        skillTypeId: skill.skillTypeId,
+        skillName: skill.skillType.name,
+        skillLevel: skill.skillLevel,
+        isPrimary: skill.isPrimary,
+      })),
     };
   }
 

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -1,0 +1,188 @@
+import { Injectable } from '@nestjs/common';
+
+import { PrismaService } from '../../../database/prisma';
+import type { Prisma } from '../../../generated/prisma';
+import type { BandGenreItem, CreateBandInvitationSuccessItem } from '../types/create-band-result.type';
+
+import type { BandsRepository, CreateBandRepositoryInput, CreateBandRepositoryResult } from './bands.repository';
+
+@Injectable()
+export class BandsPrismaRepository implements BandsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 상위 Service가 넘긴 트랜잭션이 있으면 같은 작업 단위 안에서 밴드를 생성한다.
+   *
+   * @param {CreateBandRepositoryInput} input - Service에서 정책 검증이 끝난 밴드 생성 입력값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<CreateBandRepositoryResult>} 생성된 밴드와 성공한 초대 목록
+   */
+  async createBand(input: CreateBandRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandRepositoryResult> {
+    const client = tx ?? this.prisma;
+
+    const band = await client.band.create({
+      data: {
+        name: input.name,
+        description: input.description,
+        visibility: input.visibility,
+        coverImgUrl: input.coverImgUrl,
+        bandMasterUserId: input.bandMasterUserId,
+      },
+    });
+
+    const bandMasterMember = await client.bandMember.create({
+      data: {
+        bandId: band.id,
+        userId: input.bandMasterUserId,
+        role: 'BM',
+      },
+    });
+
+    if (input.genreIds.length > 0) {
+      await client.bandGenre.createMany({
+        data: input.genreIds.map(genreId => ({
+          bandId: band.id,
+          genreId,
+        })),
+      });
+    }
+
+    const createdInvitations = await Promise.all(
+      input.inviteeUserIds.map(inviteeUserId =>
+        client.bandInvitation.create({
+          data: {
+            bandId: band.id,
+            inviterBandMemberId: bandMasterMember.id,
+            inviteeUserId,
+          },
+          select: {
+            id: true,
+            inviteeUserId: true,
+          },
+        }),
+      ),
+    );
+
+    const genres = await client.genre.findMany({
+      where: {
+        id: {
+          in: input.genreIds,
+        },
+      },
+      select: {
+        id: true,
+        name: true,
+      },
+    });
+
+    return {
+      band: {
+        id: band.id,
+        name: band.name ?? input.name,
+        description: band.description,
+        visibility: band.visibility ?? input.visibility,
+        coverImgUrl: band.coverImgUrl,
+        genres: this.mapGenres(input.genreIds, genres),
+        bandMasterUserId: band.bandMasterUserId,
+        createdAt: band.createdAt.toISOString(),
+        invitations: {
+          success: this.mapInvitationSuccess(createdInvitations),
+          failed: [],
+        },
+      },
+    };
+  }
+
+  /**
+   * 요청받은 장르 ID 중 DB에 실제 존재하는 ID만 조회한다.
+   *
+   * @param {string[]} genreIds - 확인할 장르 ID 목록
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<string[]>} 존재하는 장르 ID 목록
+   */
+  async findExistingGenreIds(genreIds: string[], tx?: Prisma.TransactionClient): Promise<string[]> {
+    if (genreIds.length === 0) {
+      return [];
+    }
+
+    const client = tx ?? this.prisma;
+
+    const genres = await client.genre.findMany({
+      where: {
+        id: {
+          in: genreIds,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    return genres.map(genre => genre.id);
+  }
+
+  /**
+   * 요청받은 사용자 ID 중 초대 대상으로 사용할 수 있는 활성 사용자 ID만 조회한다.
+   *
+   * @param {string[]} userIds - 확인할 사용자 ID 목록
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<string[]>} 존재하는 활성 사용자 ID 목록
+   */
+  async findExistingUserIds(userIds: string[], tx?: Prisma.TransactionClient): Promise<string[]> {
+    if (userIds.length === 0) {
+      return [];
+    }
+
+    const client = tx ?? this.prisma;
+
+    const users = await client.user.findMany({
+      where: {
+        id: {
+          in: userIds,
+        },
+        deletedAt: null,
+        status: 'ACTIVE',
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    return users.map(user => user.id);
+  }
+
+  private mapGenres(
+    genreIds: string[],
+    genres: {
+      id: string;
+      name: string | null;
+    }[],
+  ): BandGenreItem[] {
+    return genreIds.flatMap(genreId => {
+      const genre = genres.find(item => item.id === genreId);
+
+      if (genre === undefined) {
+        return [];
+      }
+
+      return [
+        {
+          id: genre.id,
+          name: genre.name ?? '',
+        },
+      ];
+    });
+  }
+
+  private mapInvitationSuccess(
+    invitations: {
+      id: string;
+      inviteeUserId: string;
+    }[],
+  ): CreateBandInvitationSuccessItem[] {
+    return invitations.map(invitation => ({
+      userId: invitation.inviteeUserId,
+      invitationId: invitation.id,
+    }));
+  }
+}

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -2,9 +2,11 @@ import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from '../../../database/prisma';
 import type { Prisma } from '../../../generated/prisma';
+import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
 import type { BandGenreItem, CreateBandInvitationSuccessItem } from '../types/create-band-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
+import type { GetMyBandsResult, MyBandListItem } from '../types/my-band-list.type';
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
 
 import type { BandsRepository, CreateBandRepositoryInput, CreateBandRepositoryResult } from './bands.repository';
@@ -123,6 +125,64 @@ export class BandsPrismaRepository implements BandsRepository {
     return {
       bandId: deletedBand.id,
       deletedAt: (deletedBand.deletedAt ?? deletedAt).toISOString(),
+    };
+  }
+
+  /**
+   * 사용자가 멤버로 속한 삭제되지 않은 밴드를 고정 정렬 기준으로 조회한다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {GetMyBandsQuery} query - 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetMyBandsResult>} 내가 속한 밴드 목록
+   */
+  async findMyBands(userId: string, query: GetMyBandsQuery, tx?: Prisma.TransactionClient): Promise<GetMyBandsResult> {
+    const client = tx ?? this.prisma;
+
+    const bands = await client.band.findMany({
+      where: {
+        deletedAt: null,
+        members: {
+          some: {
+            userId,
+          },
+        },
+        ...this.createMyBandsCursorWhere(query),
+      },
+      include: {
+        members: {
+          where: {
+            userId,
+          },
+          select: {
+            role: true,
+            joinedAt: true,
+          },
+          take: 1,
+        },
+        _count: {
+          select: {
+            members: true,
+          },
+        },
+      },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: query.take,
+    });
+
+    const items = bands.flatMap(band => this.mapMyBandListItem(band));
+    const count = items.length;
+    const cursor = count > 0 ? { createdAt: items[0].createdAt, id: items[0].id } : null;
+    const next = count === query.take ? { createdAt: items[count - 1].createdAt, id: items[count - 1].id } : null;
+
+    return {
+      items,
+      meta: {
+        count,
+        take: query.take,
+        cursor,
+        next,
+      },
     };
   }
 
@@ -304,6 +364,67 @@ export class BandsPrismaRepository implements BandsRepository {
     });
 
     return users.map(user => user.id);
+  }
+
+  private createMyBandsCursorWhere(query: GetMyBandsQuery): Prisma.BandWhereInput {
+    if (query.cursor__created_at === undefined || query.cursor__id === undefined) {
+      return {};
+    }
+
+    const cursorCreatedAt = new Date(query.cursor__created_at);
+
+    return {
+      OR: [
+        {
+          createdAt: {
+            lt: cursorCreatedAt,
+          },
+        },
+        {
+          createdAt: cursorCreatedAt,
+          id: {
+            lt: query.cursor__id,
+          },
+        },
+      ],
+    };
+  }
+
+  private mapMyBandListItem(
+    band: Prisma.BandGetPayload<{
+      include: {
+        members: {
+          select: {
+            role: true;
+            joinedAt: true;
+          };
+        };
+        _count: {
+          select: {
+            members: true;
+          };
+        };
+      };
+    }>,
+  ): MyBandListItem[] {
+    const myMember = band.members[0];
+
+    if (myMember === undefined) {
+      return [];
+    }
+
+    return [
+      {
+        id: band.id,
+        name: band.name ?? '',
+        description: band.description,
+        visibility: band.visibility ?? true,
+        myRole: myMember.role,
+        joinedAt: myMember.joinedAt.toISOString(),
+        createdAt: band.createdAt.toISOString(),
+        memberCount: band._count.members,
+      },
+    ];
   }
 
   private mapGenres(

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -65,7 +65,7 @@ export interface BandsRepository {
     bandMasterUserId: string;
   } | null>;
   updateBand(bandId: string, input: UpdateBandInput, tx?: Prisma.TransactionClient): Promise<UpdateBandResult>;
-  findBandMemberForRoleUpdate(
+  findBandMemberByBandIdAndUserId(
     bandId: string,
     userId: string,
     tx?: Prisma.TransactionClient,

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -1,6 +1,7 @@
 import type { Prisma } from '../../../generated/prisma';
 import type { CreateBandInput } from '../dto/create-band.dto';
 import type { CreateBandInvitationSuccessItem, CreateBandResult } from '../types/create-band-result.type';
+import type { DeleteBandResult } from '../types/delete-band-result.type';
 
 export const BANDS_REPOSITORY = Symbol('BANDS_REPOSITORY');
 
@@ -21,6 +22,14 @@ export interface CreateBandRepositoryResult extends CreateBandResult {
 
 export interface BandsRepository {
   createBand(input: CreateBandRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandRepositoryResult>;
+  deleteBand(bandId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteBandResult>;
+  findBandForDelete(
+    bandId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    bandMasterUserId: string;
+  } | null>;
   findExistingGenreIds(genreIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;
   findExistingUserIds(userIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;
 }

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -2,8 +2,10 @@ import type { Prisma } from '../../../generated/prisma';
 import type { CreateBandInput } from '../dto/create-band.dto';
 import type { GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
+import type { SearchBandsQuery } from '../dto/search-bands-query.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
 import type { GetBandMembersResult } from '../types/band-member-list.type';
+import type { SearchBandsResult } from '../types/band-search-result.type';
 import type { CreateBandInvitationSuccessItem, CreateBandResult } from '../types/create-band-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { GetMyBandsResult } from '../types/my-band-list.type';
@@ -39,6 +41,7 @@ export interface BandsRepository {
   } | null>;
   findBandMembers(bandId: string, query: GetBandMembersQuery, tx?: Prisma.TransactionClient): Promise<GetBandMembersResult>;
   findMyBands(userId: string, query: GetMyBandsQuery, tx?: Prisma.TransactionClient): Promise<GetMyBandsResult>;
+  searchBands(query: SearchBandsQuery, tx?: Prisma.TransactionClient): Promise<SearchBandsResult>;
   findBandForMemberRoleUpdate(
     bandId: string,
     tx?: Prisma.TransactionClient,

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from '../../../generated/prisma';
+import type { BandMemberRole, Prisma } from '../../../generated/prisma';
 import type { CreateBandInput } from '../dto/create-band.dto';
 import type { GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
@@ -9,6 +9,7 @@ import type { GetBandMembersResult } from '../types/band-member-list.type';
 import type { SearchBandsResult } from '../types/band-search-result.type';
 import type { CreateBandInvitationSuccessItem, CreateBandResult } from '../types/create-band-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
+import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult } from '../types/my-band-list.type';
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
 import type { UpdateBandResult } from '../types/update-band-result.type';
@@ -33,6 +34,18 @@ export interface CreateBandRepositoryResult extends CreateBandResult {
 export interface BandsRepository {
   createBand(input: CreateBandRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandRepositoryResult>;
   deleteBand(bandId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteBandResult>;
+  findBandForLeave(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    member: {
+      id: string;
+      role: BandMemberRole;
+    } | null;
+  } | null>;
+  leaveBand(bandMemberId: string, tx?: Prisma.TransactionClient): Promise<LeaveBandResult>;
   findBandForMemberList(
     bandId: string,
     requesterUserId: string,

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -1,7 +1,9 @@
 import type { Prisma } from '../../../generated/prisma';
 import type { CreateBandInput } from '../dto/create-band.dto';
+import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
 import type { CreateBandInvitationSuccessItem, CreateBandResult } from '../types/create-band-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
+import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
 
 export const BANDS_REPOSITORY = Symbol('BANDS_REPOSITORY');
 
@@ -23,6 +25,21 @@ export interface CreateBandRepositoryResult extends CreateBandResult {
 export interface BandsRepository {
   createBand(input: CreateBandRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandRepositoryResult>;
   deleteBand(bandId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteBandResult>;
+  findBandForMemberRoleUpdate(
+    bandId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    bandMasterUserId: string;
+  } | null>;
+  findBandMemberForRoleUpdate(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    userId: string;
+  } | null>;
   findBandForDelete(
     bandId: string,
     tx?: Prisma.TransactionClient,
@@ -32,4 +49,5 @@ export interface BandsRepository {
   } | null>;
   findExistingGenreIds(genreIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;
   findExistingUserIds(userIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;
+  updateBandMemberRole(bandMemberId: string, input: UpdateBandMemberRoleInput, tx?: Prisma.TransactionClient): Promise<UpdateBandMemberRoleResult>;
 }

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -1,0 +1,26 @@
+import type { Prisma } from '../../../generated/prisma';
+import type { CreateBandInput } from '../dto/create-band.dto';
+import type { CreateBandInvitationSuccessItem, CreateBandResult } from '../types/create-band-result.type';
+
+export const BANDS_REPOSITORY = Symbol('BANDS_REPOSITORY');
+
+export interface CreateBandRepositoryInput extends CreateBandInput {
+  bandMasterUserId: string;
+  genreIds: string[];
+  inviteeUserIds: string[];
+}
+
+export interface CreateBandRepositoryResult extends CreateBandResult {
+  band: CreateBandResult['band'] & {
+    invitations: {
+      success: CreateBandInvitationSuccessItem[];
+      failed: [];
+    };
+  };
+}
+
+export interface BandsRepository {
+  createBand(input: CreateBandRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandRepositoryResult>;
+  findExistingGenreIds(genreIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;
+  findExistingUserIds(userIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;
+}

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -57,7 +57,7 @@ export interface BandsRepository {
   findBandMembers(bandId: string, query: GetBandMembersQuery, tx?: Prisma.TransactionClient): Promise<GetBandMembersResult>;
   findMyBands(userId: string, query: GetMyBandsQuery, tx?: Prisma.TransactionClient): Promise<GetMyBandsResult>;
   searchBands(query: SearchBandsQuery, tx?: Prisma.TransactionClient): Promise<SearchBandsResult>;
-  findBandForUpdate(
+  findActiveBandById(
     bandId: string,
     tx?: Prisma.TransactionClient,
   ): Promise<{
@@ -65,13 +65,6 @@ export interface BandsRepository {
     bandMasterUserId: string;
   } | null>;
   updateBand(bandId: string, input: UpdateBandInput, tx?: Prisma.TransactionClient): Promise<UpdateBandResult>;
-  findBandForMemberRoleUpdate(
-    bandId: string,
-    tx?: Prisma.TransactionClient,
-  ): Promise<{
-    id: string;
-    bandMasterUserId: string;
-  } | null>;
   findBandMemberForRoleUpdate(
     bandId: string,
     userId: string,
@@ -79,13 +72,6 @@ export interface BandsRepository {
   ): Promise<{
     id: string;
     userId: string;
-  } | null>;
-  findBandForDelete(
-    bandId: string,
-    tx?: Prisma.TransactionClient,
-  ): Promise<{
-    id: string;
-    bandMasterUserId: string;
   } | null>;
   findExistingGenreIds(genreIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;
   findExistingUserIds(userIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -46,14 +46,6 @@ export interface BandsRepository {
     } | null;
   } | null>;
   leaveBand(bandMemberId: string, tx?: Prisma.TransactionClient): Promise<LeaveBandResult>;
-  findBandForMemberList(
-    bandId: string,
-    requesterUserId: string,
-    tx?: Prisma.TransactionClient,
-  ): Promise<{
-    id: string;
-    requesterMemberId: string | null;
-  } | null>;
   findBandMembers(bandId: string, query: GetBandMembersQuery, tx?: Prisma.TransactionClient): Promise<GetBandMembersResult>;
   findMyBands(userId: string, query: GetMyBandsQuery, tx?: Prisma.TransactionClient): Promise<GetMyBandsResult>;
   searchBands(query: SearchBandsQuery, tx?: Prisma.TransactionClient): Promise<SearchBandsResult>;

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -3,6 +3,7 @@ import type { CreateBandInput } from '../dto/create-band.dto';
 import type { GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { SearchBandsQuery } from '../dto/search-bands-query.dto';
+import type { UpdateBandInput } from '../dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
 import type { GetBandMembersResult } from '../types/band-member-list.type';
 import type { SearchBandsResult } from '../types/band-search-result.type';
@@ -10,6 +11,7 @@ import type { CreateBandInvitationSuccessItem, CreateBandResult } from '../types
 import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { GetMyBandsResult } from '../types/my-band-list.type';
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
+import type { UpdateBandResult } from '../types/update-band-result.type';
 
 export const BANDS_REPOSITORY = Symbol('BANDS_REPOSITORY');
 
@@ -42,6 +44,14 @@ export interface BandsRepository {
   findBandMembers(bandId: string, query: GetBandMembersQuery, tx?: Prisma.TransactionClient): Promise<GetBandMembersResult>;
   findMyBands(userId: string, query: GetMyBandsQuery, tx?: Prisma.TransactionClient): Promise<GetMyBandsResult>;
   searchBands(query: SearchBandsQuery, tx?: Prisma.TransactionClient): Promise<SearchBandsResult>;
+  findBandForUpdate(
+    bandId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    bandMasterUserId: string;
+  } | null>;
+  updateBand(bandId: string, input: UpdateBandInput, tx?: Prisma.TransactionClient): Promise<UpdateBandResult>;
   findBandForMemberRoleUpdate(
     bandId: string,
     tx?: Prisma.TransactionClient,

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -1,8 +1,10 @@
 import type { Prisma } from '../../../generated/prisma';
 import type { CreateBandInput } from '../dto/create-band.dto';
+import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
 import type { CreateBandInvitationSuccessItem, CreateBandResult } from '../types/create-band-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
+import type { GetMyBandsResult } from '../types/my-band-list.type';
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
 
 export const BANDS_REPOSITORY = Symbol('BANDS_REPOSITORY');
@@ -25,6 +27,7 @@ export interface CreateBandRepositoryResult extends CreateBandResult {
 export interface BandsRepository {
   createBand(input: CreateBandRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandRepositoryResult>;
   deleteBand(bandId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteBandResult>;
+  findMyBands(userId: string, query: GetMyBandsQuery, tx?: Prisma.TransactionClient): Promise<GetMyBandsResult>;
   findBandForMemberRoleUpdate(
     bandId: string,
     tx?: Prisma.TransactionClient,

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -1,7 +1,9 @@
 import type { Prisma } from '../../../generated/prisma';
 import type { CreateBandInput } from '../dto/create-band.dto';
+import type { GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
+import type { GetBandMembersResult } from '../types/band-member-list.type';
 import type { CreateBandInvitationSuccessItem, CreateBandResult } from '../types/create-band-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { GetMyBandsResult } from '../types/my-band-list.type';
@@ -27,6 +29,15 @@ export interface CreateBandRepositoryResult extends CreateBandResult {
 export interface BandsRepository {
   createBand(input: CreateBandRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandRepositoryResult>;
   deleteBand(bandId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteBandResult>;
+  findBandForMemberList(
+    bandId: string,
+    requesterUserId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    requesterMemberId: string | null;
+  } | null>;
+  findBandMembers(bandId: string, query: GetBandMembersQuery, tx?: Prisma.TransactionClient): Promise<GetBandMembersResult>;
   findMyBands(userId: string, query: GetMyBandsQuery, tx?: Prisma.TransactionClient): Promise<GetMyBandsResult>;
   findBandForMemberRoleUpdate(
     bandId: string,

--- a/backend/src/modules/bands/types/band-member-list.type.ts
+++ b/backend/src/modules/bands/types/band-member-list.type.ts
@@ -1,0 +1,34 @@
+import type { BandMemberRole, SkillLevelType } from '../../../generated/prisma';
+
+export interface BandMemberSkillItem {
+  skillTypeId: string;
+  skillName: string;
+  skillLevel: SkillLevelType;
+  isPrimary: boolean;
+}
+
+export interface BandMemberListItem {
+  bandMemberId: string;
+  userId: string;
+  nickname: string;
+  avatarUrl: string | null;
+  role: BandMemberRole;
+  joinedAt: string;
+  skills: BandMemberSkillItem[];
+}
+
+export interface BandMemberListCursor {
+  joinedAt: string;
+  id: string;
+}
+
+export interface GetBandMembersResult {
+  bandId: string;
+  members: BandMemberListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: BandMemberListCursor | null;
+    next: BandMemberListCursor | null;
+  };
+}

--- a/backend/src/modules/bands/types/band-search-result.type.ts
+++ b/backend/src/modules/bands/types/band-search-result.type.ts
@@ -1,0 +1,28 @@
+export interface BandSearchListItem {
+  bandId: string;
+  name: string;
+  description: string | null;
+  visibility: boolean;
+  memberCount: number;
+  bandMaster: {
+    userId: string;
+    nickname: string;
+  };
+  createdAt: string;
+}
+
+export interface BandSearchCursor {
+  createdAt: string;
+  id: string;
+}
+
+export interface SearchBandsResult {
+  keyword: string | null;
+  items: BandSearchListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: BandSearchCursor | null;
+    next: BandSearchCursor | null;
+  };
+}

--- a/backend/src/modules/bands/types/create-band-result.type.ts
+++ b/backend/src/modules/bands/types/create-band-result.type.ts
@@ -1,0 +1,31 @@
+export interface BandGenreItem {
+  id: string;
+  name: string;
+}
+
+export interface CreateBandInvitationSuccessItem {
+  userId: string;
+  invitationId: string;
+}
+
+export interface CreateBandInvitationFailedItem {
+  userId: string;
+  reason: string;
+}
+
+export interface CreateBandResult {
+  band: {
+    id: string;
+    name: string;
+    description: string | null;
+    visibility: boolean;
+    coverImgUrl: string | null;
+    genres: BandGenreItem[];
+    bandMasterUserId: string;
+    createdAt: string;
+    invitations: {
+      success: CreateBandInvitationSuccessItem[];
+      failed: CreateBandInvitationFailedItem[];
+    };
+  };
+}

--- a/backend/src/modules/bands/types/delete-band-result.type.ts
+++ b/backend/src/modules/bands/types/delete-band-result.type.ts
@@ -1,0 +1,4 @@
+export interface DeleteBandResult {
+  bandId: string;
+  deletedAt: string;
+}

--- a/backend/src/modules/bands/types/leave-band-result.type.ts
+++ b/backend/src/modules/bands/types/leave-band-result.type.ts
@@ -1,0 +1,4 @@
+export interface LeaveBandResult {
+  bandId: string;
+  userId: string;
+}

--- a/backend/src/modules/bands/types/my-band-list.type.ts
+++ b/backend/src/modules/bands/types/my-band-list.type.ts
@@ -1,0 +1,27 @@
+import type { BandMemberRole } from '../../../generated/prisma';
+
+export interface MyBandListItem {
+  id: string;
+  name: string;
+  description: string | null;
+  visibility: boolean;
+  myRole: BandMemberRole;
+  joinedAt: string;
+  createdAt: string;
+  memberCount: number;
+}
+
+export interface MyBandListCursor {
+  createdAt: string;
+  id: string;
+}
+
+export interface GetMyBandsResult {
+  items: MyBandListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: MyBandListCursor | null;
+    next: MyBandListCursor | null;
+  };
+}

--- a/backend/src/modules/bands/types/update-band-member-role-result.type.ts
+++ b/backend/src/modules/bands/types/update-band-member-role-result.type.ts
@@ -1,0 +1,8 @@
+import type { BandMemberRole } from '../../../generated/prisma';
+
+export interface UpdateBandMemberRoleResult {
+  member: {
+    userId: string;
+    role: BandMemberRole;
+  };
+}

--- a/backend/src/modules/bands/types/update-band-result.type.ts
+++ b/backend/src/modules/bands/types/update-band-result.type.ts
@@ -1,0 +1,8 @@
+export interface UpdateBandResult {
+  bandId: string;
+  name: string;
+  description: string | null;
+  visibility: boolean;
+  coverImgUrl: string | null;
+  updatedAt: string;
+}


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 20분

<br/>

## 📌 작업 요약

- 밴드 도메인 API 작업
- 생성 / 삭제 / 내 밴드 목록 / 멤버 권한 변경 / 멤버 목록 / 검색 / 정보 수정 / 밴드 나가기
- Service, Repository 모두 `tx?` 선택 인자 패턴 적용

<br/>

## 📝 작업 내용

1. 밴드 생성
   - 인증 필요
   - 인증 사용자를 BM으로 생성
   - 밴드 생성, BM 멤버 생성, 장르 연결, 초대 생성을 하나의 transaction으로 처리
   - `coverImgUrl`은 요청값 저장만 처리

2. 밴드 삭제
   - `Band.deletedAt` 기준 soft delete
   - 밴드장만 삭제 가능

3. 내 밴드 목록
   - 인증 사용자 기준으로 가입한 밴드만 조회
   - 삭제된 밴드 제외
   - 기존 목록 API 스타일대로 cursor meta 유지

4. 밴드 멤버 권한 변경
   - BM은 밴드장
   - `ADMIN`은 부리더, `MEMBER`는 일반 멤버
   - 이 API에서는 `ADMIN`, `MEMBER`만 부여 가능
   - `BandMember.updatedAt`이 없어 응답에서도 제외

5. 밴드 멤버 목록
   - 밴드 멤버만 조회 가능
   - `BandMember.createdAt`이 없어 `joinedAt + id`로 정렬
   - 정렬 query: `order__joined_at`, `order__id`
   - cursor query: `cursor__joined_at`, `cursor__id`
   - 두 order 값은 같은 방향만 허용
   - 응답 목록 필드는 `members`
   - 총 공연 횟수는 일단 제외. 논의 필요함
   - 프로필 이미지와 세션 정보 포함

6. 밴드 검색
   - 인증 없음
   - 공개 밴드만 조회: `visibility=true`, `deletedAt=null`
   - `Band.name` 기준 검색
   - 응답 목록 필드는 `items`
   - 정렬 기준은 `createdAt + id`
   - #12의 `cursor__id`는 `Band.id`

7. 밴드 정보 수정
   - 인증 필요
   - 밴드장만 수정 가능
   - 수정 가능 필드: `name`, `description`, `visibility`, `coverImgUrl`
   - `description`, `coverImgUrl`은 `null`로 제거 가능
   - BM 변경과 장르 수정은 제외

8. 밴드 나가기
   - 인증 필요
   - `DELETE /bands/:bandId/me`
   - `leftAt` 컬럼이 없어 응답에서 제외
   - `BandMember` hard delete
   - BM은 이 API로 나갈 수 없음

<br/>

## 🚨 주요 고민 및 해결 과정

### transaction

- Repository는 `tx ?? this.prisma` 패턴으로 통일
- Service는 필요한 경우에만 `$transaction`으로 경계 설정
- 외부 transaction이 있으면 그대로 사용

### cursor pagination

- cursor는 정렬 기준과 같은 필드를 사용
- 복합 정렬 방향은 같은 방향만 허용
- 멤버 목록: `joinedAt + id`
- 밴드 검색: `createdAt + id`

### BM 정책

- BM은 별도 권한으로 분리
- 권한 변경 API에서 BM 부여 불가
- 밴드 나가기 API에서 BM 탈퇴 불가
- BM 위임은 별도 API로 분리 필요

<br/>

## 📑 참고 문서/ ADR

- Notion 밴드 API 명세
- Prisma schema

<br/>

## 💬 리뷰 요구사항

- `tx?` 패턴 알맞게 사용되었는지
- cursor query / order query 정책 괜찮은지
- BM 관련 정책 괜찮은지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 밴드 생성·수정·삭제, 공개 밴드 검색, 내 밴드 목록, 밴드별 멤버 목록 및 상세 조회, 멤버 초대·탈퇴·역할 변경 기능 추가
* **Tests**
  * 밴드 서비스의 광범위한 단위 테스트 추가(생성/삭제/탈퇴/조회/검색/수정/역할 변경 시나리오 검증)
* **Chores**
  * 밴드 관련 모듈이 앱에 등록되어 서비스로 노출됨

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BandCo-House/BandCo/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->