### PR TITLE
[KAN-35] 곡 도메인 API 구현

### DIFF
--- a/backend/src/modules/skills/repositories/skills.prisma-repository.spec.ts
+++ b/backend/src/modules/skills/repositories/skills.prisma-repository.spec.ts
@@ -1,0 +1,52 @@
+import type { PrismaService } from '../../../database/prisma';
+
+import { SkillsPrismaRepository } from './skills.prisma-repository';
+
+const createPrismaMock = () => ({
+  skillType: {
+    findMany: jest.fn(),
+  },
+});
+
+describe('SkillsPrismaRepository', () => {
+  let prisma: ReturnType<typeof createPrismaMock>;
+  let repository: SkillsPrismaRepository;
+
+  beforeEach(() => {
+    prisma = createPrismaMock();
+    repository = new SkillsPrismaRepository(prisma as unknown as PrismaService);
+  });
+
+  describe('findExistingSkillTypeIds', () => {
+    it('존재하는 세션 타입 ID만 의미 있는 타입으로 감싸 반환한다', async () => {
+      prisma.skillType.findMany.mockResolvedValue([{ id: 'skill-type-1' }, { id: 'skill-type-2' }]);
+
+      const result = await repository.findExistingSkillTypeIds(['skill-type-1', 'skill-type-2']);
+
+      expect(prisma.skillType.findMany).toHaveBeenCalledWith({
+        where: {
+          id: {
+            in: ['skill-type-1', 'skill-type-2'],
+          },
+        },
+        select: {
+          id: true,
+        },
+      });
+      expect(result).toEqual({ skillTypeIds: ['skill-type-1', 'skill-type-2'] });
+    });
+
+    it('tx가 전달되면 tx 클라이언트를 사용한다', async () => {
+      const tx = {
+        skillType: {
+          findMany: jest.fn().mockResolvedValue([]),
+        },
+      };
+
+      await repository.findExistingSkillTypeIds(['skill-type-1'], tx as never);
+
+      expect(tx.skillType.findMany).toHaveBeenCalled();
+      expect(prisma.skillType.findMany).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/skills/repositories/skills.prisma-repository.ts
+++ b/backend/src/modules/skills/repositories/skills.prisma-repository.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+
+import { PrismaService } from '../../../database/prisma';
+import type { Prisma } from '../../../generated/prisma';
+import type { ExistingSkillTypeIdsResult } from '../types/existing-skill-type-ids-result.type';
+
+import type { SkillsRepository } from './skills.repository';
+
+@Injectable()
+export class SkillsPrismaRepository implements SkillsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 요청받은 세션 타입 ID가 실제로 존재하는지 확인한다.
+   *
+   * @param {string[]} skillTypeIds - 확인할 세션 타입 ID 목록
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<ExistingSkillTypeIdsResult>} 존재하는 세션 타입 ID 목록
+   */
+  async findExistingSkillTypeIds(skillTypeIds: string[], tx?: Prisma.TransactionClient): Promise<ExistingSkillTypeIdsResult> {
+    const client = tx ?? this.prisma;
+
+    const skillTypes = await client.skillType.findMany({
+      where: {
+        id: {
+          in: skillTypeIds,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    return {
+      skillTypeIds: skillTypes.map(skillType => skillType.id),
+    };
+  }
+}

--- a/backend/src/modules/skills/repositories/skills.repository.ts
+++ b/backend/src/modules/skills/repositories/skills.repository.ts
@@ -1,0 +1,8 @@
+import type { Prisma } from '../../../generated/prisma';
+import type { ExistingSkillTypeIdsResult } from '../types/existing-skill-type-ids-result.type';
+
+export const SKILLS_REPOSITORY = Symbol('SKILLS_REPOSITORY');
+
+export interface SkillsRepository {
+  findExistingSkillTypeIds(skillTypeIds: string[], tx?: Prisma.TransactionClient): Promise<ExistingSkillTypeIdsResult>;
+}

--- a/backend/src/modules/skills/skills.module.ts
+++ b/backend/src/modules/skills/skills.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+
+import { SkillsPrismaRepository } from './repositories/skills.prisma-repository';
+import { SKILLS_REPOSITORY } from './repositories/skills.repository';
+import { SkillsService } from './skills.service';
+
+@Module({
+  providers: [
+    SkillsService,
+    SkillsPrismaRepository,
+    {
+      provide: SKILLS_REPOSITORY,
+      useExisting: SkillsPrismaRepository,
+    },
+  ],
+  exports: [SkillsService],
+})
+export class SkillsModule {}

--- a/backend/src/modules/skills/skills.service.spec.ts
+++ b/backend/src/modules/skills/skills.service.spec.ts
@@ -1,0 +1,30 @@
+import type { SkillsRepository } from './repositories/skills.repository';
+import { SkillsService } from './skills.service';
+
+describe('SkillsService', () => {
+  const createService = () => {
+    const repository: jest.Mocked<SkillsRepository> = {
+      findExistingSkillTypeIds: jest.fn(),
+    };
+
+    const service = new SkillsService(repository);
+
+    return {
+      repository,
+      service,
+    };
+  };
+
+  describe('findExistingSkillTypeIds', () => {
+    it('Repository 결과를 그대로 반환한다', async () => {
+      const { repository, service } = createService();
+
+      repository.findExistingSkillTypeIds.mockResolvedValue({ skillTypeIds: ['skill-type-1'] });
+
+      const result = await service.findExistingSkillTypeIds(['skill-type-1']);
+
+      expect(repository.findExistingSkillTypeIds).toHaveBeenCalledWith(['skill-type-1'], undefined);
+      expect(result).toEqual({ skillTypeIds: ['skill-type-1'] });
+    });
+  });
+});

--- a/backend/src/modules/skills/skills.service.ts
+++ b/backend/src/modules/skills/skills.service.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import type { Prisma } from '../../generated/prisma';
+
+import { SKILLS_REPOSITORY, type SkillsRepository } from './repositories/skills.repository';
+import type { ExistingSkillTypeIdsResult } from './types/existing-skill-type-ids-result.type';
+
+@Injectable()
+export class SkillsService {
+  constructor(
+    @Inject(SKILLS_REPOSITORY)
+    private readonly skillsRepository: SkillsRepository,
+  ) {}
+
+  async findExistingSkillTypeIds(skillTypeIds: string[], tx?: Prisma.TransactionClient): Promise<ExistingSkillTypeIdsResult> {
+    return this.skillsRepository.findExistingSkillTypeIds(skillTypeIds, tx);
+  }
+}

--- a/backend/src/modules/skills/types/existing-skill-type-ids-result.type.ts
+++ b/backend/src/modules/skills/types/existing-skill-type-ids-result.type.ts
@@ -1,0 +1,3 @@
+export interface ExistingSkillTypeIdsResult {
+  skillTypeIds: string[];
+}

--- a/backend/src/modules/songs/dto/create-song.dto.ts
+++ b/backend/src/modules/songs/dto/create-song.dto.ts
@@ -1,0 +1,72 @@
+import { Transform } from 'class-transformer';
+import { IsArray, IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
+
+import { normalizeOptionalStringValue, trimStringValue } from '../../../common/validation/transform.util';
+import { enumValidationMessage } from '../../../common/validation-message/enum-validation.message';
+import { lengthValidationMessage } from '../../../common/validation-message/length-validation.message';
+import { notemptyValidationMessage } from '../../../common/validation-message/notempty-validation.message';
+import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
+import { uuidValidationMessage } from '../../../common/validation-message/uuid-validation.message';
+import type { SongSourceType } from '../types/song-preview.type';
+
+export const SONG_SOURCE_TYPES = ['SPOTIFY', 'DEEZER'] as const satisfies readonly SongSourceType[];
+
+/**
+ * 곡 생성 요청 본문을 검증한다.
+ */
+export class CreateSongBodyDto {
+  @Transform(trimStringValue)
+  @IsString({
+    message: stringValidationMessage,
+  })
+  @IsNotEmpty({
+    message: notemptyValidationMessage,
+  })
+  @MaxLength(200, {
+    message: lengthValidationMessage,
+  })
+  title!: string;
+
+  @Transform(trimStringValue)
+  @IsString({
+    message: stringValidationMessage,
+  })
+  @IsNotEmpty({
+    message: notemptyValidationMessage,
+  })
+  @MaxLength(200, {
+    message: lengthValidationMessage,
+  })
+  artistName!: string;
+
+  @Transform(trimStringValue)
+  @IsString({
+    message: stringValidationMessage,
+  })
+  @IsNotEmpty({
+    message: notemptyValidationMessage,
+  })
+  sourceUrl!: string;
+
+  @IsEnum(SONG_SOURCE_TYPES, {
+    message: enumValidationMessage,
+  })
+  sourceType!: SongSourceType;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({
+    message: stringValidationMessage,
+  })
+  memo?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', {
+    each: true,
+    message: uuidValidationMessage,
+  })
+  skillTypeIds?: string[];
+}
+
+export type CreateSongInput = CreateSongBodyDto;

--- a/backend/src/modules/songs/dto/get-band-songs-query.dto.ts
+++ b/backend/src/modules/songs/dto/get-band-songs-query.dto.ts
@@ -1,0 +1,52 @@
+import { Transform } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, IsUUID, Min } from 'class-validator';
+
+import { normalizeOptionalStringValue, parseOptionalPositiveIntegerValue } from '../../../common/validation/transform.util';
+import { enumValidationMessage } from '../../../common/validation-message/enum-validation.message';
+import { intValidationMessage } from '../../../common/validation-message/int-validation.message';
+import { minValidationMessage } from '../../../common/validation-message/min-validation.message';
+import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
+import { uuidValidationMessage } from '../../../common/validation-message/uuid-validation.message';
+
+const ORDER_DIRECTIONS = ['asc', 'desc'] as const;
+export type SongListOrderDirection = (typeof ORDER_DIRECTIONS)[number];
+
+/**
+ * 곡 목록 조회 조건을 기존 커서 기반 목록 API 규칙에 맞춰 검증한다.
+ */
+export class GetBandSongsQueryDto {
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  where__title__contain?: string;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  where__artist_name__contain?: string;
+
+  @IsOptional()
+  @IsEnum(ORDER_DIRECTIONS, { message: enumValidationMessage })
+  order__created_at: SongListOrderDirection = 'desc';
+
+  @IsOptional()
+  @IsEnum(ORDER_DIRECTIONS, { message: enumValidationMessage })
+  order__id: SongListOrderDirection = 'desc';
+
+  @Transform(parseOptionalPositiveIntegerValue)
+  @IsInt({ message: intValidationMessage })
+  @Min(1, { message: minValidationMessage })
+  take: number = 20;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  cursor__created_at?: string;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  cursor__id?: string;
+}
+
+export type GetBandSongsQuery = GetBandSongsQueryDto;

--- a/backend/src/modules/songs/dto/get-band-songs-query.dto.ts
+++ b/backend/src/modules/songs/dto/get-band-songs-query.dto.ts
@@ -40,11 +40,6 @@ export class GetBandSongsQueryDto {
 
   @Transform(normalizeOptionalStringValue)
   @IsOptional()
-  @IsString({ message: stringValidationMessage })
-  cursor__created_at?: string;
-
-  @Transform(normalizeOptionalStringValue)
-  @IsOptional()
   @IsUUID(undefined, { message: uuidValidationMessage })
   cursor__id?: string;
 }

--- a/backend/src/modules/songs/dto/search-deezer-track-previews-query.dto.ts
+++ b/backend/src/modules/songs/dto/search-deezer-track-previews-query.dto.ts
@@ -1,0 +1,20 @@
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+import { trimStringValue } from '../../../common/validation/transform.util';
+import { notemptyValidationMessage } from '../../../common/validation-message/notempty-validation.message';
+import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
+
+/**
+ * Deezer 검색어는 외부 API 호출 전에 빈 문자열을 차단한다.
+ */
+export class SearchDeezerTrackPreviewsQueryDto {
+  @Transform(trimStringValue)
+  @IsString({
+    message: stringValidationMessage,
+  })
+  @IsNotEmpty({
+    message: notemptyValidationMessage,
+  })
+  query!: string;
+}

--- a/backend/src/modules/songs/dto/update-song.dto.ts
+++ b/backend/src/modules/songs/dto/update-song.dto.ts
@@ -1,0 +1,73 @@
+import { Transform } from 'class-transformer';
+import { IsArray, IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID, MaxLength, ValidateIf } from 'class-validator';
+
+import { normalizeOptionalStringValue, trimStringValue } from '../../../common/validation/transform.util';
+import { enumValidationMessage } from '../../../common/validation-message/enum-validation.message';
+import { lengthValidationMessage } from '../../../common/validation-message/length-validation.message';
+import { notemptyValidationMessage } from '../../../common/validation-message/notempty-validation.message';
+import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
+import { uuidValidationMessage } from '../../../common/validation-message/uuid-validation.message';
+import type { SongSourceType } from '../types/song-preview.type';
+
+import { SONG_SOURCE_TYPES } from './create-song.dto';
+
+/**
+ * 곡 수정 요청 본문은 PATCH 의미에 맞춰 전달된 필드만 검증한다.
+ */
+export class UpdateSongBodyDto {
+  @Transform(trimStringValue)
+  @ValidateIf((_, value) => value !== undefined)
+  @IsString({
+    message: stringValidationMessage,
+  })
+  @IsNotEmpty({
+    message: notemptyValidationMessage,
+  })
+  @MaxLength(200, {
+    message: lengthValidationMessage,
+  })
+  title?: string;
+
+  @Transform(trimStringValue)
+  @ValidateIf((_, value) => value !== undefined)
+  @IsString({
+    message: stringValidationMessage,
+  })
+  @IsNotEmpty({
+    message: notemptyValidationMessage,
+  })
+  @MaxLength(200, {
+    message: lengthValidationMessage,
+  })
+  artistName?: string;
+
+  @Transform(normalizeOptionalStringValue)
+  @ValidateIf((_, value) => value !== undefined && value !== null)
+  @IsString({
+    message: stringValidationMessage,
+  })
+  sourceUrl?: string | null;
+
+  @IsOptional()
+  @IsEnum(SONG_SOURCE_TYPES, {
+    message: enumValidationMessage,
+  })
+  sourceType?: SongSourceType | null;
+
+  @Transform(normalizeOptionalStringValue)
+  @ValidateIf((_, value) => value !== undefined && value !== null)
+  @IsString({
+    message: stringValidationMessage,
+  })
+  memo?: string | null;
+
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', {
+    each: true,
+    message: uuidValidationMessage,
+  })
+  skillTypeIds?: string[];
+}
+
+export type UpdateSongInput = UpdateSongBodyDto;

--- a/backend/src/modules/songs/dto/update-song.dto.ts
+++ b/backend/src/modules/songs/dto/update-song.dto.ts
@@ -1,5 +1,5 @@
 import { Transform } from 'class-transformer';
-import { IsArray, IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID, MaxLength, ValidateIf } from 'class-validator';
+import { IsArray, IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
 
 import { normalizeOptionalStringValue, trimStringValue } from '../../../common/validation/transform.util';
 import { enumValidationMessage } from '../../../common/validation-message/enum-validation.message';
@@ -16,7 +16,7 @@ import { SONG_SOURCE_TYPES } from './create-song.dto';
  */
 export class UpdateSongBodyDto {
   @Transform(trimStringValue)
-  @ValidateIf((_, value) => value !== undefined)
+  @IsOptional()
   @IsString({
     message: stringValidationMessage,
   })
@@ -29,7 +29,7 @@ export class UpdateSongBodyDto {
   title?: string;
 
   @Transform(trimStringValue)
-  @ValidateIf((_, value) => value !== undefined)
+  @IsOptional()
   @IsString({
     message: stringValidationMessage,
   })
@@ -42,7 +42,7 @@ export class UpdateSongBodyDto {
   artistName?: string;
 
   @Transform(normalizeOptionalStringValue)
-  @ValidateIf((_, value) => value !== undefined && value !== null)
+  @IsOptional()
   @IsString({
     message: stringValidationMessage,
   })
@@ -55,7 +55,7 @@ export class UpdateSongBodyDto {
   sourceType?: SongSourceType | null;
 
   @Transform(normalizeOptionalStringValue)
-  @ValidateIf((_, value) => value !== undefined && value !== null)
+  @IsOptional()
   @IsString({
     message: stringValidationMessage,
   })

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
@@ -634,6 +634,23 @@ describe('SongsPrismaRepository', () => {
       });
     });
 
+    it('삭제 대상 곡이 없으면 undefined를 반환한다', async () => {
+      prisma.song.delete.mockRejectedValue({
+        code: 'P2025',
+      });
+
+      const result = await repository.deleteSong('song-id', new Date('2026-05-20T00:00:00.000Z'));
+
+      expect(result).toBeUndefined();
+    });
+
+    it('삭제 실패가 대상 없음이 아니면 예외를 다시 던진다', async () => {
+      const error = new Error('DB 연결 실패');
+      prisma.song.delete.mockRejectedValue(error);
+
+      await expect(repository.deleteSong('song-id', new Date('2026-05-20T00:00:00.000Z'))).rejects.toThrow(error);
+    });
+
     it('tx가 전달되면 tx 클라이언트를 사용한다', async () => {
       const tx = {
         song: {

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
@@ -14,6 +14,7 @@ const createPrismaMock = () => ({
     findMany: jest.fn(),
     findFirst: jest.fn(),
     update: jest.fn(),
+    delete: jest.fn(),
   },
   songSkill: {
     createMany: jest.fn(),
@@ -621,6 +622,45 @@ describe('SongsPrismaRepository', () => {
           ],
         },
       });
+    });
+  });
+
+  describe('deleteSong', () => {
+    it('곡을 hard delete하고 삭제 처리 시각을 응답한다', async () => {
+      prisma.song.delete.mockResolvedValue({
+        id: 'song-id',
+      });
+
+      const deletedAt = new Date('2026-05-20T00:00:00.000Z');
+      const result = await repository.deleteSong('song-id', deletedAt);
+
+      expect(prisma.song.delete).toHaveBeenCalledWith({
+        where: {
+          id: 'song-id',
+        },
+        select: {
+          id: true,
+        },
+      });
+      expect(result).toEqual({
+        songId: 'song-id',
+        deletedAt: '2026-05-20T00:00:00.000Z',
+      });
+    });
+
+    it('tx가 전달되면 tx 클라이언트를 사용한다', async () => {
+      const tx = {
+        song: {
+          delete: jest.fn().mockResolvedValue({
+            id: 'song-id',
+          }),
+        },
+      };
+
+      await repository.deleteSong('song-id', new Date('2026-05-20T00:00:00.000Z'), tx as never);
+
+      expect(tx.song.delete).toHaveBeenCalled();
+      expect(prisma.song.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
@@ -1,0 +1,248 @@
+import type { PrismaService } from '../../../database/prisma';
+
+import { SongsPrismaRepository } from './songs.prisma-repository';
+
+const createPrismaMock = () => ({
+  band: {
+    findFirst: jest.fn(),
+  },
+  skillType: {
+    findMany: jest.fn(),
+  },
+  song: {
+    create: jest.fn(),
+  },
+  songSkill: {
+    createMany: jest.fn(),
+  },
+});
+
+describe('SongsPrismaRepository', () => {
+  let prisma: ReturnType<typeof createPrismaMock>;
+  let repository: SongsPrismaRepository;
+
+  beforeEach(() => {
+    prisma = createPrismaMock();
+    repository = new SongsPrismaRepository(prisma as unknown as PrismaService);
+  });
+
+  describe('findBandForSongCreate', () => {
+    it('삭제되지 않은 밴드와 요청자 멤버를 조회한다', async () => {
+      prisma.band.findFirst.mockResolvedValue({
+        id: 'band-id',
+        members: [
+          {
+            id: 'band-member-id',
+            userId: 'user-id',
+          },
+        ],
+      });
+
+      const result = await repository.findBandForSongCreate('band-id', 'user-id');
+
+      expect(prisma.band.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 'band-id',
+          deletedAt: null,
+        },
+        select: {
+          id: true,
+          members: {
+            where: {
+              userId: 'user-id',
+            },
+            select: {
+              id: true,
+              userId: true,
+            },
+            take: 1,
+          },
+        },
+      });
+      expect(result).toEqual({
+        id: 'band-id',
+        member: {
+          id: 'band-member-id',
+          userId: 'user-id',
+        },
+      });
+    });
+
+    it('밴드가 없으면 null을 반환한다', async () => {
+      prisma.band.findFirst.mockResolvedValue(null);
+
+      const result = await repository.findBandForSongCreate('band-id', 'user-id');
+
+      expect(result).toBeNull();
+    });
+
+    it('밴드는 있지만 요청자가 멤버가 아니면 member를 null로 반환한다', async () => {
+      prisma.band.findFirst.mockResolvedValue({
+        id: 'band-id',
+        members: [],
+      });
+
+      const result = await repository.findBandForSongCreate('band-id', 'user-id');
+
+      expect(result).toEqual({
+        id: 'band-id',
+        member: null,
+      });
+    });
+
+    it('tx가 전달되면 tx 클라이언트를 사용한다', async () => {
+      const tx = {
+        band: {
+          findFirst: jest.fn().mockResolvedValue(null),
+        },
+      };
+
+      await repository.findBandForSongCreate('band-id', 'user-id', tx as never);
+
+      expect(tx.band.findFirst).toHaveBeenCalled();
+      expect(prisma.band.findFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findExistingSkillTypeIds', () => {
+    it('존재하는 세션 타입 ID만 반환한다', async () => {
+      prisma.skillType.findMany.mockResolvedValue([{ id: 'skill-type-1' }, { id: 'skill-type-2' }]);
+
+      const result = await repository.findExistingSkillTypeIds(['skill-type-1', 'skill-type-2']);
+
+      expect(prisma.skillType.findMany).toHaveBeenCalledWith({
+        where: {
+          id: {
+            in: ['skill-type-1', 'skill-type-2'],
+          },
+        },
+        select: {
+          id: true,
+        },
+      });
+      expect(result).toEqual(['skill-type-1', 'skill-type-2']);
+    });
+  });
+
+  describe('createSong', () => {
+    const input = {
+      bandId: 'band-id',
+      userId: 'user-id',
+      title: 'Harder, Better, Faster, Stronger',
+      artistName: 'Daft Punk',
+      sourceUrl: 'https://www.deezer.com/track/3135556',
+      sourceType: 'DEEZER' as const,
+      memo: '후렴 진입 전 드럼 큐 확인',
+      createdByBandMemberId: 'band-member-id',
+      skillTypeIds: ['skill-type-2', 'skill-type-1'],
+    };
+
+    beforeEach(() => {
+      prisma.song.create.mockResolvedValue({
+        id: 'song-id',
+        bandId: 'band-id',
+        title: 'Harder, Better, Faster, Stronger',
+        artistName: 'Daft Punk',
+        sourceUrl: 'https://www.deezer.com/track/3135556',
+        sourceType: 'DEEZER',
+        memo: '후렴 진입 전 드럼 큐 확인',
+        key: null,
+        bpm: null,
+        difficultyLevel: null,
+        createdAt: new Date('2026-05-20T00:00:00.000Z'),
+      });
+      prisma.songSkill.createMany.mockResolvedValue({ count: 2 });
+      prisma.skillType.findMany.mockResolvedValue([
+        {
+          id: 'skill-type-1',
+          name: '기타',
+        },
+        {
+          id: 'skill-type-2',
+          name: '보컬',
+        },
+      ]);
+    });
+
+    it('곡과 곡 세션 타입 연결 정보를 생성한다', async () => {
+      await repository.createSong(input);
+
+      expect(prisma.song.create).toHaveBeenCalledWith({
+        data: {
+          bandId: 'band-id',
+          title: 'Harder, Better, Faster, Stronger',
+          artistName: 'Daft Punk',
+          sourceUrl: 'https://www.deezer.com/track/3135556',
+          sourceType: 'DEEZER',
+          memo: '후렴 진입 전 드럼 큐 확인',
+          createdByBandMemberId: 'band-member-id',
+        },
+        select: {
+          id: true,
+          bandId: true,
+          title: true,
+          artistName: true,
+          sourceUrl: true,
+          sourceType: true,
+          memo: true,
+          key: true,
+          bpm: true,
+          difficultyLevel: true,
+          createdAt: true,
+        },
+      });
+      expect(prisma.songSkill.createMany).toHaveBeenCalledWith({
+        data: [
+          {
+            songId: 'song-id',
+            skillTypeId: 'skill-type-2',
+          },
+          {
+            songId: 'song-id',
+            skillTypeId: 'skill-type-1',
+          },
+        ],
+      });
+    });
+
+    it('응답 세션 타입 순서는 요청 순서를 유지한다', async () => {
+      const result = await repository.createSong(input);
+
+      expect(result).toEqual({
+        song: {
+          id: 'song-id',
+          bandId: 'band-id',
+          title: 'Harder, Better, Faster, Stronger',
+          artistName: 'Daft Punk',
+          sourceUrl: 'https://www.deezer.com/track/3135556',
+          sourceType: 'DEEZER',
+          memo: '후렴 진입 전 드럼 큐 확인',
+          key: null,
+          bpm: null,
+          difficultyLevel: null,
+          userId: 'user-id',
+          createdAt: '2026-05-20T00:00:00.000Z',
+        },
+        skillTypes: [
+          {
+            id: 'skill-type-2',
+            name: '보컬',
+          },
+          {
+            id: 'skill-type-1',
+            name: '기타',
+          },
+        ],
+      });
+    });
+
+    it('세션 타입이 없으면 곡 세션 타입 연결을 생성하지 않는다', async () => {
+      await repository.createSong({
+        ...input,
+        skillTypeIds: [],
+      });
+
+      expect(prisma.songSkill.createMany).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
@@ -109,26 +109,6 @@ describe('SongsPrismaRepository', () => {
     });
   });
 
-  describe('findExistingSkillTypeIds', () => {
-    it('존재하는 세션 타입 ID만 반환한다', async () => {
-      prisma.skillType.findMany.mockResolvedValue([{ id: 'skill-type-1' }, { id: 'skill-type-2' }]);
-
-      const result = await repository.findExistingSkillTypeIds(['skill-type-1', 'skill-type-2']);
-
-      expect(prisma.skillType.findMany).toHaveBeenCalledWith({
-        where: {
-          id: {
-            in: ['skill-type-1', 'skill-type-2'],
-          },
-        },
-        select: {
-          id: true,
-        },
-      });
-      expect(result).toEqual(['skill-type-1', 'skill-type-2']);
-    });
-  });
-
   describe('findBandSongs', () => {
     it('검색어와 커서 ID 조건으로 곡 목록을 조회한다', async () => {
       prisma.song.findMany.mockResolvedValue([]);

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
@@ -11,6 +11,7 @@ const createPrismaMock = () => ({
   },
   song: {
     create: jest.fn(),
+    findMany: jest.fn(),
   },
   songSkill: {
     createMany: jest.fn(),
@@ -26,7 +27,7 @@ describe('SongsPrismaRepository', () => {
     repository = new SongsPrismaRepository(prisma as unknown as PrismaService);
   });
 
-  describe('findBandForSongCreate', () => {
+  describe('findActiveBandWithMemberByBandIdAndUserId', () => {
     it('삭제되지 않은 밴드와 요청자 멤버를 조회한다', async () => {
       prisma.band.findFirst.mockResolvedValue({
         id: 'band-id',
@@ -38,7 +39,7 @@ describe('SongsPrismaRepository', () => {
         ],
       });
 
-      const result = await repository.findBandForSongCreate('band-id', 'user-id');
+      const result = await repository.findActiveBandWithMemberByBandIdAndUserId('band-id', 'user-id');
 
       expect(prisma.band.findFirst).toHaveBeenCalledWith({
         where: {
@@ -71,7 +72,7 @@ describe('SongsPrismaRepository', () => {
     it('밴드가 없으면 null을 반환한다', async () => {
       prisma.band.findFirst.mockResolvedValue(null);
 
-      const result = await repository.findBandForSongCreate('band-id', 'user-id');
+      const result = await repository.findActiveBandWithMemberByBandIdAndUserId('band-id', 'user-id');
 
       expect(result).toBeNull();
     });
@@ -82,7 +83,7 @@ describe('SongsPrismaRepository', () => {
         members: [],
       });
 
-      const result = await repository.findBandForSongCreate('band-id', 'user-id');
+      const result = await repository.findActiveBandWithMemberByBandIdAndUserId('band-id', 'user-id');
 
       expect(result).toEqual({
         id: 'band-id',
@@ -97,7 +98,7 @@ describe('SongsPrismaRepository', () => {
         },
       };
 
-      await repository.findBandForSongCreate('band-id', 'user-id', tx as never);
+      await repository.findActiveBandWithMemberByBandIdAndUserId('band-id', 'user-id', tx as never);
 
       expect(tx.band.findFirst).toHaveBeenCalled();
       expect(prisma.band.findFirst).not.toHaveBeenCalled();
@@ -121,6 +122,176 @@ describe('SongsPrismaRepository', () => {
         },
       });
       expect(result).toEqual(['skill-type-1', 'skill-type-2']);
+    });
+  });
+
+  describe('findBandSongs', () => {
+    it('검색어와 커서 조건으로 곡 목록을 조회한다', async () => {
+      prisma.song.findMany.mockResolvedValue([]);
+
+      await repository.findBandSongs('band-id', {
+        where__title__contain: 'Harder',
+        where__artist_name__contain: 'Daft',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+        cursor__created_at: '2026-05-20T00:00:00.000Z',
+        cursor__id: 'cursor-song-id',
+      });
+
+      expect(prisma.song.findMany).toHaveBeenCalledWith({
+        where: {
+          bandId: 'band-id',
+          AND: [
+            {
+              title: {
+                contains: 'Harder',
+                mode: 'insensitive',
+              },
+            },
+            {
+              artistName: {
+                contains: 'Daft',
+                mode: 'insensitive',
+              },
+            },
+          ],
+          OR: [
+            {
+              createdAt: {
+                lt: new Date('2026-05-20T00:00:00.000Z'),
+              },
+            },
+            {
+              createdAt: new Date('2026-05-20T00:00:00.000Z'),
+              id: {
+                lt: 'cursor-song-id',
+              },
+            },
+          ],
+        },
+        include: {
+          songSkills: {
+            include: {
+              skillType: {
+                select: {
+                  name: true,
+                },
+              },
+            },
+            orderBy: {
+              skillTypeId: 'asc',
+            },
+          },
+        },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: 20,
+      });
+    });
+
+    it('조회 결과를 목록 응답으로 매핑한다', async () => {
+      prisma.song.findMany.mockResolvedValue([
+        {
+          id: 'song-id-1',
+          bandId: 'band-id',
+          title: 'Harder, Better, Faster, Stronger',
+          artistName: 'Daft Punk',
+          key: null,
+          bpm: null,
+          difficultyLevel: null,
+          sourceUrl: 'https://www.deezer.com/track/3135556',
+          sourceType: 'DEEZER',
+          createdAt: new Date('2026-05-20T00:00:00.000Z'),
+          songSkills: [
+            {
+              skillTypeId: 'skill-type-1',
+              skillType: {
+                name: '기타',
+              },
+            },
+          ],
+        },
+        {
+          id: 'song-id-2',
+          bandId: 'band-id',
+          title: 'Around the World',
+          artistName: 'Daft Punk',
+          key: null,
+          bpm: null,
+          difficultyLevel: null,
+          sourceUrl: 'https://www.deezer.com/track/3135557',
+          sourceType: 'DEEZER',
+          createdAt: new Date('2026-05-19T00:00:00.000Z'),
+          songSkills: [],
+        },
+      ]);
+
+      const result = await repository.findBandSongs('band-id', {
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 2,
+      });
+
+      expect(result).toEqual({
+        items: [
+          {
+            id: 'song-id-1',
+            bandId: 'band-id',
+            title: 'Harder, Better, Faster, Stronger',
+            artistName: 'Daft Punk',
+            key: null,
+            bpm: null,
+            difficultyLevel: null,
+            sourceUrl: 'https://www.deezer.com/track/3135556',
+            sourceType: 'DEEZER',
+            createdAt: '2026-05-20T00:00:00.000Z',
+            skills: [
+              {
+                skillTypeId: 'skill-type-1',
+                skillName: '기타',
+              },
+            ],
+          },
+          {
+            id: 'song-id-2',
+            bandId: 'band-id',
+            title: 'Around the World',
+            artistName: 'Daft Punk',
+            key: null,
+            bpm: null,
+            difficultyLevel: null,
+            sourceUrl: 'https://www.deezer.com/track/3135557',
+            sourceType: 'DEEZER',
+            createdAt: '2026-05-19T00:00:00.000Z',
+            skills: [],
+          },
+        ],
+        meta: {
+          count: 2,
+          take: 2,
+          cursor: {
+            createdAt: '2026-05-20T00:00:00.000Z',
+            id: 'song-id-1',
+          },
+          next: {
+            createdAt: '2026-05-19T00:00:00.000Z',
+            id: 'song-id-2',
+          },
+        },
+      });
+    });
+
+    it('결과가 없으면 cursor와 next가 null이다', async () => {
+      prisma.song.findMany.mockResolvedValue([]);
+
+      const result = await repository.findBandSongs('band-id', {
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      });
+
+      expect(result.meta.cursor).toBeNull();
+      expect(result.meta.next).toBeNull();
     });
   });
 

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
@@ -130,7 +130,7 @@ describe('SongsPrismaRepository', () => {
   });
 
   describe('findBandSongs', () => {
-    it('검색어와 커서 조건으로 곡 목록을 조회한다', async () => {
+    it('검색어와 커서 ID 조건으로 곡 목록을 조회한다', async () => {
       prisma.song.findMany.mockResolvedValue([]);
 
       await repository.findBandSongs('band-id', {
@@ -139,7 +139,6 @@ describe('SongsPrismaRepository', () => {
         order__created_at: 'desc',
         order__id: 'desc',
         take: 20,
-        cursor__created_at: '2026-05-20T00:00:00.000Z',
         cursor__id: 'cursor-song-id',
       });
 
@@ -160,19 +159,6 @@ describe('SongsPrismaRepository', () => {
               },
             },
           ],
-          OR: [
-            {
-              createdAt: {
-                lt: new Date('2026-05-20T00:00:00.000Z'),
-              },
-            },
-            {
-              createdAt: new Date('2026-05-20T00:00:00.000Z'),
-              id: {
-                lt: 'cursor-song-id',
-              },
-            },
-          ],
         },
         include: {
           songSkills: {
@@ -189,6 +175,8 @@ describe('SongsPrismaRepository', () => {
           },
         },
         orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        cursor: { id: 'cursor-song-id' },
+        skip: 1,
         take: 20,
       });
     });
@@ -274,11 +262,9 @@ describe('SongsPrismaRepository', () => {
           count: 2,
           take: 2,
           cursor: {
-            createdAt: '2026-05-20T00:00:00.000Z',
             id: 'song-id-1',
           },
           next: {
-            createdAt: '2026-05-19T00:00:00.000Z',
             id: 'song-id-2',
           },
         },

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
@@ -12,9 +12,12 @@ const createPrismaMock = () => ({
   song: {
     create: jest.fn(),
     findMany: jest.fn(),
+    findFirst: jest.fn(),
+    update: jest.fn(),
   },
   songSkill: {
     createMany: jest.fn(),
+    deleteMany: jest.fn(),
   },
 });
 
@@ -295,6 +298,86 @@ describe('SongsPrismaRepository', () => {
     });
   });
 
+  describe('findSongWithBandMemberBySongIdAndUserId', () => {
+    it('삭제되지 않은 밴드의 곡과 요청자 멤버를 조회한다', async () => {
+      prisma.song.findFirst.mockResolvedValue({
+        id: 'song-id',
+        bandId: 'band-id',
+        band: {
+          members: [
+            {
+              id: 'band-member-id',
+              userId: 'user-id',
+            },
+          ],
+        },
+      });
+
+      const result = await repository.findSongWithBandMemberBySongIdAndUserId('song-id', 'user-id');
+
+      expect(prisma.song.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 'song-id',
+          band: {
+            deletedAt: null,
+          },
+        },
+        select: {
+          id: true,
+          bandId: true,
+          band: {
+            select: {
+              members: {
+                where: {
+                  userId: 'user-id',
+                },
+                select: {
+                  id: true,
+                  userId: true,
+                },
+                take: 1,
+              },
+            },
+          },
+        },
+      });
+      expect(result).toEqual({
+        id: 'song-id',
+        bandId: 'band-id',
+        member: {
+          id: 'band-member-id',
+          userId: 'user-id',
+        },
+      });
+    });
+
+    it('곡이 없으면 null을 반환한다', async () => {
+      prisma.song.findFirst.mockResolvedValue(null);
+
+      const result = await repository.findSongWithBandMemberBySongIdAndUserId('song-id', 'user-id');
+
+      expect(result).toBeNull();
+    });
+
+    it('곡은 있지만 요청자가 밴드 멤버가 아니면 member를 null로 반환한다', async () => {
+      prisma.song.findFirst.mockResolvedValue({
+        id: 'song-id',
+        bandId: 'band-id',
+        band: {
+          members: [],
+        },
+      });
+
+      const result = await repository.findSongWithBandMemberBySongIdAndUserId('song-id', 'user-id');
+
+      expect(result).toEqual({
+        id: 'song-id',
+        bandId: 'band-id',
+        member: null,
+      });
+    });
+  });
+
   describe('createSong', () => {
     const input = {
       bandId: 'band-id',
@@ -414,6 +497,130 @@ describe('SongsPrismaRepository', () => {
       });
 
       expect(prisma.songSkill.createMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateSong', () => {
+    beforeEach(() => {
+      prisma.songSkill.deleteMany.mockResolvedValue({ count: 2 });
+      prisma.songSkill.createMany.mockResolvedValue({ count: 1 });
+      prisma.song.update.mockResolvedValue({
+        id: 'song-id',
+        bandId: 'band-id',
+        title: 'Harder, Better, Faster, Stronger',
+        artistName: 'Daft Punk',
+        sourceUrl: 'https://www.deezer.com/track/3135556',
+        sourceType: 'DEEZER',
+        memo: '템포 124 기준으로 연습',
+        key: null,
+        bpm: null,
+        difficultyLevel: null,
+        updatedAt: new Date('2026-05-20T00:00:00.000Z'),
+        songSkills: [
+          {
+            skillTypeId: 'skill-type-1',
+            skillType: {
+              name: '기타',
+            },
+          },
+        ],
+      });
+    });
+
+    it('곡 기본 정보와 곡 세션 타입 연결을 수정한다', async () => {
+      await repository.updateSong('song-id', {
+        title: 'Harder, Better, Faster, Stronger',
+        memo: '템포 124 기준으로 연습',
+        skillTypeIds: ['skill-type-1'],
+      });
+
+      expect(prisma.songSkill.deleteMany).toHaveBeenCalledWith({
+        where: {
+          songId: 'song-id',
+        },
+      });
+      expect(prisma.songSkill.createMany).toHaveBeenCalledWith({
+        data: [
+          {
+            songId: 'song-id',
+            skillTypeId: 'skill-type-1',
+          },
+        ],
+      });
+      expect(prisma.song.update).toHaveBeenCalledWith({
+        where: {
+          id: 'song-id',
+        },
+        data: {
+          title: 'Harder, Better, Faster, Stronger',
+          memo: '템포 124 기준으로 연습',
+        },
+        include: {
+          songSkills: {
+            include: {
+              skillType: {
+                select: {
+                  name: true,
+                },
+              },
+            },
+            orderBy: {
+              skillTypeId: 'asc',
+            },
+          },
+        },
+      });
+    });
+
+    it('skillTypeIds가 없으면 곡 세션 타입 연결을 수정하지 않는다', async () => {
+      await repository.updateSong('song-id', {
+        memo: null,
+      });
+
+      expect(prisma.songSkill.deleteMany).not.toHaveBeenCalled();
+      expect(prisma.songSkill.createMany).not.toHaveBeenCalled();
+      expect(prisma.song.update).toHaveBeenCalledWith(expect.objectContaining({ data: { memo: null } }));
+    });
+
+    it('skillTypeIds가 빈 배열이면 기존 연결만 삭제한다', async () => {
+      await repository.updateSong('song-id', {
+        skillTypeIds: [],
+      });
+
+      expect(prisma.songSkill.deleteMany).toHaveBeenCalledWith({
+        where: {
+          songId: 'song-id',
+        },
+      });
+      expect(prisma.songSkill.createMany).not.toHaveBeenCalled();
+    });
+
+    it('수정된 곡 정보를 응답 형태로 매핑한다', async () => {
+      const result = await repository.updateSong('song-id', {
+        memo: '템포 124 기준으로 연습',
+      });
+
+      expect(result).toEqual({
+        song: {
+          id: 'song-id',
+          bandId: 'band-id',
+          title: 'Harder, Better, Faster, Stronger',
+          artistName: 'Daft Punk',
+          sourceUrl: 'https://www.deezer.com/track/3135556',
+          sourceType: 'DEEZER',
+          memo: '템포 124 기준으로 연습',
+          key: null,
+          bpm: null,
+          difficultyLevel: null,
+          updatedAt: '2026-05-20T00:00:00.000Z',
+          skills: [
+            {
+              skillTypeId: 'skill-type-1',
+              skillName: '기타',
+            },
+          ],
+        },
+      });
     });
   });
 });

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.ts
@@ -5,6 +5,7 @@ import type { Prisma } from '../../../generated/prisma';
 import type { GetBandSongsQuery, SongListOrderDirection } from '../dto/get-band-songs-query.dto';
 import type { UpdateSongInput } from '../dto/update-song.dto';
 import type { CreatedSongSkillType, CreateSongResult } from '../types/create-song-result.type';
+import type { DeleteSongResult } from '../types/delete-song-result.type';
 import type { GetBandSongsResult, SongListItem } from '../types/song-list.type';
 import type { SongSourceType } from '../types/song-preview.type';
 import type { UpdateSongResult } from '../types/update-song-result.type';
@@ -343,6 +344,32 @@ export class SongsPrismaRepository implements SongsRepository {
           skillName: songSkill.skillType.name,
         })),
       },
+    };
+  }
+
+  /**
+   * Song은 삭제 상태 컬럼이 없으므로 hard delete 한다.
+   *
+   * @param {string} songId - 삭제할 곡 ID
+   * @param {Date} deletedAt - 응답에 표시할 삭제 처리 시각
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<DeleteSongResult>} 삭제 처리 결과
+   */
+  async deleteSong(songId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteSongResult> {
+    const client = tx ?? this.prisma;
+
+    const deletedSong = await client.song.delete({
+      where: {
+        id: songId,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    return {
+      songId: deletedSong.id,
+      deletedAt: deletedAt.toISOString(),
     };
   }
 

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.ts
@@ -353,24 +353,40 @@ export class SongsPrismaRepository implements SongsRepository {
    * @param {string} songId - 삭제할 곡 ID
    * @param {Date} deletedAt - 응답에 표시할 삭제 처리 시각
    * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
-   * @returns {Promise<DeleteSongResult>} 삭제 처리 결과
+   * @returns {Promise<DeleteSongResult | undefined>} 삭제 처리 결과 또는 대상 없음
    */
-  async deleteSong(songId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteSongResult> {
+  async deleteSong(songId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteSongResult | undefined> {
     const client = tx ?? this.prisma;
 
-    const deletedSong = await client.song.delete({
-      where: {
-        id: songId,
-      },
-      select: {
-        id: true,
-      },
-    });
+    try {
+      const deletedSong = await client.song.delete({
+        where: {
+          id: songId,
+        },
+        select: {
+          id: true,
+        },
+      });
 
-    return {
-      songId: deletedSong.id,
-      deletedAt: deletedAt.toISOString(),
-    };
+      return {
+        songId: deletedSong.id,
+        deletedAt: deletedAt.toISOString(),
+      };
+    } catch (error) {
+      if (this.isPrismaRecordNotFoundError(error)) {
+        return undefined;
+      }
+
+      throw error;
+    }
+  }
+
+  private isPrismaRecordNotFoundError(error: unknown): boolean {
+    if (typeof error !== 'object' || error === null) {
+      return false;
+    }
+
+    return 'code' in error && error.code === 'P2025';
   }
 
   private mapSkillTypes(skillTypeIds: string[], skillTypes: CreatedSongSkillType[]): CreatedSongSkillType[] {

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.ts
@@ -1,0 +1,169 @@
+import { Injectable } from '@nestjs/common';
+
+import { PrismaService } from '../../../database/prisma';
+import type { Prisma } from '../../../generated/prisma';
+import type { CreatedSongSkillType, CreateSongResult } from '../types/create-song-result.type';
+import type { SongSourceType } from '../types/song-preview.type';
+
+import type { CreateSongRepositoryInput, SongsRepository } from './songs.repository';
+
+@Injectable()
+export class SongsPrismaRepository implements SongsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 곡 생성 정책 판단에 필요한 밴드와 요청자 멤버 정보를 조회한다.
+   *
+   * @param {string} bandId - 곡을 추가할 밴드 ID
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string; member: { id: string; userId: string } | null } | null>} 삭제되지 않은 밴드와 요청자 멤버 정보
+   */
+  async findBandForSongCreate(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    member: {
+      id: string;
+      userId: string;
+    } | null;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    const band = await client.band.findFirst({
+      where: {
+        id: bandId,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        members: {
+          where: {
+            userId,
+          },
+          select: {
+            id: true,
+            userId: true,
+          },
+          take: 1,
+        },
+      },
+    });
+
+    if (band === null) {
+      return null;
+    }
+
+    return {
+      id: band.id,
+      member: band.members[0] ?? null,
+    };
+  }
+
+  /**
+   * 요청받은 세션 타입 ID가 실제로 존재하는지 확인한다.
+   *
+   * @param {string[]} skillTypeIds - 확인할 세션 타입 ID 목록
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<string[]>} 존재하는 세션 타입 ID 목록
+   */
+  async findExistingSkillTypeIds(skillTypeIds: string[], tx?: Prisma.TransactionClient): Promise<string[]> {
+    const client = tx ?? this.prisma;
+
+    const skillTypes = await client.skillType.findMany({
+      where: {
+        id: {
+          in: skillTypeIds,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    return skillTypes.map(skillType => skillType.id);
+  }
+
+  /**
+   * 곡과 곡 세션 타입 연결 정보를 같은 작업 단위에서 생성한다.
+   *
+   * @param {CreateSongRepositoryInput} input - Service에서 정책 검증이 끝난 곡 생성 입력값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<CreateSongResult>} 생성된 곡과 연결된 세션 타입 목록
+   */
+  async createSong(input: CreateSongRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateSongResult> {
+    const client = tx ?? this.prisma;
+
+    const song = await client.song.create({
+      data: {
+        bandId: input.bandId,
+        title: input.title,
+        artistName: input.artistName,
+        sourceUrl: input.sourceUrl,
+        sourceType: input.sourceType,
+        memo: input.memo,
+        createdByBandMemberId: input.createdByBandMemberId,
+      },
+      select: {
+        id: true,
+        bandId: true,
+        title: true,
+        artistName: true,
+        sourceUrl: true,
+        sourceType: true,
+        memo: true,
+        key: true,
+        bpm: true,
+        difficultyLevel: true,
+        createdAt: true,
+      },
+    });
+
+    if (input.skillTypeIds.length > 0) {
+      await client.songSkill.createMany({
+        data: input.skillTypeIds.map(skillTypeId => ({
+          songId: song.id,
+          skillTypeId,
+        })),
+      });
+    }
+
+    const skillTypes = await client.skillType.findMany({
+      where: {
+        id: {
+          in: input.skillTypeIds,
+        },
+      },
+      select: {
+        id: true,
+        name: true,
+      },
+    });
+
+    return {
+      song: {
+        id: song.id,
+        bandId: song.bandId,
+        title: song.title,
+        artistName: song.artistName,
+        sourceUrl: song.sourceUrl,
+        sourceType: song.sourceType as SongSourceType | null,
+        memo: song.memo,
+        key: song.key,
+        bpm: song.bpm,
+        difficultyLevel: song.difficultyLevel,
+        userId: input.userId,
+        createdAt: song.createdAt.toISOString(),
+      },
+      skillTypes: this.mapSkillTypes(input.skillTypeIds, skillTypes),
+    };
+  }
+
+  private mapSkillTypes(skillTypeIds: string[], skillTypes: CreatedSongSkillType[]): CreatedSongSkillType[] {
+    return skillTypeIds
+      .map(skillTypeId => skillTypes.find(skillType => skillType.id === skillTypeId))
+      .filter((skillType): skillType is CreatedSongSkillType => skillType !== undefined);
+  }
+}

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from '../../../database/prisma';
 import type { Prisma } from '../../../generated/prisma';
-import type { GetBandSongsQuery, SongListOrderDirection } from '../dto/get-band-songs-query.dto';
+import type { GetBandSongsQuery } from '../dto/get-band-songs-query.dto';
 import type { UpdateSongInput } from '../dto/update-song.dto';
 import type { CreatedSongSkillType, CreateSongResult } from '../types/create-song-result.type';
 import type { DeleteSongResult } from '../types/delete-song-result.type';
@@ -82,7 +82,6 @@ export class SongsPrismaRepository implements SongsRepository {
       where: {
         bandId,
         ...this.createSongListSearchWhere(query),
-        ...this.createSongListCursorWhere(query),
       },
       include: {
         songSkills: {
@@ -99,13 +98,14 @@ export class SongsPrismaRepository implements SongsRepository {
         },
       },
       orderBy: [{ createdAt: query.order__created_at }, { id: query.order__id }],
+      ...(query.cursor__id ? { cursor: { id: query.cursor__id }, skip: 1 } : {}),
       take: query.take,
     });
 
     const items = songs.map(song => this.mapSongListItem(song));
     const count = items.length;
-    const cursor = count > 0 ? { createdAt: items[0].createdAt, id: items[0].id } : null;
-    const next = count === query.take ? { createdAt: items[count - 1].createdAt, id: items[count - 1].id } : null;
+    const cursor = count > 0 ? { id: items[0].id } : null;
+    const next = count === query.take ? { id: items[count - 1].id } : null;
 
     return {
       items,
@@ -407,39 +407,6 @@ export class SongsPrismaRepository implements SongsRepository {
     return {
       AND: searchWhere,
     };
-  }
-
-  private createSongListCursorWhere(query: GetBandSongsQuery): Prisma.SongWhereInput {
-    if (query.cursor__created_at === undefined || query.cursor__id === undefined) {
-      return {};
-    }
-
-    const cursorCreatedAt = new Date(query.cursor__created_at);
-    const cursorOperator = this.getCursorOperator(query.order__created_at);
-
-    return {
-      OR: [
-        {
-          createdAt: {
-            [cursorOperator]: cursorCreatedAt,
-          },
-        },
-        {
-          createdAt: cursorCreatedAt,
-          id: {
-            [cursorOperator]: query.cursor__id,
-          },
-        },
-      ],
-    };
-  }
-
-  private getCursorOperator(orderDirection: SongListOrderDirection): 'lt' | 'gt' {
-    if (orderDirection === 'desc') {
-      return 'lt';
-    }
-
-    return 'gt';
   }
 
   private createUpdateSongData(input: UpdateSongInput): Prisma.SongUpdateInput {

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.ts
@@ -3,9 +3,11 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../../database/prisma';
 import type { Prisma } from '../../../generated/prisma';
 import type { GetBandSongsQuery, SongListOrderDirection } from '../dto/get-band-songs-query.dto';
+import type { UpdateSongInput } from '../dto/update-song.dto';
 import type { CreatedSongSkillType, CreateSongResult } from '../types/create-song-result.type';
 import type { GetBandSongsResult, SongListItem } from '../types/song-list.type';
 import type { SongSourceType } from '../types/song-preview.type';
+import type { UpdateSongResult } from '../types/update-song-result.type';
 
 import type { CreateSongRepositoryInput, SongsRepository } from './songs.repository';
 
@@ -116,6 +118,66 @@ export class SongsPrismaRepository implements SongsRepository {
   }
 
   /**
+   * 곡 수정 권한 판단에 필요한 곡의 밴드와 요청자 멤버 정보를 조회한다.
+   *
+   * @param {string} songId - 수정할 곡 ID
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string; bandId: string; member: { id: string; userId: string } | null } | null>} 곡과 요청자 멤버 정보
+   */
+  async findSongWithBandMemberBySongIdAndUserId(
+    songId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    bandId: string;
+    member: {
+      id: string;
+      userId: string;
+    } | null;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    const song = await client.song.findFirst({
+      where: {
+        id: songId,
+        band: {
+          deletedAt: null,
+        },
+      },
+      select: {
+        id: true,
+        bandId: true,
+        band: {
+          select: {
+            members: {
+              where: {
+                userId,
+              },
+              select: {
+                id: true,
+                userId: true,
+              },
+              take: 1,
+            },
+          },
+        },
+      },
+    });
+
+    if (song === null) {
+      return null;
+    }
+
+    return {
+      id: song.id,
+      bandId: song.bandId,
+      member: song.band.members[0] ?? null,
+    };
+  }
+
+  /**
    * 요청받은 세션 타입 ID가 실제로 존재하는지 확인한다.
    *
    * @param {string[]} skillTypeIds - 확인할 세션 타입 ID 목록
@@ -214,6 +276,76 @@ export class SongsPrismaRepository implements SongsRepository {
     };
   }
 
+  /**
+   * 곡 기본 정보와 곡 세션 타입 연결을 수정한다.
+   *
+   * @param {string} songId - 수정할 곡 ID
+   * @param {UpdateSongInput} input - Service 검증이 끝난 곡 수정 입력값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<UpdateSongResult>} 수정된 곡 정보
+   */
+  async updateSong(songId: string, input: UpdateSongInput, tx?: Prisma.TransactionClient): Promise<UpdateSongResult> {
+    const client = tx ?? this.prisma;
+
+    if (input.skillTypeIds !== undefined) {
+      await client.songSkill.deleteMany({
+        where: {
+          songId,
+        },
+      });
+
+      if (input.skillTypeIds.length > 0) {
+        await client.songSkill.createMany({
+          data: input.skillTypeIds.map(skillTypeId => ({
+            songId,
+            skillTypeId,
+          })),
+        });
+      }
+    }
+
+    const updatedSong = await client.song.update({
+      where: {
+        id: songId,
+      },
+      data: this.createUpdateSongData(input),
+      include: {
+        songSkills: {
+          include: {
+            skillType: {
+              select: {
+                name: true,
+              },
+            },
+          },
+          orderBy: {
+            skillTypeId: 'asc',
+          },
+        },
+      },
+    });
+
+    return {
+      song: {
+        id: updatedSong.id,
+        bandId: updatedSong.bandId,
+        title: updatedSong.title,
+        artistName: updatedSong.artistName,
+        sourceUrl: updatedSong.sourceUrl,
+        sourceType: updatedSong.sourceType as SongSourceType | null,
+        memo: updatedSong.memo,
+        key: updatedSong.key,
+        bpm: updatedSong.bpm,
+        difficultyLevel: updatedSong.difficultyLevel,
+        updatedAt: updatedSong.updatedAt.toISOString(),
+        skills: updatedSong.songSkills.map(songSkill => ({
+          skillTypeId: songSkill.skillTypeId,
+          skillName: songSkill.skillType.name,
+        })),
+      },
+    };
+  }
+
   private mapSkillTypes(skillTypeIds: string[], skillTypes: CreatedSongSkillType[]): CreatedSongSkillType[] {
     return skillTypeIds
       .map(skillTypeId => skillTypes.find(skillType => skillType.id === skillTypeId))
@@ -281,6 +413,32 @@ export class SongsPrismaRepository implements SongsRepository {
     }
 
     return 'gt';
+  }
+
+  private createUpdateSongData(input: UpdateSongInput): Prisma.SongUpdateInput {
+    const data: Prisma.SongUpdateInput = {};
+
+    if (input.title !== undefined) {
+      data.title = input.title;
+    }
+
+    if (input.artistName !== undefined) {
+      data.artistName = input.artistName;
+    }
+
+    if (input.sourceUrl !== undefined) {
+      data.sourceUrl = input.sourceUrl;
+    }
+
+    if (input.sourceType !== undefined) {
+      data.sourceType = input.sourceType;
+    }
+
+    if (input.memo !== undefined) {
+      data.memo = input.memo;
+    }
+
+    return data;
   }
 
   private mapSongListItem(

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.ts
@@ -6,6 +6,7 @@ import type { GetBandSongsQuery } from '../dto/get-band-songs-query.dto';
 import type { UpdateSongInput } from '../dto/update-song.dto';
 import type { CreatedSongSkillType, CreateSongResult } from '../types/create-song-result.type';
 import type { DeleteSongResult } from '../types/delete-song-result.type';
+import type { ActiveBandWithMember, SongWithBandMember } from '../types/song-access-context.type';
 import type { GetBandSongsResult, SongListItem } from '../types/song-list.type';
 import type { SongSourceType } from '../types/song-preview.type';
 import type { UpdateSongResult } from '../types/update-song-result.type';
@@ -22,19 +23,13 @@ export class SongsPrismaRepository implements SongsRepository {
    * @param {string} bandId - 곡을 추가할 밴드 ID
    * @param {string} userId - 인증된 사용자 ID
    * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
-   * @returns {Promise<{ id: string; member: { id: string; userId: string } | null } | null>} 삭제되지 않은 밴드와 요청자 멤버 정보
+   * @returns {Promise<ActiveBandWithMember | null>} 삭제되지 않은 밴드와 요청자 멤버 정보
    */
   async findActiveBandWithMemberByBandIdAndUserId(
     bandId: string,
     userId: string,
     tx?: Prisma.TransactionClient,
-  ): Promise<{
-    id: string;
-    member: {
-      id: string;
-      userId: string;
-    } | null;
-  } | null> {
+  ): Promise<ActiveBandWithMember | null> {
     const client = tx ?? this.prisma;
 
     const band = await client.band.findFirst({
@@ -124,20 +119,9 @@ export class SongsPrismaRepository implements SongsRepository {
    * @param {string} songId - 수정할 곡 ID
    * @param {string} userId - 인증된 사용자 ID
    * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
-   * @returns {Promise<{ id: string; bandId: string; member: { id: string; userId: string } | null } | null>} 곡과 요청자 멤버 정보
+   * @returns {Promise<SongWithBandMember | null>} 곡과 요청자 멤버 정보
    */
-  async findSongWithBandMemberBySongIdAndUserId(
-    songId: string,
-    userId: string,
-    tx?: Prisma.TransactionClient,
-  ): Promise<{
-    id: string;
-    bandId: string;
-    member: {
-      id: string;
-      userId: string;
-    } | null;
-  } | null> {
+  async findSongWithBandMemberBySongIdAndUserId(songId: string, userId: string, tx?: Prisma.TransactionClient): Promise<SongWithBandMember | null> {
     const client = tx ?? this.prisma;
 
     const song = await client.song.findFirst({

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.ts
@@ -2,7 +2,9 @@ import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from '../../../database/prisma';
 import type { Prisma } from '../../../generated/prisma';
+import type { GetBandSongsQuery, SongListOrderDirection } from '../dto/get-band-songs-query.dto';
 import type { CreatedSongSkillType, CreateSongResult } from '../types/create-song-result.type';
+import type { GetBandSongsResult, SongListItem } from '../types/song-list.type';
 import type { SongSourceType } from '../types/song-preview.type';
 
 import type { CreateSongRepositoryInput, SongsRepository } from './songs.repository';
@@ -19,7 +21,7 @@ export class SongsPrismaRepository implements SongsRepository {
    * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
    * @returns {Promise<{ id: string; member: { id: string; userId: string } | null } | null>} 삭제되지 않은 밴드와 요청자 멤버 정보
    */
-  async findBandForSongCreate(
+  async findActiveBandWithMemberByBandIdAndUserId(
     bandId: string,
     userId: string,
     tx?: Prisma.TransactionClient,
@@ -59,6 +61,57 @@ export class SongsPrismaRepository implements SongsRepository {
     return {
       id: band.id,
       member: band.members[0] ?? null,
+    };
+  }
+
+  /**
+   * 밴드의 곡 목록을 생성 시점과 ID 기준으로 정렬해 조회한다.
+   *
+   * @param {string} bandId - 조회할 밴드 ID
+   * @param {GetBandSongsQuery} query - 검색어와 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetBandSongsResult>} 밴드 곡 목록
+   */
+  async findBandSongs(bandId: string, query: GetBandSongsQuery, tx?: Prisma.TransactionClient): Promise<GetBandSongsResult> {
+    const client = tx ?? this.prisma;
+
+    const songs = await client.song.findMany({
+      where: {
+        bandId,
+        ...this.createSongListSearchWhere(query),
+        ...this.createSongListCursorWhere(query),
+      },
+      include: {
+        songSkills: {
+          include: {
+            skillType: {
+              select: {
+                name: true,
+              },
+            },
+          },
+          orderBy: {
+            skillTypeId: 'asc',
+          },
+        },
+      },
+      orderBy: [{ createdAt: query.order__created_at }, { id: query.order__id }],
+      take: query.take,
+    });
+
+    const items = songs.map(song => this.mapSongListItem(song));
+    const count = items.length;
+    const cursor = count > 0 ? { createdAt: items[0].createdAt, id: items[0].id } : null;
+    const next = count === query.take ? { createdAt: items[count - 1].createdAt, id: items[count - 1].id } : null;
+
+    return {
+      items,
+      meta: {
+        count,
+        take: query.take,
+        cursor,
+        next,
+      },
     };
   }
 
@@ -165,5 +218,101 @@ export class SongsPrismaRepository implements SongsRepository {
     return skillTypeIds
       .map(skillTypeId => skillTypes.find(skillType => skillType.id === skillTypeId))
       .filter((skillType): skillType is CreatedSongSkillType => skillType !== undefined);
+  }
+
+  private createSongListSearchWhere(query: GetBandSongsQuery): Prisma.SongWhereInput {
+    const searchWhere: Prisma.SongWhereInput[] = [];
+
+    if (query.where__title__contain !== undefined) {
+      searchWhere.push({
+        title: {
+          contains: query.where__title__contain,
+          mode: 'insensitive',
+        },
+      });
+    }
+
+    if (query.where__artist_name__contain !== undefined) {
+      searchWhere.push({
+        artistName: {
+          contains: query.where__artist_name__contain,
+          mode: 'insensitive',
+        },
+      });
+    }
+
+    if (searchWhere.length === 0) {
+      return {};
+    }
+
+    return {
+      AND: searchWhere,
+    };
+  }
+
+  private createSongListCursorWhere(query: GetBandSongsQuery): Prisma.SongWhereInput {
+    if (query.cursor__created_at === undefined || query.cursor__id === undefined) {
+      return {};
+    }
+
+    const cursorCreatedAt = new Date(query.cursor__created_at);
+    const cursorOperator = this.getCursorOperator(query.order__created_at);
+
+    return {
+      OR: [
+        {
+          createdAt: {
+            [cursorOperator]: cursorCreatedAt,
+          },
+        },
+        {
+          createdAt: cursorCreatedAt,
+          id: {
+            [cursorOperator]: query.cursor__id,
+          },
+        },
+      ],
+    };
+  }
+
+  private getCursorOperator(orderDirection: SongListOrderDirection): 'lt' | 'gt' {
+    if (orderDirection === 'desc') {
+      return 'lt';
+    }
+
+    return 'gt';
+  }
+
+  private mapSongListItem(
+    song: Prisma.SongGetPayload<{
+      include: {
+        songSkills: {
+          include: {
+            skillType: {
+              select: {
+                name: true;
+              };
+            };
+          };
+        };
+      };
+    }>,
+  ): SongListItem {
+    return {
+      id: song.id,
+      bandId: song.bandId,
+      title: song.title,
+      artistName: song.artistName,
+      key: song.key,
+      bpm: song.bpm,
+      difficultyLevel: song.difficultyLevel,
+      sourceUrl: song.sourceUrl,
+      sourceType: song.sourceType as SongSourceType | null,
+      createdAt: song.createdAt.toISOString(),
+      skills: song.songSkills.map(songSkill => ({
+        skillTypeId: songSkill.skillTypeId,
+        skillName: songSkill.skillType.name,
+      })),
+    };
   }
 }

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.ts
@@ -179,30 +179,6 @@ export class SongsPrismaRepository implements SongsRepository {
   }
 
   /**
-   * 요청받은 세션 타입 ID가 실제로 존재하는지 확인한다.
-   *
-   * @param {string[]} skillTypeIds - 확인할 세션 타입 ID 목록
-   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
-   * @returns {Promise<string[]>} 존재하는 세션 타입 ID 목록
-   */
-  async findExistingSkillTypeIds(skillTypeIds: string[], tx?: Prisma.TransactionClient): Promise<string[]> {
-    const client = tx ?? this.prisma;
-
-    const skillTypes = await client.skillType.findMany({
-      where: {
-        id: {
-          in: skillTypeIds,
-        },
-      },
-      select: {
-        id: true,
-      },
-    });
-
-    return skillTypes.map(skillType => skillType.id);
-  }
-
-  /**
    * 곡과 곡 세션 타입 연결 정보를 같은 작업 단위에서 생성한다.
    *
    * @param {CreateSongRepositoryInput} input - Service에서 정책 검증이 끝난 곡 생성 입력값

--- a/backend/src/modules/songs/repositories/songs.repository.ts
+++ b/backend/src/modules/songs/repositories/songs.repository.ts
@@ -44,5 +44,5 @@ export interface SongsRepository {
     } | null;
   } | null>;
   updateSong(songId: string, input: UpdateSongInput, tx?: Prisma.TransactionClient): Promise<UpdateSongResult>;
-  deleteSong(songId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteSongResult>;
+  deleteSong(songId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteSongResult | undefined>;
 }

--- a/backend/src/modules/songs/repositories/songs.repository.ts
+++ b/backend/src/modules/songs/repositories/songs.repository.ts
@@ -4,6 +4,7 @@ import type { GetBandSongsQuery } from '../dto/get-band-songs-query.dto';
 import type { UpdateSongInput } from '../dto/update-song.dto';
 import type { CreateSongResult } from '../types/create-song-result.type';
 import type { DeleteSongResult } from '../types/delete-song-result.type';
+import type { ActiveBandWithMember, SongWithBandMember } from '../types/song-access-context.type';
 import type { GetBandSongsResult } from '../types/song-list.type';
 import type { UpdateSongResult } from '../types/update-song-result.type';
 
@@ -17,31 +18,10 @@ export interface CreateSongRepositoryInput extends CreateSongInput {
 }
 
 export interface SongsRepository {
-  findActiveBandWithMemberByBandIdAndUserId(
-    bandId: string,
-    userId: string,
-    tx?: Prisma.TransactionClient,
-  ): Promise<{
-    id: string;
-    member: {
-      id: string;
-      userId: string;
-    } | null;
-  } | null>;
+  findActiveBandWithMemberByBandIdAndUserId(bandId: string, userId: string, tx?: Prisma.TransactionClient): Promise<ActiveBandWithMember | null>;
   createSong(input: CreateSongRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateSongResult>;
   findBandSongs(bandId: string, query: GetBandSongsQuery, tx?: Prisma.TransactionClient): Promise<GetBandSongsResult>;
-  findSongWithBandMemberBySongIdAndUserId(
-    songId: string,
-    userId: string,
-    tx?: Prisma.TransactionClient,
-  ): Promise<{
-    id: string;
-    bandId: string;
-    member: {
-      id: string;
-      userId: string;
-    } | null;
-  } | null>;
+  findSongWithBandMemberBySongIdAndUserId(songId: string, userId: string, tx?: Prisma.TransactionClient): Promise<SongWithBandMember | null>;
   updateSong(songId: string, input: UpdateSongInput, tx?: Prisma.TransactionClient): Promise<UpdateSongResult>;
   deleteSong(songId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteSongResult | undefined>;
 }

--- a/backend/src/modules/songs/repositories/songs.repository.ts
+++ b/backend/src/modules/songs/repositories/songs.repository.ts
@@ -28,7 +28,6 @@ export interface SongsRepository {
       userId: string;
     } | null;
   } | null>;
-  findExistingSkillTypeIds(skillTypeIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;
   createSong(input: CreateSongRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateSongResult>;
   findBandSongs(bandId: string, query: GetBandSongsQuery, tx?: Prisma.TransactionClient): Promise<GetBandSongsResult>;
   findSongWithBandMemberBySongIdAndUserId(

--- a/backend/src/modules/songs/repositories/songs.repository.ts
+++ b/backend/src/modules/songs/repositories/songs.repository.ts
@@ -3,6 +3,7 @@ import type { CreateSongInput } from '../dto/create-song.dto';
 import type { GetBandSongsQuery } from '../dto/get-band-songs-query.dto';
 import type { UpdateSongInput } from '../dto/update-song.dto';
 import type { CreateSongResult } from '../types/create-song-result.type';
+import type { DeleteSongResult } from '../types/delete-song-result.type';
 import type { GetBandSongsResult } from '../types/song-list.type';
 import type { UpdateSongResult } from '../types/update-song-result.type';
 
@@ -43,4 +44,5 @@ export interface SongsRepository {
     } | null;
   } | null>;
   updateSong(songId: string, input: UpdateSongInput, tx?: Prisma.TransactionClient): Promise<UpdateSongResult>;
+  deleteSong(songId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteSongResult>;
 }

--- a/backend/src/modules/songs/repositories/songs.repository.ts
+++ b/backend/src/modules/songs/repositories/songs.repository.ts
@@ -1,8 +1,10 @@
 import type { Prisma } from '../../../generated/prisma';
 import type { CreateSongInput } from '../dto/create-song.dto';
 import type { GetBandSongsQuery } from '../dto/get-band-songs-query.dto';
+import type { UpdateSongInput } from '../dto/update-song.dto';
 import type { CreateSongResult } from '../types/create-song-result.type';
 import type { GetBandSongsResult } from '../types/song-list.type';
+import type { UpdateSongResult } from '../types/update-song-result.type';
 
 export const SONGS_REPOSITORY = Symbol('SONGS_REPOSITORY');
 
@@ -28,4 +30,17 @@ export interface SongsRepository {
   findExistingSkillTypeIds(skillTypeIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;
   createSong(input: CreateSongRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateSongResult>;
   findBandSongs(bandId: string, query: GetBandSongsQuery, tx?: Prisma.TransactionClient): Promise<GetBandSongsResult>;
+  findSongWithBandMemberBySongIdAndUserId(
+    songId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    bandId: string;
+    member: {
+      id: string;
+      userId: string;
+    } | null;
+  } | null>;
+  updateSong(songId: string, input: UpdateSongInput, tx?: Prisma.TransactionClient): Promise<UpdateSongResult>;
 }

--- a/backend/src/modules/songs/repositories/songs.repository.ts
+++ b/backend/src/modules/songs/repositories/songs.repository.ts
@@ -1,0 +1,28 @@
+import type { Prisma } from '../../../generated/prisma';
+import type { CreateSongInput } from '../dto/create-song.dto';
+import type { CreateSongResult } from '../types/create-song-result.type';
+
+export const SONGS_REPOSITORY = Symbol('SONGS_REPOSITORY');
+
+export interface CreateSongRepositoryInput extends CreateSongInput {
+  bandId: string;
+  userId: string;
+  createdByBandMemberId: string;
+  skillTypeIds: string[];
+}
+
+export interface SongsRepository {
+  findBandForSongCreate(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    member: {
+      id: string;
+      userId: string;
+    } | null;
+  } | null>;
+  findExistingSkillTypeIds(skillTypeIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;
+  createSong(input: CreateSongRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateSongResult>;
+}

--- a/backend/src/modules/songs/repositories/songs.repository.ts
+++ b/backend/src/modules/songs/repositories/songs.repository.ts
@@ -1,6 +1,8 @@
 import type { Prisma } from '../../../generated/prisma';
 import type { CreateSongInput } from '../dto/create-song.dto';
+import type { GetBandSongsQuery } from '../dto/get-band-songs-query.dto';
 import type { CreateSongResult } from '../types/create-song-result.type';
+import type { GetBandSongsResult } from '../types/song-list.type';
 
 export const SONGS_REPOSITORY = Symbol('SONGS_REPOSITORY');
 
@@ -12,7 +14,7 @@ export interface CreateSongRepositoryInput extends CreateSongInput {
 }
 
 export interface SongsRepository {
-  findBandForSongCreate(
+  findActiveBandWithMemberByBandIdAndUserId(
     bandId: string,
     userId: string,
     tx?: Prisma.TransactionClient,
@@ -25,4 +27,5 @@ export interface SongsRepository {
   } | null>;
   findExistingSkillTypeIds(skillTypeIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;
   createSong(input: CreateSongRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateSongResult>;
+  findBandSongs(bandId: string, query: GetBandSongsQuery, tx?: Prisma.TransactionClient): Promise<GetBandSongsResult>;
 }

--- a/backend/src/modules/songs/songs.controller.ts
+++ b/backend/src/modules/songs/songs.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Patch, Post, Query, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query, Req, UseGuards } from '@nestjs/common';
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
@@ -9,6 +9,7 @@ import { GetBandSongsQueryDto } from './dto/get-band-songs-query.dto';
 import { SearchDeezerTrackPreviewsQueryDto } from './dto/search-deezer-track-previews-query.dto';
 import { UpdateSongBodyDto } from './dto/update-song.dto';
 import type { CreateSongResult } from './types/create-song-result.type';
+import type { DeleteSongResult } from './types/delete-song-result.type';
 import type { GetBandSongsResult } from './types/song-list.type';
 import type { SongPreview } from './types/song-preview.type';
 import type { UpdateSongResult } from './types/update-song-result.type';
@@ -56,6 +57,14 @@ export class SongsController {
     const result = await this.songsService.updateSong(req.user.id, songId, body);
 
     return createSuccessResponse('곡이 수정되었습니다.', result);
+  }
+
+  @Delete('songs/:songId')
+  @UseGuards(AccessTokenGuard)
+  async deleteSong(@Req() req: AuthenticatedRequest, @Param('songId') songId: string): Promise<ApiSuccessResponse<DeleteSongResult>> {
+    const result = await this.songsService.deleteSong(req.user.id, songId);
+
+    return createSuccessResponse('곡이 삭제되었습니다.', result);
   }
 
   @Get('songs/spotify/tracks/:trackId')

--- a/backend/src/modules/songs/songs.controller.ts
+++ b/backend/src/modules/songs/songs.controller.ts
@@ -1,13 +1,34 @@
-import { BadRequestException, Controller, Get, Param, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query, Req, UseGuards } from '@nestjs/common';
 
+import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
+import type { User } from '../../generated/prisma';
 
+import { CreateSongBodyDto } from './dto/create-song.dto';
+import { SearchDeezerTrackPreviewsQueryDto } from './dto/search-deezer-track-previews-query.dto';
+import type { CreateSongResult } from './types/create-song-result.type';
 import type { SongPreview } from './types/song-preview.type';
 import { SongsService } from './songs.service';
+
+interface AuthenticatedRequest {
+  user: User;
+}
 
 @Controller()
 export class SongsController {
   constructor(private readonly songsService: SongsService) {}
+
+  @Post('bands/:bandId/songs')
+  @UseGuards(AccessTokenGuard)
+  async createSong(
+    @Req() req: AuthenticatedRequest,
+    @Param('bandId') bandId: string,
+    @Body() body: CreateSongBodyDto,
+  ): Promise<ApiSuccessResponse<CreateSongResult>> {
+    const result = await this.songsService.createSong(req.user.id, bandId, body);
+
+    return createSuccessResponse('곡 생성 성공', result);
+  }
 
   @Get('songs/spotify/tracks/:trackId')
   async getSpotifyTrackPreview(@Param('trackId') trackId: string): Promise<ApiSuccessResponse<SongPreview>> {
@@ -17,12 +38,8 @@ export class SongsController {
   }
 
   @Get('songs/deezer/tracks/search')
-  async searchDeezerTrackPreviews(@Query('query') query: string | undefined): Promise<ApiSuccessResponse<SongPreview[]>> {
-    if (query === undefined || query.trim() === '') {
-      throw new BadRequestException('query는 필수입니다.');
-    }
-
-    const songPreviews = await this.songsService.searchDeezerTrackPreviews(query.trim());
+  async searchDeezerTrackPreviews(@Query() query: SearchDeezerTrackPreviewsQueryDto): Promise<ApiSuccessResponse<SongPreview[]>> {
+    const songPreviews = await this.songsService.searchDeezerTrackPreviews(query.query);
 
     return createSuccessResponse('Deezer 곡 미리보기 목록 조회 성공', songPreviews);
   }

--- a/backend/src/modules/songs/songs.controller.ts
+++ b/backend/src/modules/songs/songs.controller.ts
@@ -5,8 +5,10 @@ import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api
 import type { User } from '../../generated/prisma';
 
 import { CreateSongBodyDto } from './dto/create-song.dto';
+import { GetBandSongsQueryDto } from './dto/get-band-songs-query.dto';
 import { SearchDeezerTrackPreviewsQueryDto } from './dto/search-deezer-track-previews-query.dto';
 import type { CreateSongResult } from './types/create-song-result.type';
+import type { GetBandSongsResult } from './types/song-list.type';
 import type { SongPreview } from './types/song-preview.type';
 import { SongsService } from './songs.service';
 
@@ -28,6 +30,18 @@ export class SongsController {
     const result = await this.songsService.createSong(req.user.id, bandId, body);
 
     return createSuccessResponse('곡 생성 성공', result);
+  }
+
+  @Get('bands/:bandId/songs')
+  @UseGuards(AccessTokenGuard)
+  async getBandSongs(
+    @Req() req: AuthenticatedRequest,
+    @Param('bandId') bandId: string,
+    @Query() query: GetBandSongsQueryDto,
+  ): Promise<ApiSuccessResponse<GetBandSongsResult>> {
+    const result = await this.songsService.getBandSongs(req.user.id, bandId, query);
+
+    return createSuccessResponse('곡 목록 조회 성공', result);
   }
 
   @Get('songs/spotify/tracks/:trackId')

--- a/backend/src/modules/songs/songs.controller.ts
+++ b/backend/src/modules/songs/songs.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, Query, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post, Query, Req, UseGuards } from '@nestjs/common';
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
@@ -7,9 +7,11 @@ import type { User } from '../../generated/prisma';
 import { CreateSongBodyDto } from './dto/create-song.dto';
 import { GetBandSongsQueryDto } from './dto/get-band-songs-query.dto';
 import { SearchDeezerTrackPreviewsQueryDto } from './dto/search-deezer-track-previews-query.dto';
+import { UpdateSongBodyDto } from './dto/update-song.dto';
 import type { CreateSongResult } from './types/create-song-result.type';
 import type { GetBandSongsResult } from './types/song-list.type';
 import type { SongPreview } from './types/song-preview.type';
+import type { UpdateSongResult } from './types/update-song-result.type';
 import { SongsService } from './songs.service';
 
 interface AuthenticatedRequest {
@@ -42,6 +44,18 @@ export class SongsController {
     const result = await this.songsService.getBandSongs(req.user.id, bandId, query);
 
     return createSuccessResponse('곡 목록 조회 성공', result);
+  }
+
+  @Patch('songs/:songId')
+  @UseGuards(AccessTokenGuard)
+  async updateSong(
+    @Req() req: AuthenticatedRequest,
+    @Param('songId') songId: string,
+    @Body() body: UpdateSongBodyDto,
+  ): Promise<ApiSuccessResponse<UpdateSongResult>> {
+    const result = await this.songsService.updateSong(req.user.id, songId, body);
+
+    return createSuccessResponse('곡이 수정되었습니다.', result);
   }
 
   @Get('songs/spotify/tracks/:trackId')

--- a/backend/src/modules/songs/songs.module.ts
+++ b/backend/src/modules/songs/songs.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 
 import { AuthModule } from '../../auth/auth.module';
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
+import { SkillsModule } from '../skills/skills.module';
 import { UsersModule } from '../users/users.module';
 
 import { SongsPrismaRepository } from './repositories/songs.prisma-repository';
@@ -12,7 +13,7 @@ import { SongsService } from './songs.service';
 import { SpotifyTrackClient } from './spotify-track.client';
 
 @Module({
-  imports: [AuthModule, UsersModule],
+  imports: [AuthModule, UsersModule, SkillsModule],
   controllers: [SongsController],
   providers: [
     AccessTokenGuard,

--- a/backend/src/modules/songs/songs.module.ts
+++ b/backend/src/modules/songs/songs.module.ts
@@ -1,12 +1,29 @@
 import { Module } from '@nestjs/common';
 
+import { AuthModule } from '../../auth/auth.module';
+import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
+import { UsersModule } from '../users/users.module';
+
+import { SongsPrismaRepository } from './repositories/songs.prisma-repository';
+import { SONGS_REPOSITORY } from './repositories/songs.repository';
 import { DeezerTrackClient } from './deezer-track.client';
 import { SongsController } from './songs.controller';
 import { SongsService } from './songs.service';
 import { SpotifyTrackClient } from './spotify-track.client';
 
 @Module({
+  imports: [AuthModule, UsersModule],
   controllers: [SongsController],
-  providers: [SongsService, SpotifyTrackClient, DeezerTrackClient],
+  providers: [
+    AccessTokenGuard,
+    SongsService,
+    SpotifyTrackClient,
+    DeezerTrackClient,
+    SongsPrismaRepository,
+    {
+      provide: SONGS_REPOSITORY,
+      useExisting: SongsPrismaRepository,
+    },
+  ],
 })
 export class SongsModule {}

--- a/backend/src/modules/songs/songs.service.spec.ts
+++ b/backend/src/modules/songs/songs.service.spec.ts
@@ -1,100 +1,300 @@
-import assert from 'node:assert/strict';
-import test from 'node:test';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 
+import type { PrismaService } from '../../database/prisma';
+
+import type { SongsRepository } from './repositories/songs.repository';
 import type { DeezerTrackSearcher } from './deezer-track.client';
 import { SongsService } from './songs.service';
 import type { SpotifyTrackReader } from './spotify-track.client';
 
-test('Spotify 곡 미리보기 서비스는 Spotify track 조회를 위임한다', async () => {
-  let capturedTrackId: string | undefined;
+describe('SongsService', () => {
+  const createService = (repositoryOverrides: Partial<SongsRepository> = {}) => {
+    const transactionClient = {};
+    const prisma = {
+      $transaction: jest.fn(async callback => callback(transactionClient)),
+    } as unknown as PrismaService;
 
-  const spotifyTrackReader: SpotifyTrackReader = {
-    async findTrack(trackId) {
-      capturedTrackId = trackId;
+    const repository: jest.Mocked<SongsRepository> = {
+      findBandForSongCreate: jest.fn(),
+      findExistingSkillTypeIds: jest.fn(),
+      createSong: jest.fn(),
+      ...repositoryOverrides,
+    } as jest.Mocked<SongsRepository>;
 
-      return {
-        id: trackId,
-        name: 'Cut To The Feeling',
-        duration_ms: 207959,
-        preview_url: null,
-        artists: [
-          {
-            name: 'Carly Rae Jepsen',
-          },
-        ],
-        album: {
-          name: 'Cut To The Feeling',
-          release_date: '2017-05-26',
-          images: [],
-        },
-        external_urls: {
-          spotify: 'https://open.spotify.com/track/11dFghVXANMlKmJXsNCbNl',
-        },
-      };
-    },
+    const spotifyTrackReader: jest.Mocked<SpotifyTrackReader> = {
+      findTrack: jest.fn(),
+    };
+    const deezerTrackSearcher: jest.Mocked<DeezerTrackSearcher> = {
+      searchTracks: jest.fn(),
+    };
+
+    const service = new SongsService(repository, prisma, spotifyTrackReader, deezerTrackSearcher);
+
+    return {
+      service,
+      repository,
+      prisma,
+      transactionClient,
+      spotifyTrackReader,
+      deezerTrackSearcher,
+    };
   };
-  const deezerTrackSearcher: DeezerTrackSearcher = {
-    async searchTracks() {
-      throw new Error('Spotify 조회 테스트에서는 Deezer를 호출하지 않습니다.');
-    },
-  };
-  const service = new SongsService(spotifyTrackReader, deezerTrackSearcher);
 
-  const result = await service.previewSpotifyTrack('11dFghVXANMlKmJXsNCbNl');
+  it('Spotify 곡 미리보기 서비스는 Spotify track 조회를 위임한다', async () => {
+    const { service, spotifyTrackReader } = createService();
 
-  assert.equal(capturedTrackId, '11dFghVXANMlKmJXsNCbNl');
-  assert.equal(result.externalTrackId, '11dFghVXANMlKmJXsNCbNl');
-  assert.equal(result.title, 'Cut To The Feeling');
-  assert.equal(result.artistName, 'Carly Rae Jepsen');
-  assert.equal(result.albumName, 'Cut To The Feeling');
-  assert.equal(result.sourceUrl, 'https://open.spotify.com/track/11dFghVXANMlKmJXsNCbNl');
-  assert.equal(result.sourceType, 'SPOTIFY');
-});
-
-test('Deezer 곡 미리보기 서비스는 Deezer track 검색 결과를 목록으로 변환한다', async () => {
-  let capturedQuery: string | undefined;
-
-  const spotifyTrackReader: SpotifyTrackReader = {
-    async findTrack() {
-      throw new Error('Deezer 조회 테스트에서는 Spotify를 호출하지 않습니다.');
-    },
-  };
-  const deezerTrackSearcher: DeezerTrackSearcher = {
-    async searchTracks(query) {
-      capturedQuery = query;
-
-      return [
+    spotifyTrackReader.findTrack.mockResolvedValue({
+      id: '11dFghVXANMlKmJXsNCbNl',
+      name: 'Cut To The Feeling',
+      duration_ms: 207959,
+      preview_url: null,
+      artists: [
         {
-          id: 3135556,
-          title: 'Harder, Better, Faster, Stronger',
-          duration: 224,
-          link: 'https://www.deezer.com/track/3135556',
-          preview: 'https://cdns-preview.dzcdn.net/stream/demo.mp3',
-          artist: {
-            name: 'Daft Punk',
-          },
-          album: {
-            title: 'Discovery',
-            cover: 'https://api.deezer.com/album/302127/image',
-            cover_medium: 'https://e-cdns-images.dzcdn.net/images/cover/medium.jpg',
-            cover_big: 'https://e-cdns-images.dzcdn.net/images/cover/big.jpg',
-            cover_xl: 'https://e-cdns-images.dzcdn.net/images/cover/xl.jpg',
-          },
+          name: 'Carly Rae Jepsen',
         },
-      ];
-    },
-  };
-  const service = new SongsService(spotifyTrackReader, deezerTrackSearcher);
+      ],
+      album: {
+        name: 'Cut To The Feeling',
+        release_date: '2017-05-26',
+        images: [],
+      },
+      external_urls: {
+        spotify: 'https://open.spotify.com/track/11dFghVXANMlKmJXsNCbNl',
+      },
+    });
 
-  const result = await service.searchDeezerTrackPreviews('Daft Punk Harder Better Faster Stronger');
+    const result = await service.previewSpotifyTrack('11dFghVXANMlKmJXsNCbNl');
 
-  assert.equal(capturedQuery, 'Daft Punk Harder Better Faster Stronger');
-  assert.equal(result.length, 1);
-  assert.equal(result[0]?.externalTrackId, '3135556');
-  assert.equal(result[0]?.title, 'Harder, Better, Faster, Stronger');
-  assert.equal(result[0]?.artistName, 'Daft Punk');
-  assert.equal(result[0]?.albumName, 'Discovery');
-  assert.equal(result[0]?.durationMs, 224000);
-  assert.equal(result[0]?.sourceUrl, 'https://www.deezer.com/track/3135556');
-  assert.equal(result[0]?.sourceType, 'DEEZER');
+    expect(spotifyTrackReader.findTrack).toHaveBeenCalledWith('11dFghVXANMlKmJXsNCbNl');
+    expect(result).toMatchObject({
+      externalTrackId: '11dFghVXANMlKmJXsNCbNl',
+      title: 'Cut To The Feeling',
+      artistName: 'Carly Rae Jepsen',
+      albumName: 'Cut To The Feeling',
+      sourceUrl: 'https://open.spotify.com/track/11dFghVXANMlKmJXsNCbNl',
+      sourceType: 'SPOTIFY',
+    });
+  });
+
+  it('Deezer 곡 미리보기 서비스는 Deezer track 검색 결과를 목록으로 변환한다', async () => {
+    const { service, deezerTrackSearcher } = createService();
+
+    deezerTrackSearcher.searchTracks.mockResolvedValue([
+      {
+        id: 3135556,
+        title: 'Harder, Better, Faster, Stronger',
+        duration: 224,
+        link: 'https://www.deezer.com/track/3135556',
+        preview: 'https://cdns-preview.dzcdn.net/stream/demo.mp3',
+        artist: {
+          name: 'Daft Punk',
+        },
+        album: {
+          title: 'Discovery',
+          cover: 'https://api.deezer.com/album/302127/image',
+          cover_medium: 'https://e-cdns-images.dzcdn.net/images/cover/medium.jpg',
+          cover_big: 'https://e-cdns-images.dzcdn.net/images/cover/big.jpg',
+          cover_xl: 'https://e-cdns-images.dzcdn.net/images/cover/xl.jpg',
+        },
+      },
+    ]);
+
+    const result = await service.searchDeezerTrackPreviews('Daft Punk Harder Better Faster Stronger');
+
+    expect(deezerTrackSearcher.searchTracks).toHaveBeenCalledWith('Daft Punk Harder Better Faster Stronger');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      externalTrackId: '3135556',
+      title: 'Harder, Better, Faster, Stronger',
+      artistName: 'Daft Punk',
+      albumName: 'Discovery',
+      durationMs: 224000,
+      sourceUrl: 'https://www.deezer.com/track/3135556',
+      sourceType: 'DEEZER',
+    });
+  });
+
+  it('밴드 멤버가 곡을 생성하면 세션 타입을 검증하고 곡을 저장한다', async () => {
+    const { service, repository, transactionClient } = createService();
+
+    repository.findBandForSongCreate.mockResolvedValue({
+      id: 'band-id',
+      member: {
+        id: 'band-member-id',
+        userId: 'user-id',
+      },
+    });
+    repository.findExistingSkillTypeIds.mockResolvedValue(['skill-type-1', 'skill-type-2']);
+    repository.createSong.mockResolvedValue({
+      song: {
+        id: 'song-id',
+        bandId: 'band-id',
+        title: 'Harder, Better, Faster, Stronger',
+        artistName: 'Daft Punk',
+        sourceUrl: 'https://www.deezer.com/track/3135556',
+        sourceType: 'DEEZER',
+        memo: '후렴 진입 전 드럼 큐 확인',
+        key: null,
+        bpm: null,
+        difficultyLevel: null,
+        userId: 'user-id',
+        createdAt: '2026-05-20T00:00:00.000Z',
+      },
+      skillTypes: [
+        {
+          id: 'skill-type-1',
+          name: '보컬',
+        },
+        {
+          id: 'skill-type-2',
+          name: '기타',
+        },
+      ],
+    });
+
+    const result = await service.createSong('user-id', 'band-id', {
+      title: 'Harder, Better, Faster, Stronger',
+      artistName: 'Daft Punk',
+      sourceUrl: 'https://www.deezer.com/track/3135556',
+      sourceType: 'DEEZER',
+      memo: '후렴 진입 전 드럼 큐 확인',
+      skillTypeIds: ['skill-type-1', 'skill-type-2'],
+    });
+
+    expect(repository.findBandForSongCreate).toHaveBeenCalledWith('band-id', 'user-id', transactionClient);
+    expect(repository.findExistingSkillTypeIds).toHaveBeenCalledWith(['skill-type-1', 'skill-type-2'], transactionClient);
+    expect(repository.createSong).toHaveBeenCalledWith(
+      {
+        title: 'Harder, Better, Faster, Stronger',
+        artistName: 'Daft Punk',
+        sourceUrl: 'https://www.deezer.com/track/3135556',
+        sourceType: 'DEEZER',
+        memo: '후렴 진입 전 드럼 큐 확인',
+        skillTypeIds: ['skill-type-1', 'skill-type-2'],
+        bandId: 'band-id',
+        userId: 'user-id',
+        createdByBandMemberId: 'band-member-id',
+      },
+      transactionClient,
+    );
+    expect(result.song.userId).toBe('user-id');
+  });
+
+  it('상위 트랜잭션이 있으면 새 트랜잭션을 열지 않는다', async () => {
+    const { service, repository, prisma } = createService();
+    const tx = {};
+
+    repository.findBandForSongCreate.mockResolvedValue({
+      id: 'band-id',
+      member: {
+        id: 'band-member-id',
+        userId: 'user-id',
+      },
+    });
+    repository.createSong.mockResolvedValue({
+      song: {
+        id: 'song-id',
+        bandId: 'band-id',
+        title: 'Song',
+        artistName: 'Artist',
+        sourceUrl: 'https://www.deezer.com/track/3135556',
+        sourceType: 'DEEZER',
+        memo: null,
+        key: null,
+        bpm: null,
+        difficultyLevel: null,
+        userId: 'user-id',
+        createdAt: '2026-05-20T00:00:00.000Z',
+      },
+      skillTypes: [],
+    });
+
+    await service.createSong(
+      'user-id',
+      'band-id',
+      {
+        title: 'Song',
+        artistName: 'Artist',
+        sourceUrl: 'https://www.deezer.com/track/3135556',
+        sourceType: 'DEEZER',
+      },
+      tx as never,
+    );
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(repository.findBandForSongCreate).toHaveBeenCalledWith('band-id', 'user-id', tx);
+    expect(repository.findExistingSkillTypeIds).not.toHaveBeenCalled();
+  });
+
+  it('세션 타입 ID가 중복되면 BadRequestException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    await expect(
+      service.createSong('user-id', 'band-id', {
+        title: 'Song',
+        artistName: 'Artist',
+        sourceUrl: 'https://www.deezer.com/track/3135556',
+        sourceType: 'DEEZER',
+        skillTypeIds: ['skill-type-1', 'skill-type-1'],
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(repository.findBandForSongCreate).not.toHaveBeenCalled();
+  });
+
+  it('밴드가 없으면 NotFoundException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    repository.findBandForSongCreate.mockResolvedValue(null);
+
+    await expect(
+      service.createSong('user-id', 'band-id', {
+        title: 'Song',
+        artistName: 'Artist',
+        sourceUrl: 'https://www.deezer.com/track/3135556',
+        sourceType: 'DEEZER',
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('밴드 멤버가 아니면 ForbiddenException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    repository.findBandForSongCreate.mockResolvedValue({
+      id: 'band-id',
+      member: null,
+    });
+
+    await expect(
+      service.createSong('user-id', 'band-id', {
+        title: 'Song',
+        artistName: 'Artist',
+        sourceUrl: 'https://www.deezer.com/track/3135556',
+        sourceType: 'DEEZER',
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('존재하지 않는 세션 타입이 있으면 BadRequestException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    repository.findBandForSongCreate.mockResolvedValue({
+      id: 'band-id',
+      member: {
+        id: 'band-member-id',
+        userId: 'user-id',
+      },
+    });
+    repository.findExistingSkillTypeIds.mockResolvedValue(['skill-type-1']);
+
+    await expect(
+      service.createSong('user-id', 'band-id', {
+        title: 'Song',
+        artistName: 'Artist',
+        sourceUrl: 'https://www.deezer.com/track/3135556',
+        sourceType: 'DEEZER',
+        skillTypeIds: ['skill-type-1', 'skill-type-2'],
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(repository.createSong).not.toHaveBeenCalled();
+  });
 });

--- a/backend/src/modules/songs/songs.service.spec.ts
+++ b/backend/src/modules/songs/songs.service.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 
 import type { PrismaService } from '../../database/prisma';
+import type { SkillsService } from '../skills/skills.service';
 
 import type { SongsRepository } from './repositories/songs.repository';
 import type { DeezerTrackSearcher } from './deezer-track.client';
@@ -16,7 +17,6 @@ describe('SongsService', () => {
 
     const repository: jest.Mocked<SongsRepository> = {
       findActiveBandWithMemberByBandIdAndUserId: jest.fn(),
-      findExistingSkillTypeIds: jest.fn(),
       createSong: jest.fn(),
       findBandSongs: jest.fn(),
       findSongWithBandMemberBySongIdAndUserId: jest.fn(),
@@ -31,14 +31,18 @@ describe('SongsService', () => {
     const deezerTrackSearcher: jest.Mocked<DeezerTrackSearcher> = {
       searchTracks: jest.fn(),
     };
+    const skillsService: jest.Mocked<SkillsService> = {
+      findExistingSkillTypeIds: jest.fn(),
+    } as unknown as jest.Mocked<SkillsService>;
 
-    const service = new SongsService(repository, prisma, spotifyTrackReader, deezerTrackSearcher);
+    const service = new SongsService(repository, prisma, skillsService, spotifyTrackReader, deezerTrackSearcher);
 
     return {
       service,
       repository,
       prisma,
       transactionClient,
+      skillsService,
       spotifyTrackReader,
       deezerTrackSearcher,
     };
@@ -119,7 +123,7 @@ describe('SongsService', () => {
   });
 
   it('밴드 멤버가 곡을 생성하면 세션 타입을 검증하고 곡을 저장한다', async () => {
-    const { service, repository, transactionClient } = createService();
+    const { service, repository, transactionClient, skillsService } = createService();
 
     repository.findActiveBandWithMemberByBandIdAndUserId.mockResolvedValue({
       id: 'band-id',
@@ -128,7 +132,7 @@ describe('SongsService', () => {
         userId: 'user-id',
       },
     });
-    repository.findExistingSkillTypeIds.mockResolvedValue(['skill-type-1', 'skill-type-2']);
+    skillsService.findExistingSkillTypeIds.mockResolvedValue({ skillTypeIds: ['skill-type-1', 'skill-type-2'] });
     repository.createSong.mockResolvedValue({
       song: {
         id: 'song-id',
@@ -166,7 +170,7 @@ describe('SongsService', () => {
     });
 
     expect(repository.findActiveBandWithMemberByBandIdAndUserId).toHaveBeenCalledWith('band-id', 'user-id', transactionClient);
-    expect(repository.findExistingSkillTypeIds).toHaveBeenCalledWith(['skill-type-1', 'skill-type-2'], transactionClient);
+    expect(skillsService.findExistingSkillTypeIds).toHaveBeenCalledWith(['skill-type-1', 'skill-type-2'], transactionClient);
     expect(repository.createSong).toHaveBeenCalledWith(
       {
         title: 'Harder, Better, Faster, Stronger',
@@ -185,7 +189,7 @@ describe('SongsService', () => {
   });
 
   it('상위 트랜잭션이 있으면 새 트랜잭션을 열지 않는다', async () => {
-    const { service, repository, prisma } = createService();
+    const { service, repository, prisma, skillsService } = createService();
     const tx = {};
 
     repository.findActiveBandWithMemberByBandIdAndUserId.mockResolvedValue({
@@ -227,7 +231,7 @@ describe('SongsService', () => {
 
     expect(prisma.$transaction).not.toHaveBeenCalled();
     expect(repository.findActiveBandWithMemberByBandIdAndUserId).toHaveBeenCalledWith('band-id', 'user-id', tx);
-    expect(repository.findExistingSkillTypeIds).not.toHaveBeenCalled();
+    expect(skillsService.findExistingSkillTypeIds).not.toHaveBeenCalled();
   });
 
   it('세션 타입 ID가 중복되면 BadRequestException을 던진다', async () => {
@@ -279,7 +283,7 @@ describe('SongsService', () => {
   });
 
   it('존재하지 않는 세션 타입이 있으면 BadRequestException을 던진다', async () => {
-    const { service, repository } = createService();
+    const { service, repository, skillsService } = createService();
 
     repository.findActiveBandWithMemberByBandIdAndUserId.mockResolvedValue({
       id: 'band-id',
@@ -288,7 +292,7 @@ describe('SongsService', () => {
         userId: 'user-id',
       },
     });
-    repository.findExistingSkillTypeIds.mockResolvedValue(['skill-type-1']);
+    skillsService.findExistingSkillTypeIds.mockResolvedValue({ skillTypeIds: ['skill-type-1'] });
 
     await expect(
       service.createSong('user-id', 'band-id', {
@@ -402,7 +406,7 @@ describe('SongsService', () => {
   });
 
   it('밴드 멤버가 곡을 수정하면 세션 타입을 검증하고 저장한다', async () => {
-    const { service, repository, transactionClient } = createService();
+    const { service, repository, transactionClient, skillsService } = createService();
 
     repository.findSongWithBandMemberBySongIdAndUserId.mockResolvedValue({
       id: 'song-id',
@@ -412,7 +416,7 @@ describe('SongsService', () => {
         userId: 'user-id',
       },
     });
-    repository.findExistingSkillTypeIds.mockResolvedValue(['skill-type-1']);
+    skillsService.findExistingSkillTypeIds.mockResolvedValue({ skillTypeIds: ['skill-type-1'] });
     repository.updateSong.mockResolvedValue({
       song: {
         id: 'song-id',
@@ -443,7 +447,7 @@ describe('SongsService', () => {
     const result = await service.updateSong('user-id', 'song-id', input);
 
     expect(repository.findSongWithBandMemberBySongIdAndUserId).toHaveBeenCalledWith('song-id', 'user-id', transactionClient);
-    expect(repository.findExistingSkillTypeIds).toHaveBeenCalledWith(['skill-type-1'], transactionClient);
+    expect(skillsService.findExistingSkillTypeIds).toHaveBeenCalledWith(['skill-type-1'], transactionClient);
     expect(repository.updateSong).toHaveBeenCalledWith('song-id', input, transactionClient);
     expect(result.song.memo).toBe('템포 124 기준으로 연습');
   });
@@ -530,7 +534,7 @@ describe('SongsService', () => {
   });
 
   it('곡 수정 시 존재하지 않는 세션 타입이 있으면 BadRequestException을 던진다', async () => {
-    const { service, repository } = createService();
+    const { service, repository, skillsService } = createService();
 
     repository.findSongWithBandMemberBySongIdAndUserId.mockResolvedValue({
       id: 'song-id',
@@ -540,7 +544,7 @@ describe('SongsService', () => {
         userId: 'user-id',
       },
     });
-    repository.findExistingSkillTypeIds.mockResolvedValue([]);
+    skillsService.findExistingSkillTypeIds.mockResolvedValue({ skillTypeIds: [] });
 
     await expect(service.updateSong('user-id', 'song-id', { skillTypeIds: ['skill-type-1'] })).rejects.toBeInstanceOf(BadRequestException);
     expect(repository.updateSong).not.toHaveBeenCalled();

--- a/backend/src/modules/songs/songs.service.spec.ts
+++ b/backend/src/modules/songs/songs.service.spec.ts
@@ -15,9 +15,10 @@ describe('SongsService', () => {
     } as unknown as PrismaService;
 
     const repository: jest.Mocked<SongsRepository> = {
-      findBandForSongCreate: jest.fn(),
+      findActiveBandWithMemberByBandIdAndUserId: jest.fn(),
       findExistingSkillTypeIds: jest.fn(),
       createSong: jest.fn(),
+      findBandSongs: jest.fn(),
       ...repositoryOverrides,
     } as jest.Mocked<SongsRepository>;
 
@@ -117,7 +118,7 @@ describe('SongsService', () => {
   it('밴드 멤버가 곡을 생성하면 세션 타입을 검증하고 곡을 저장한다', async () => {
     const { service, repository, transactionClient } = createService();
 
-    repository.findBandForSongCreate.mockResolvedValue({
+    repository.findActiveBandWithMemberByBandIdAndUserId.mockResolvedValue({
       id: 'band-id',
       member: {
         id: 'band-member-id',
@@ -161,7 +162,7 @@ describe('SongsService', () => {
       skillTypeIds: ['skill-type-1', 'skill-type-2'],
     });
 
-    expect(repository.findBandForSongCreate).toHaveBeenCalledWith('band-id', 'user-id', transactionClient);
+    expect(repository.findActiveBandWithMemberByBandIdAndUserId).toHaveBeenCalledWith('band-id', 'user-id', transactionClient);
     expect(repository.findExistingSkillTypeIds).toHaveBeenCalledWith(['skill-type-1', 'skill-type-2'], transactionClient);
     expect(repository.createSong).toHaveBeenCalledWith(
       {
@@ -184,7 +185,7 @@ describe('SongsService', () => {
     const { service, repository, prisma } = createService();
     const tx = {};
 
-    repository.findBandForSongCreate.mockResolvedValue({
+    repository.findActiveBandWithMemberByBandIdAndUserId.mockResolvedValue({
       id: 'band-id',
       member: {
         id: 'band-member-id',
@@ -222,7 +223,7 @@ describe('SongsService', () => {
     );
 
     expect(prisma.$transaction).not.toHaveBeenCalled();
-    expect(repository.findBandForSongCreate).toHaveBeenCalledWith('band-id', 'user-id', tx);
+    expect(repository.findActiveBandWithMemberByBandIdAndUserId).toHaveBeenCalledWith('band-id', 'user-id', tx);
     expect(repository.findExistingSkillTypeIds).not.toHaveBeenCalled();
   });
 
@@ -238,13 +239,13 @@ describe('SongsService', () => {
         skillTypeIds: ['skill-type-1', 'skill-type-1'],
       }),
     ).rejects.toBeInstanceOf(BadRequestException);
-    expect(repository.findBandForSongCreate).not.toHaveBeenCalled();
+    expect(repository.findActiveBandWithMemberByBandIdAndUserId).not.toHaveBeenCalled();
   });
 
   it('밴드가 없으면 NotFoundException을 던진다', async () => {
     const { service, repository } = createService();
 
-    repository.findBandForSongCreate.mockResolvedValue(null);
+    repository.findActiveBandWithMemberByBandIdAndUserId.mockResolvedValue(null);
 
     await expect(
       service.createSong('user-id', 'band-id', {
@@ -259,7 +260,7 @@ describe('SongsService', () => {
   it('밴드 멤버가 아니면 ForbiddenException을 던진다', async () => {
     const { service, repository } = createService();
 
-    repository.findBandForSongCreate.mockResolvedValue({
+    repository.findActiveBandWithMemberByBandIdAndUserId.mockResolvedValue({
       id: 'band-id',
       member: null,
     });
@@ -277,7 +278,7 @@ describe('SongsService', () => {
   it('존재하지 않는 세션 타입이 있으면 BadRequestException을 던진다', async () => {
     const { service, repository } = createService();
 
-    repository.findBandForSongCreate.mockResolvedValue({
+    repository.findActiveBandWithMemberByBandIdAndUserId.mockResolvedValue({
       id: 'band-id',
       member: {
         id: 'band-member-id',
@@ -296,5 +297,134 @@ describe('SongsService', () => {
       }),
     ).rejects.toBeInstanceOf(BadRequestException);
     expect(repository.createSong).not.toHaveBeenCalled();
+  });
+
+  it('밴드 멤버가 곡 목록을 조회한다', async () => {
+    const { service, repository } = createService();
+
+    repository.findActiveBandWithMemberByBandIdAndUserId.mockResolvedValue({
+      id: 'band-id',
+      member: {
+        id: 'band-member-id',
+        userId: 'user-id',
+      },
+    });
+    repository.findBandSongs.mockResolvedValue({
+      items: [
+        {
+          id: 'song-id',
+          bandId: 'band-id',
+          title: 'Harder, Better, Faster, Stronger',
+          artistName: 'Daft Punk',
+          key: null,
+          bpm: null,
+          difficultyLevel: null,
+          sourceUrl: 'https://www.deezer.com/track/3135556',
+          sourceType: 'DEEZER',
+          createdAt: '2026-05-20T00:00:00.000Z',
+          skills: [
+            {
+              skillTypeId: 'skill-type-id',
+              skillName: '기타',
+            },
+          ],
+        },
+      ],
+      meta: {
+        count: 1,
+        take: 20,
+        cursor: {
+          createdAt: '2026-05-20T00:00:00.000Z',
+          id: 'song-id',
+        },
+        next: null,
+      },
+    });
+
+    const query = {
+      order__created_at: 'desc' as const,
+      order__id: 'desc' as const,
+      take: 20,
+      where__title__contain: 'Harder',
+    };
+
+    const result = await service.getBandSongs('user-id', 'band-id', query);
+
+    expect(repository.findActiveBandWithMemberByBandIdAndUserId).toHaveBeenCalledWith('band-id', 'user-id', undefined);
+    expect(repository.findBandSongs).toHaveBeenCalledWith('band-id', query, undefined);
+    expect(result.items).toHaveLength(1);
+  });
+
+  it('곡 목록 조회 시 밴드가 없으면 NotFoundException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    repository.findActiveBandWithMemberByBandIdAndUserId.mockResolvedValue(null);
+
+    await expect(
+      service.getBandSongs('user-id', 'band-id', {
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('곡 목록 조회 시 밴드 멤버가 아니면 ForbiddenException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    repository.findActiveBandWithMemberByBandIdAndUserId.mockResolvedValue({
+      id: 'band-id',
+      member: null,
+    });
+
+    await expect(
+      service.getBandSongs('user-id', 'band-id', {
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('곡 목록 조회 정렬 방향이 다르면 BadRequestException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    await expect(
+      service.getBandSongs('user-id', 'band-id', {
+        order__created_at: 'desc',
+        order__id: 'asc',
+        take: 20,
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(repository.findActiveBandWithMemberByBandIdAndUserId).not.toHaveBeenCalled();
+  });
+
+  it('곡 목록 조회 커서 값이 한쪽만 있으면 BadRequestException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    await expect(
+      service.getBandSongs('user-id', 'band-id', {
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+        cursor__created_at: '2026-05-20T00:00:00.000Z',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(repository.findActiveBandWithMemberByBandIdAndUserId).not.toHaveBeenCalled();
+  });
+
+  it('곡 목록 조회 커서 날짜가 잘못되면 BadRequestException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    await expect(
+      service.getBandSongs('user-id', 'band-id', {
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+        cursor__created_at: 'invalid-date',
+        cursor__id: 'song-id',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(repository.findActiveBandWithMemberByBandIdAndUserId).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/songs/songs.service.spec.ts
+++ b/backend/src/modules/songs/songs.service.spec.ts
@@ -602,6 +602,22 @@ describe('SongsService', () => {
     expect(repository.deleteSong).not.toHaveBeenCalled();
   });
 
+  it('곡 삭제 실행 시 이미 삭제된 곡이면 NotFoundException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    repository.findSongWithBandMemberBySongIdAndUserId.mockResolvedValue({
+      id: 'song-id',
+      bandId: 'band-id',
+      member: {
+        id: 'band-member-id',
+        userId: 'user-id',
+      },
+    });
+    repository.deleteSong.mockResolvedValue(undefined);
+
+    await expect(service.deleteSong('user-id', 'song-id')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
   it('곡 삭제 시 밴드 멤버가 아니면 ForbiddenException을 던진다', async () => {
     const { service, repository } = createService();
 

--- a/backend/src/modules/songs/songs.service.spec.ts
+++ b/backend/src/modules/songs/songs.service.spec.ts
@@ -337,7 +337,6 @@ describe('SongsService', () => {
         count: 1,
         take: 20,
         cursor: {
-          createdAt: '2026-05-20T00:00:00.000Z',
           id: 'song-id',
         },
         next: null,
@@ -397,35 +396,6 @@ describe('SongsService', () => {
         order__created_at: 'desc',
         order__id: 'asc',
         take: 20,
-      }),
-    ).rejects.toBeInstanceOf(BadRequestException);
-    expect(repository.findActiveBandWithMemberByBandIdAndUserId).not.toHaveBeenCalled();
-  });
-
-  it('곡 목록 조회 커서 값이 한쪽만 있으면 BadRequestException을 던진다', async () => {
-    const { service, repository } = createService();
-
-    await expect(
-      service.getBandSongs('user-id', 'band-id', {
-        order__created_at: 'desc',
-        order__id: 'desc',
-        take: 20,
-        cursor__created_at: '2026-05-20T00:00:00.000Z',
-      }),
-    ).rejects.toBeInstanceOf(BadRequestException);
-    expect(repository.findActiveBandWithMemberByBandIdAndUserId).not.toHaveBeenCalled();
-  });
-
-  it('곡 목록 조회 커서 날짜가 잘못되면 BadRequestException을 던진다', async () => {
-    const { service, repository } = createService();
-
-    await expect(
-      service.getBandSongs('user-id', 'band-id', {
-        order__created_at: 'desc',
-        order__id: 'desc',
-        take: 20,
-        cursor__created_at: 'invalid-date',
-        cursor__id: 'song-id',
       }),
     ).rejects.toBeInstanceOf(BadRequestException);
     expect(repository.findActiveBandWithMemberByBandIdAndUserId).not.toHaveBeenCalled();

--- a/backend/src/modules/songs/songs.service.spec.ts
+++ b/backend/src/modules/songs/songs.service.spec.ts
@@ -21,6 +21,7 @@ describe('SongsService', () => {
       findBandSongs: jest.fn(),
       findSongWithBandMemberBySongIdAndUserId: jest.fn(),
       updateSong: jest.fn(),
+      deleteSong: jest.fn(),
       ...repositoryOverrides,
     } as jest.Mocked<SongsRepository>;
 
@@ -573,5 +574,74 @@ describe('SongsService', () => {
 
     await expect(service.updateSong('user-id', 'song-id', { skillTypeIds: ['skill-type-1'] })).rejects.toBeInstanceOf(BadRequestException);
     expect(repository.updateSong).not.toHaveBeenCalled();
+  });
+
+  it('밴드 멤버가 곡을 삭제한다', async () => {
+    const { service, repository, transactionClient } = createService();
+
+    repository.findSongWithBandMemberBySongIdAndUserId.mockResolvedValue({
+      id: 'song-id',
+      bandId: 'band-id',
+      member: {
+        id: 'band-member-id',
+        userId: 'user-id',
+      },
+    });
+    repository.deleteSong.mockResolvedValue({
+      songId: 'song-id',
+      deletedAt: '2026-05-20T00:00:00.000Z',
+    });
+
+    const result = await service.deleteSong('user-id', 'song-id');
+
+    expect(repository.findSongWithBandMemberBySongIdAndUserId).toHaveBeenCalledWith('song-id', 'user-id', transactionClient);
+    expect(repository.deleteSong).toHaveBeenCalledWith('song-id', expect.any(Date), transactionClient);
+    expect(result.songId).toBe('song-id');
+  });
+
+  it('곡 삭제 시 상위 트랜잭션이 있으면 새 트랜잭션을 열지 않는다', async () => {
+    const { service, repository, prisma } = createService();
+    const tx = {};
+
+    repository.findSongWithBandMemberBySongIdAndUserId.mockResolvedValue({
+      id: 'song-id',
+      bandId: 'band-id',
+      member: {
+        id: 'band-member-id',
+        userId: 'user-id',
+      },
+    });
+    repository.deleteSong.mockResolvedValue({
+      songId: 'song-id',
+      deletedAt: '2026-05-20T00:00:00.000Z',
+    });
+
+    await service.deleteSong('user-id', 'song-id', tx as never);
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(repository.findSongWithBandMemberBySongIdAndUserId).toHaveBeenCalledWith('song-id', 'user-id', tx);
+    expect(repository.deleteSong).toHaveBeenCalledWith('song-id', expect.any(Date), tx);
+  });
+
+  it('곡 삭제 시 곡이 없으면 NotFoundException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    repository.findSongWithBandMemberBySongIdAndUserId.mockResolvedValue(null);
+
+    await expect(service.deleteSong('user-id', 'song-id')).rejects.toBeInstanceOf(NotFoundException);
+    expect(repository.deleteSong).not.toHaveBeenCalled();
+  });
+
+  it('곡 삭제 시 밴드 멤버가 아니면 ForbiddenException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    repository.findSongWithBandMemberBySongIdAndUserId.mockResolvedValue({
+      id: 'song-id',
+      bandId: 'band-id',
+      member: null,
+    });
+
+    await expect(service.deleteSong('user-id', 'song-id')).rejects.toBeInstanceOf(ForbiddenException);
+    expect(repository.deleteSong).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/songs/songs.service.spec.ts
+++ b/backend/src/modules/songs/songs.service.spec.ts
@@ -19,6 +19,8 @@ describe('SongsService', () => {
       findExistingSkillTypeIds: jest.fn(),
       createSong: jest.fn(),
       findBandSongs: jest.fn(),
+      findSongWithBandMemberBySongIdAndUserId: jest.fn(),
+      updateSong: jest.fn(),
       ...repositoryOverrides,
     } as jest.Mocked<SongsRepository>;
 
@@ -426,5 +428,150 @@ describe('SongsService', () => {
       }),
     ).rejects.toBeInstanceOf(BadRequestException);
     expect(repository.findActiveBandWithMemberByBandIdAndUserId).not.toHaveBeenCalled();
+  });
+
+  it('밴드 멤버가 곡을 수정하면 세션 타입을 검증하고 저장한다', async () => {
+    const { service, repository, transactionClient } = createService();
+
+    repository.findSongWithBandMemberBySongIdAndUserId.mockResolvedValue({
+      id: 'song-id',
+      bandId: 'band-id',
+      member: {
+        id: 'band-member-id',
+        userId: 'user-id',
+      },
+    });
+    repository.findExistingSkillTypeIds.mockResolvedValue(['skill-type-1']);
+    repository.updateSong.mockResolvedValue({
+      song: {
+        id: 'song-id',
+        bandId: 'band-id',
+        title: 'Harder, Better, Faster, Stronger',
+        artistName: 'Daft Punk',
+        sourceUrl: 'https://www.deezer.com/track/3135556',
+        sourceType: 'DEEZER',
+        memo: '템포 124 기준으로 연습',
+        key: null,
+        bpm: null,
+        difficultyLevel: null,
+        updatedAt: '2026-05-20T00:00:00.000Z',
+        skills: [
+          {
+            skillTypeId: 'skill-type-1',
+            skillName: '기타',
+          },
+        ],
+      },
+    });
+
+    const input = {
+      memo: '템포 124 기준으로 연습',
+      skillTypeIds: ['skill-type-1'],
+    };
+
+    const result = await service.updateSong('user-id', 'song-id', input);
+
+    expect(repository.findSongWithBandMemberBySongIdAndUserId).toHaveBeenCalledWith('song-id', 'user-id', transactionClient);
+    expect(repository.findExistingSkillTypeIds).toHaveBeenCalledWith(['skill-type-1'], transactionClient);
+    expect(repository.updateSong).toHaveBeenCalledWith('song-id', input, transactionClient);
+    expect(result.song.memo).toBe('템포 124 기준으로 연습');
+  });
+
+  it('곡 수정 시 상위 트랜잭션이 있으면 새 트랜잭션을 열지 않는다', async () => {
+    const { service, repository, prisma } = createService();
+    const tx = {};
+
+    repository.findSongWithBandMemberBySongIdAndUserId.mockResolvedValue({
+      id: 'song-id',
+      bandId: 'band-id',
+      member: {
+        id: 'band-member-id',
+        userId: 'user-id',
+      },
+    });
+    repository.updateSong.mockResolvedValue({
+      song: {
+        id: 'song-id',
+        bandId: 'band-id',
+        title: 'Song',
+        artistName: 'Artist',
+        sourceUrl: null,
+        sourceType: null,
+        memo: null,
+        key: null,
+        bpm: null,
+        difficultyLevel: null,
+        updatedAt: '2026-05-20T00:00:00.000Z',
+        skills: [],
+      },
+    });
+
+    await service.updateSong('user-id', 'song-id', { memo: null }, tx as never);
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(repository.findSongWithBandMemberBySongIdAndUserId).toHaveBeenCalledWith('song-id', 'user-id', tx);
+    expect(repository.updateSong).toHaveBeenCalledWith('song-id', { memo: null }, tx);
+  });
+
+  it('곡 수정 본문이 비어 있으면 BadRequestException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    await expect(service.updateSong('user-id', 'song-id', {})).rejects.toBeInstanceOf(BadRequestException);
+    expect(repository.findSongWithBandMemberBySongIdAndUserId).not.toHaveBeenCalled();
+  });
+
+  it('곡 수정 시 곡이 없으면 NotFoundException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    repository.findSongWithBandMemberBySongIdAndUserId.mockResolvedValue(null);
+
+    await expect(service.updateSong('user-id', 'song-id', { memo: '메모' })).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('곡 수정 시 밴드 멤버가 아니면 ForbiddenException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    repository.findSongWithBandMemberBySongIdAndUserId.mockResolvedValue({
+      id: 'song-id',
+      bandId: 'band-id',
+      member: null,
+    });
+
+    await expect(service.updateSong('user-id', 'song-id', { memo: '메모' })).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('곡 수정 시 세션 타입 ID가 중복되면 BadRequestException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    repository.findSongWithBandMemberBySongIdAndUserId.mockResolvedValue({
+      id: 'song-id',
+      bandId: 'band-id',
+      member: {
+        id: 'band-member-id',
+        userId: 'user-id',
+      },
+    });
+
+    await expect(service.updateSong('user-id', 'song-id', { skillTypeIds: ['skill-type-1', 'skill-type-1'] })).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+    expect(repository.updateSong).not.toHaveBeenCalled();
+  });
+
+  it('곡 수정 시 존재하지 않는 세션 타입이 있으면 BadRequestException을 던진다', async () => {
+    const { service, repository } = createService();
+
+    repository.findSongWithBandMemberBySongIdAndUserId.mockResolvedValue({
+      id: 'song-id',
+      bandId: 'band-id',
+      member: {
+        id: 'band-member-id',
+        userId: 'user-id',
+      },
+    });
+    repository.findExistingSkillTypeIds.mockResolvedValue([]);
+
+    await expect(service.updateSong('user-id', 'song-id', { skillTypeIds: ['skill-type-1'] })).rejects.toBeInstanceOf(BadRequestException);
+    expect(repository.updateSong).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/songs/songs.service.ts
+++ b/backend/src/modules/songs/songs.service.ts
@@ -216,23 +216,6 @@ export class SongsService {
     if (query.order__created_at !== query.order__id) {
       throw new BadRequestException('order__created_at과 order__id는 같은 방향이어야 합니다.');
     }
-
-    const hasCursorCreatedAt = query.cursor__created_at !== undefined;
-    const hasCursorId = query.cursor__id !== undefined;
-
-    if (hasCursorCreatedAt !== hasCursorId) {
-      throw new BadRequestException('커서 조회에는 cursor__created_at과 cursor__id가 함께 필요합니다.');
-    }
-
-    if (query.cursor__created_at === undefined) {
-      return;
-    }
-
-    const cursorCreatedAt = new Date(query.cursor__created_at);
-
-    if (Number.isNaN(cursorCreatedAt.getTime())) {
-      throw new BadRequestException('cursor__created_at은 유효한 날짜여야 합니다.');
-    }
   }
 
   private validateUpdateSongInput(input: UpdateSongInput): void {

--- a/backend/src/modules/songs/songs.service.ts
+++ b/backend/src/modules/songs/songs.service.ts
@@ -182,7 +182,13 @@ export class SongsService {
         throw new ForbiddenException('밴드 멤버만 곡을 삭제할 수 있습니다.');
       }
 
-      return this.songsRepository.deleteSong(song.id, new Date(), client);
+      const deletedSong = await this.songsRepository.deleteSong(song.id, new Date(), client);
+
+      if (deletedSong === undefined) {
+        throw new NotFoundException('요청한 곡을 찾을 수 없습니다.');
+      }
+
+      return deletedSong;
     };
 
     if (tx !== undefined) {

--- a/backend/src/modules/songs/songs.service.ts
+++ b/backend/src/modules/songs/songs.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, ForbiddenException, Inject, Injectable, NotFoundEx
 
 import { PrismaService } from '../../database/prisma';
 import type { Prisma } from '../../generated/prisma';
+import { SkillsService } from '../skills/skills.service';
 
 import type { CreateSongInput } from './dto/create-song.dto';
 import type { GetBandSongsQuery } from './dto/get-band-songs-query.dto';
@@ -23,6 +24,7 @@ export class SongsService {
     @Inject(SONGS_REPOSITORY)
     private readonly songsRepository: SongsRepository,
     private readonly prisma: PrismaService,
+    private readonly skillsService: SkillsService,
     @Inject(SpotifyTrackClient)
     private readonly spotifyTrackReader: SpotifyTrackReader,
     @Inject(DeezerTrackClient)
@@ -211,7 +213,7 @@ export class SongsService {
       return;
     }
 
-    const existingSkillTypeIds = await this.songsRepository.findExistingSkillTypeIds(skillTypeIds, tx);
+    const { skillTypeIds: existingSkillTypeIds } = await this.skillsService.findExistingSkillTypeIds(skillTypeIds, tx);
 
     if (existingSkillTypeIds.length !== skillTypeIds.length) {
       throw new BadRequestException('존재하지 않는 세션이 포함되어 있습니다.');

--- a/backend/src/modules/songs/songs.service.ts
+++ b/backend/src/modules/songs/songs.service.ts
@@ -1,5 +1,11 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 
+import { PrismaService } from '../../database/prisma';
+import type { Prisma } from '../../generated/prisma';
+
+import type { CreateSongInput } from './dto/create-song.dto';
+import { SONGS_REPOSITORY, type SongsRepository } from './repositories/songs.repository';
+import type { CreateSongResult } from './types/create-song-result.type';
 import type { SongPreview } from './types/song-preview.type';
 import { DeezerTrackClient, type DeezerTrackSearcher } from './deezer-track.client';
 import { parseDeezerTrackToSongPreview } from './deezer-track.parser';
@@ -9,6 +15,9 @@ import { parseSpotifyTrackToSongPreview } from './spotify-track.parser';
 @Injectable()
 export class SongsService {
   constructor(
+    @Inject(SONGS_REPOSITORY)
+    private readonly songsRepository: SongsRepository,
+    private readonly prisma: PrismaService,
     @Inject(SpotifyTrackClient)
     private readonly spotifyTrackReader: SpotifyTrackReader,
     @Inject(DeezerTrackClient)
@@ -37,5 +46,71 @@ export class SongsService {
     const deezerTracks = await this.deezerTrackSearcher.searchTracks(query);
 
     return deezerTracks.map(deezerTrack => parseDeezerTrackToSongPreview(deezerTrack));
+  }
+
+  /**
+   * 밴드 멤버만 곡을 생성할 수 있으므로 멤버십과 세션 타입을 검증한 뒤 저장한다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} bandId - 곡을 추가할 밴드 ID
+   * @param {CreateSongInput} input - 곡 생성 입력값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<CreateSongResult>} 생성된 곡 정보
+   */
+  async createSong(userId: string, bandId: string, input: CreateSongInput, tx?: Prisma.TransactionClient): Promise<CreateSongResult> {
+    const createSong = async (client: Prisma.TransactionClient): Promise<CreateSongResult> => {
+      const skillTypeIds = input.skillTypeIds ?? [];
+
+      this.validateDuplicatedIds(skillTypeIds);
+
+      const band = await this.songsRepository.findBandForSongCreate(bandId, userId, client);
+
+      if (band === null) {
+        throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
+      }
+
+      if (band.member === null) {
+        throw new ForbiddenException('밴드 멤버만 곡을 생성할 수 있습니다.');
+      }
+
+      await this.validateSkillTypes(skillTypeIds, client);
+
+      return this.songsRepository.createSong(
+        {
+          ...input,
+          bandId: band.id,
+          userId,
+          createdByBandMemberId: band.member.id,
+          skillTypeIds,
+        },
+        client,
+      );
+    };
+
+    if (tx !== undefined) {
+      return createSong(tx);
+    }
+
+    return this.prisma.$transaction(createSong);
+  }
+
+  private validateDuplicatedIds(ids: string[]): void {
+    const uniqueIds = new Set(ids);
+
+    if (uniqueIds.size !== ids.length) {
+      throw new BadRequestException('중복된 세션이 포함되어 있습니다.');
+    }
+  }
+
+  private async validateSkillTypes(skillTypeIds: string[], tx: Prisma.TransactionClient): Promise<void> {
+    if (skillTypeIds.length === 0) {
+      return;
+    }
+
+    const existingSkillTypeIds = await this.songsRepository.findExistingSkillTypeIds(skillTypeIds, tx);
+
+    if (existingSkillTypeIds.length !== skillTypeIds.length) {
+      throw new BadRequestException('존재하지 않는 세션이 포함되어 있습니다.');
+    }
   }
 }

--- a/backend/src/modules/songs/songs.service.ts
+++ b/backend/src/modules/songs/songs.service.ts
@@ -5,10 +5,12 @@ import type { Prisma } from '../../generated/prisma';
 
 import type { CreateSongInput } from './dto/create-song.dto';
 import type { GetBandSongsQuery } from './dto/get-band-songs-query.dto';
+import type { UpdateSongInput } from './dto/update-song.dto';
 import { SONGS_REPOSITORY, type SongsRepository } from './repositories/songs.repository';
 import type { CreateSongResult } from './types/create-song-result.type';
 import type { GetBandSongsResult } from './types/song-list.type';
 import type { SongPreview } from './types/song-preview.type';
+import type { UpdateSongResult } from './types/update-song-result.type';
 import { DeezerTrackClient, type DeezerTrackSearcher } from './deezer-track.client';
 import { parseDeezerTrackToSongPreview } from './deezer-track.parser';
 import { SpotifyTrackClient, type SpotifyTrackReader } from './spotify-track.client';
@@ -121,6 +123,44 @@ export class SongsService {
     return this.songsRepository.findBandSongs(band.id, query, tx);
   }
 
+  /**
+   * 밴드 멤버만 곡 기본 정보와 세션 타입 연결을 수정할 수 있다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} songId - 수정할 곡 ID
+   * @param {UpdateSongInput} input - 곡 수정 입력값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<UpdateSongResult>} 수정된 곡 정보
+   */
+  async updateSong(userId: string, songId: string, input: UpdateSongInput, tx?: Prisma.TransactionClient): Promise<UpdateSongResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<UpdateSongResult> => {
+      this.validateUpdateSongInput(input);
+
+      const song = await this.songsRepository.findSongWithBandMemberBySongIdAndUserId(songId, userId, client);
+
+      if (song === null) {
+        throw new NotFoundException('요청한 곡을 찾을 수 없습니다.');
+      }
+
+      if (song.member === null) {
+        throw new ForbiddenException('밴드 멤버만 곡을 수정할 수 있습니다.');
+      }
+
+      if (input.skillTypeIds !== undefined) {
+        this.validateDuplicatedIds(input.skillTypeIds);
+        await this.validateSkillTypes(input.skillTypeIds, client);
+      }
+
+      return this.songsRepository.updateSong(song.id, input, client);
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
   private validateDuplicatedIds(ids: string[]): void {
     const uniqueIds = new Set(ids);
 
@@ -161,6 +201,19 @@ export class SongsService {
 
     if (Number.isNaN(cursorCreatedAt.getTime())) {
       throw new BadRequestException('cursor__created_at은 유효한 날짜여야 합니다.');
+    }
+  }
+
+  private validateUpdateSongInput(input: UpdateSongInput): void {
+    const hasTitle = input.title !== undefined;
+    const hasArtistName = input.artistName !== undefined;
+    const hasSourceUrl = input.sourceUrl !== undefined;
+    const hasSourceType = input.sourceType !== undefined;
+    const hasMemo = input.memo !== undefined;
+    const hasSkillTypeIds = input.skillTypeIds !== undefined;
+
+    if (!hasTitle && !hasArtistName && !hasSourceUrl && !hasSourceType && !hasMemo && !hasSkillTypeIds) {
+      throw new BadRequestException('수정할 곡 정보가 필요합니다.');
     }
   }
 }

--- a/backend/src/modules/songs/songs.service.ts
+++ b/backend/src/modules/songs/songs.service.ts
@@ -8,6 +8,7 @@ import type { GetBandSongsQuery } from './dto/get-band-songs-query.dto';
 import type { UpdateSongInput } from './dto/update-song.dto';
 import { SONGS_REPOSITORY, type SongsRepository } from './repositories/songs.repository';
 import type { CreateSongResult } from './types/create-song-result.type';
+import type { DeleteSongResult } from './types/delete-song-result.type';
 import type { GetBandSongsResult } from './types/song-list.type';
 import type { SongPreview } from './types/song-preview.type';
 import type { UpdateSongResult } from './types/update-song-result.type';
@@ -152,6 +153,36 @@ export class SongsService {
       }
 
       return this.songsRepository.updateSong(song.id, input, client);
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
+  /**
+   * 밴드 멤버만 곡을 hard delete 할 수 있다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} songId - 삭제할 곡 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<DeleteSongResult>} 삭제 처리 결과
+   */
+  async deleteSong(userId: string, songId: string, tx?: Prisma.TransactionClient): Promise<DeleteSongResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<DeleteSongResult> => {
+      const song = await this.songsRepository.findSongWithBandMemberBySongIdAndUserId(songId, userId, client);
+
+      if (song === null) {
+        throw new NotFoundException('요청한 곡을 찾을 수 없습니다.');
+      }
+
+      if (song.member === null) {
+        throw new ForbiddenException('밴드 멤버만 곡을 삭제할 수 있습니다.');
+      }
+
+      return this.songsRepository.deleteSong(song.id, new Date(), client);
     };
 
     if (tx !== undefined) {

--- a/backend/src/modules/songs/songs.service.ts
+++ b/backend/src/modules/songs/songs.service.ts
@@ -4,8 +4,10 @@ import { PrismaService } from '../../database/prisma';
 import type { Prisma } from '../../generated/prisma';
 
 import type { CreateSongInput } from './dto/create-song.dto';
+import type { GetBandSongsQuery } from './dto/get-band-songs-query.dto';
 import { SONGS_REPOSITORY, type SongsRepository } from './repositories/songs.repository';
 import type { CreateSongResult } from './types/create-song-result.type';
+import type { GetBandSongsResult } from './types/song-list.type';
 import type { SongPreview } from './types/song-preview.type';
 import { DeezerTrackClient, type DeezerTrackSearcher } from './deezer-track.client';
 import { parseDeezerTrackToSongPreview } from './deezer-track.parser';
@@ -63,7 +65,7 @@ export class SongsService {
 
       this.validateDuplicatedIds(skillTypeIds);
 
-      const band = await this.songsRepository.findBandForSongCreate(bandId, userId, client);
+      const band = await this.songsRepository.findActiveBandWithMemberByBandIdAndUserId(bandId, userId, client);
 
       if (band === null) {
         throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
@@ -94,6 +96,31 @@ export class SongsService {
     return this.prisma.$transaction(createSong);
   }
 
+  /**
+   * 밴드 멤버만 밴드 곡 목록을 조회할 수 있다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} bandId - 조회할 밴드 ID
+   * @param {GetBandSongsQuery} query - 검색어와 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetBandSongsResult>} 밴드 곡 목록
+   */
+  async getBandSongs(userId: string, bandId: string, query: GetBandSongsQuery, tx?: Prisma.TransactionClient): Promise<GetBandSongsResult> {
+    this.validateSongListQuery(query);
+
+    const band = await this.songsRepository.findActiveBandWithMemberByBandIdAndUserId(bandId, userId, tx);
+
+    if (band === null) {
+      throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
+    }
+
+    if (band.member === null) {
+      throw new ForbiddenException('밴드 멤버만 곡 목록을 조회할 수 있습니다.');
+    }
+
+    return this.songsRepository.findBandSongs(band.id, query, tx);
+  }
+
   private validateDuplicatedIds(ids: string[]): void {
     const uniqueIds = new Set(ids);
 
@@ -111,6 +138,29 @@ export class SongsService {
 
     if (existingSkillTypeIds.length !== skillTypeIds.length) {
       throw new BadRequestException('존재하지 않는 세션이 포함되어 있습니다.');
+    }
+  }
+
+  private validateSongListQuery(query: GetBandSongsQuery): void {
+    if (query.order__created_at !== query.order__id) {
+      throw new BadRequestException('order__created_at과 order__id는 같은 방향이어야 합니다.');
+    }
+
+    const hasCursorCreatedAt = query.cursor__created_at !== undefined;
+    const hasCursorId = query.cursor__id !== undefined;
+
+    if (hasCursorCreatedAt !== hasCursorId) {
+      throw new BadRequestException('커서 조회에는 cursor__created_at과 cursor__id가 함께 필요합니다.');
+    }
+
+    if (query.cursor__created_at === undefined) {
+      return;
+    }
+
+    const cursorCreatedAt = new Date(query.cursor__created_at);
+
+    if (Number.isNaN(cursorCreatedAt.getTime())) {
+      throw new BadRequestException('cursor__created_at은 유효한 날짜여야 합니다.');
     }
   }
 }

--- a/backend/src/modules/songs/types/create-song-result.type.ts
+++ b/backend/src/modules/songs/types/create-song-result.type.ts
@@ -1,0 +1,26 @@
+import type { SongKey } from '../../../generated/prisma';
+
+import type { SongSourceType } from './song-preview.type';
+
+export interface CreatedSongSkillType {
+  id: string;
+  name: string;
+}
+
+export interface CreateSongResult {
+  song: {
+    id: string;
+    bandId: string;
+    title: string;
+    artistName: string;
+    sourceUrl: string | null;
+    sourceType: SongSourceType | null;
+    memo: string | null;
+    key: SongKey | null;
+    bpm: number | null;
+    difficultyLevel: number | null;
+    userId: string;
+    createdAt: string;
+  };
+  skillTypes: CreatedSongSkillType[];
+}

--- a/backend/src/modules/songs/types/delete-song-result.type.ts
+++ b/backend/src/modules/songs/types/delete-song-result.type.ts
@@ -1,0 +1,4 @@
+export interface DeleteSongResult {
+  songId: string;
+  deletedAt: string;
+}

--- a/backend/src/modules/songs/types/song-access-context.type.ts
+++ b/backend/src/modules/songs/types/song-access-context.type.ts
@@ -1,0 +1,15 @@
+export interface SongAccessMember {
+  id: string;
+  userId: string;
+}
+
+export interface ActiveBandWithMember {
+  id: string;
+  member: SongAccessMember | null;
+}
+
+export interface SongWithBandMember {
+  id: string;
+  bandId: string;
+  member: SongAccessMember | null;
+}

--- a/backend/src/modules/songs/types/song-list.type.ts
+++ b/backend/src/modules/songs/types/song-list.type.ts
@@ -1,0 +1,37 @@
+import type { SongKey } from '../../../generated/prisma';
+
+import type { SongSourceType } from './song-preview.type';
+
+export interface SongListSkillItem {
+  skillTypeId: string;
+  skillName: string;
+}
+
+export interface SongListItem {
+  id: string;
+  bandId: string;
+  title: string;
+  artistName: string;
+  key: SongKey | null;
+  bpm: number | null;
+  difficultyLevel: number | null;
+  sourceUrl: string | null;
+  sourceType: SongSourceType | null;
+  createdAt: string;
+  skills: SongListSkillItem[];
+}
+
+export interface SongListCursor {
+  createdAt: string;
+  id: string;
+}
+
+export interface GetBandSongsResult {
+  items: SongListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: SongListCursor | null;
+    next: SongListCursor | null;
+  };
+}

--- a/backend/src/modules/songs/types/song-list.type.ts
+++ b/backend/src/modules/songs/types/song-list.type.ts
@@ -22,7 +22,6 @@ export interface SongListItem {
 }
 
 export interface SongListCursor {
-  createdAt: string;
   id: string;
 }
 

--- a/backend/src/modules/songs/types/update-song-result.type.ts
+++ b/backend/src/modules/songs/types/update-song-result.type.ts
@@ -1,0 +1,21 @@
+import type { SongKey } from '../../../generated/prisma';
+
+import type { SongListSkillItem } from './song-list.type';
+import type { SongSourceType } from './song-preview.type';
+
+export interface UpdateSongResult {
+  song: {
+    id: string;
+    bandId: string;
+    title: string;
+    artistName: string;
+    sourceUrl: string | null;
+    sourceType: SongSourceType | null;
+    memo: string | null;
+    key: SongKey | null;
+    bpm: number | null;
+    difficultyLevel: number | null;
+    updatedAt: string;
+    skills: SongListSkillItem[];
+  };
+}


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 10분

<br/>

## 📌 작업 요약

- 곡 API 개발
- 곡 생성 / 목록 조회 / 수정 / 삭제

<br/>

## 📝 작업 내용

1. 곡 생성
   - `POST /bands/:bandId/songs`
   - 인증 필요
   - 밴드 멤버만 생성 가능
   - `Song` 생성과 `SongSkill` 생성을 하나의 transaction으로 처리
   - `createdByBandMemberId`는 DB 저장용, 응답은 `userId`로 반환
   - `skillTypeIds` 중복 / 미존재 세션 타입 검증

2. 곡 목록 조회
   - `GET /bands/:bandId/songs`
   - 인증 필요
   - 밴드 멤버만 조회 가능
   - 검색 query: `where__title__contain`, `where__artist_name__contain`
   - 정렬 기준: `createdAt + id`
   - cursor query: `cursor__created_at`, `cursor__id`
   - order query: `order__created_at`, `order__id`
   - 두 order 값은 같은 방향만 허용
   - 곡별 세션 정보 포함

3. 곡 수정
   - `PATCH /songs/:songId`
   - 인증 필요
   - 곡이 속한 밴드의 멤버만 수정 가능
   - 부분 수정 방식
   - 빈 body는 요청 실패 처리
   - `skillTypeIds`가 오면 기존 `SongSkill` 삭제 후 재생성
   - `skillTypeIds` 생략 시 기존 세션 유지
   - `skillTypeIds: []`는 세션 전체 제거

4. 곡 삭제
   - `DELETE /songs/:songId`
   - 인증 필요
   - 곡이 속한 밴드의 멤버만 삭제 가능
   - `Song`은 `deletedAt/status`가 없어 hard delete
   - `SongSkill`, `TeamSong`, `ScheduleSong`은 Prisma cascade 정책 사용
   - 응답의 `deletedAt`은 DB 저장값이 아니라 삭제 처리 시각

<br/>

## 🚨 주요 고민 및 결정

### 권한 정책

- 생성 / 목록 / 수정 / 삭제 모두 밴드 멤버 기준으로 통일
- 수정/삭제 권한도 밴드 멤버도 가능하게 함.
- 필요하면 이후 `BM/ADMIN만 가능` 또는 `생성자만 가능`으로 좁힐 수 있음

### cursor pagination

- 목록 조회는 기존 API 스타일에 맞춰 `items + meta`
- cursor는 정렬 기준과 같은 `createdAt + id`
- FE는 `meta.next`를 저장했다가 다음 요청에 cursor로 넘기면 됨

<br/>

## 💬 리뷰 요구사항

- 곡 수정/삭제 권한을 밴드 멤버 전체로 둬도 괜찮은지

# Deezer 곡 미리보기 검색 API 정리

## 목적

곡 등록 화면에서 사용자가 곡명 또는 아티스트명으로 Deezer 트랙을 검색하고, 검색 결과를 우리 서비스의 `SongPreview` 형식으로 변환해 보여주기 위한 API입니다.

- 내부 API: `GET /songs/deezer/tracks/search`
- 외부 API: `GET https://api.deezer.com/search/track`
- 공식 문서:
  - Search: https://developers.deezer.com/api/search
  - Track search: https://developers.deezer.com/api/search/track
  - Track object: https://developers.deezer.com/api/track

## 요청 DTO

파일: `src/modules/songs/dto/search-deezer-track-previews-query.dto.ts`

```ts
export class SearchDeezerTrackPreviewsQueryDto {
  @Transform(trimStringValue)
  @IsString({ message: stringValidationMessage })
  @IsNotEmpty({ message: notemptyValidationMessage })
  query!: string;
}
```

| DTO 필드 | 내부 API query param | Deezer API query param | 필요 이유 |
| --- | --- | --- | --- |
| `query` | `query` | `q` | Deezer track 검색어입니다. 곡명, 아티스트명, 앨범명 등을 포함한 문자열을 Deezer `/search/track`의 `q`로 전달합니다. |

## DTO 검증 기준

| 검증 | 이유 |
| --- | --- |
| `trimStringValue` | 사용자가 공백만 입력하거나 앞뒤 공백이 포함된 검색어를 보낼 수 있어, 외부 API 호출 전 검색어를 정규화합니다. |
| `IsString` | Deezer 검색어는 문자열이어야 하므로 숫자, 객체, 배열 같은 잘못된 입력을 차단합니다. |
| `IsNotEmpty` | 빈 검색어로 Deezer API를 호출하지 않도록 차단합니다. 의미 없는 외부 API 호출과 불명확한 검색 결과를 막기 위한 검증입니다. |

## 외부 API 호출 방식

파일: `src/modules/songs/deezer-track.client.ts`

```ts
const searchUrl = new URL('https://api.deezer.com/search/track');
searchUrl.searchParams.set('q', query);
searchUrl.searchParams.set('limit', '10');
```

| Deezer 파라미터 | 값 | 이유 |
| --- | --- | --- |
| `q` | DTO의 `query` | 사용자가 입력한 검색어를 Deezer track 검색어로 전달합니다. |
| `limit` | `10` | 곡 등록 미리보기 용도라 너무 많은 후보를 보여주지 않도록 상위 10개만 조회합니다. |

현재 Deezer 검색 API는 별도 인증 없이 호출합니다. 외부 API 호출이 실패하면 `BadGatewayException`으로 변환합니다.

## Deezer 응답 필드 매핑

파일: `src/modules/songs/deezer-track.parser.ts`

| Deezer 응답 필드 | 내부 응답 필드 | 변환 기준 |
| --- | --- | --- |
| `id` | `externalTrackId` | Deezer track ID를 문자열로 변환합니다. |
| `title` | `title` | 곡 제목입니다. |
| `artist.name` | `artistName` | 대표 아티스트명입니다. |
| `album.title` | `albumName` | 앨범명입니다. |
| `album.cover_xl`, `cover_big`, `cover_medium`, `cover` | `albumImageUrl` | 큰 이미지부터 우선 사용하고, 모두 없으면 `null`입니다. |
| 없음 | `releaseDate` | Deezer 검색 응답에서 사용 중인 필드에 발매일이 없어 `null`로 둡니다. |
| `duration` | `durationMs` | Deezer는 초 단위로 내려주므로 `duration * 1000`으로 밀리초로 변환합니다. |
| `preview` | `previewUrl` | Deezer 미리듣기 URL입니다. 없으면 `null`입니다. |
| `link` | `sourceUrl` | Deezer 트랙 페이지 URL입니다. |
| 고정값 | `sourceType` | Deezer 검색 결과이므로 `DEEZER`로 고정합니다. |

## 예시

요청:

```http
GET /songs/deezer/tracks/search?query=Daft%20Punk%20Harder
```

외부 API 호출:

```http
GET https://api.deezer.com/search/track?q=Daft%20Punk%20Harder&limit=10
```

내부 응답의 `data`는 `SongPreview[]` 형태입니다.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 곡 생성/목록 조회/수정/삭제 API 및 권한 적용
  * 밴드별 곡 검색/필터링(제목/아티스트/정렬/커서 페이징) 개선
  * Deezer/Spotify 트랙 미리보기 검색 통합 및 입력 검증 강화
  * 곡에 스킬 타입(태그) 연결 기능 및 관련 응답 형태 추가
* **검증/유효성**
  * 입력 DTO 기반 엄격한 필드 검증(문자열 트리밍, 길이, UUID, enum 등) 도입
* **테스트**
  * 서비스·리포지토리 단위 테스트 대거 추가 및 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BandCo-House/BandCo/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->