### PR TITLE
[KAN-49] 밴드 초대/가입요청 API 구현

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -7,7 +7,415 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
-// suspended 에서 inactive로 변경 0505
+
+model User {
+  id                  String            @id @default(uuid()) @db.Uuid
+  email               String?           @unique @db.VarChar(255)
+  passwordHash        String?           @map("password_hash") @db.VarChar(255)
+  status              UserStatus        @default(ACTIVE)
+  lastLoginAt         DateTime?         @map("last_login_at") @db.Timestamptz(6)
+  createdAt           DateTime          @default(now()) @map("created_at") @db.Timestamptz(6)
+  deletedAt           DateTime?         @map("deleted_at") @db.Timestamptz(6)
+  updatedAt           DateTime          @updatedAt @map("updated_at") @db.Timestamptz(6)
+  blacklistedBands    BandBlacklist[]
+  receivedInvitations BandInvitation[]  @relation("BandInvitationInvitee")
+  joinRequests        BandJoinRequest[]
+  bandMemberships     BandMember[]
+  managedBands        Band[]            @relation("BandManager")
+  favoriteGenres      FavoriteGenre[]
+  notifications       Notification[]
+  profile             UserProfile?
+  userSkills          UserSkill[]
+
+  @@map("users")
+}
+
+model SkillType {
+  id         String      @id @default(uuid()) @db.Uuid
+  name       String      @db.VarChar(40)
+  songSkills SongSkill[]
+  userSkills UserSkill[]
+
+  @@map("skill_types")
+}
+
+model Genre {
+  id             String          @id @default(uuid()) @db.Uuid
+  name           String          @db.VarChar(20)
+  bandGenres     BandGenre[]
+  favoriteGenres FavoriteGenre[]
+
+  @@map("genres")
+}
+
+model UserProfile {
+  userId          String    @id @map("user_id") @db.Uuid
+  nickname        String    @db.VarChar(255)
+  selfDescription String?   @map("self_description")
+  profileMusicUrl String?   @map("profile_music_url")
+  avatarUrl       String?   @map("avatar_url")
+  updatedAt       DateTime? @map("updated_at") @db.Timestamptz(6)
+  user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("user_profiles")
+}
+
+model Notification {
+  id          String           @id @default(uuid()) @db.Uuid
+  userId      String           @map("user_id") @db.Uuid
+  type        NotificationType
+  title       String           @db.VarChar(120)
+  description String?
+  targetPath  String?          @map("target_path")
+  isRead      Boolean          @default(false) @map("is_read")
+  remindsAt   DateTime?        @map("reminds_at") @db.Timestamptz(6)
+  createdAt   DateTime?        @default(now()) @map("created_at") @db.Timestamptz(6)
+  user        User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, isRead])
+  @@index([userId, isRead, type])
+  @@map("notifications")
+}
+
+model UserSkill {
+  id          String         @id @default(uuid()) @db.Uuid
+  skillLevel  SkillLevelType @default(BEGINNER) @map("skill_level")
+  isPrimary   Boolean        @default(false) @map("is_primary")
+  createdAt   DateTime       @default(now()) @map("created_at") @db.Timestamptz(6)
+  skillTypeId String         @map("skill_type_id") @db.Uuid
+  userId      String         @map("user_id") @db.Uuid
+  skillType   SkillType      @relation(fields: [skillTypeId], references: [id], onDelete: Cascade)
+  user        User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, skillTypeId])
+  @@map("user_skills")
+}
+
+model FavoriteGenre {
+  id      String @id @default(uuid()) @db.Uuid
+  userId  String @map("user_id") @db.Uuid
+  genreId String @map("genre_id") @db.Uuid
+  genre   Genre  @relation(fields: [genreId], references: [id], onDelete: Cascade)
+  user    User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, genreId])
+  @@map("favor_genres")
+}
+
+model BandGenre {
+  id      String @id @default(uuid()) @db.Uuid
+  bandId  String @map("band_id") @db.Uuid
+  genreId String @map("genre_id") @db.Uuid
+  band    Band   @relation(fields: [bandId], references: [id], onDelete: Cascade)
+  genre   Genre  @relation(fields: [genreId], references: [id], onDelete: Cascade)
+
+  @@unique([bandId, genreId])
+  @@map("band_genres")
+}
+
+model Band {
+  id               String            @id @default(uuid()) @db.Uuid
+  name             String            @db.VarChar(40)
+  bandMasterUserId String            @map("bm_id") @db.Uuid
+  description      String?
+  visibility       Boolean           @default(true)
+  coverImgUrl      String?           @map("cover_img_url")
+  createdAt        DateTime          @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt        DateTime          @updatedAt @map("updated_at") @db.Timestamptz(6)
+  deletedAt        DateTime?         @map("deleted_at") @db.Timestamptz(6)
+  blacklists       BandBlacklist[]
+  bandGenres       BandGenre[]
+  invitations      BandInvitation[]
+  inviteLinks      BandInviteLink[]
+  joinRequests     BandJoinRequest[]
+  members          BandMember[]
+  spaces           BandSpace[]
+  bandMasterUser   User              @relation("BandManager", fields: [bandMasterUserId], references: [id])
+  places           Place[]
+  songs            Song[]
+  teams            Team[]
+
+  @@map("bands")
+}
+
+model BandJoinRequest {
+  id        String            @id @default(uuid()) @db.Uuid
+  userId    String            @map("user_id") @db.Uuid
+  bandId    String            @map("band_id") @db.Uuid
+  message   String?
+  status    JoinRequestStatus @default(PENDING)
+  createdAt DateTime          @default(now()) @map("created_at") @db.Timestamptz(6)
+  band      Band              @relation(fields: [bandId], references: [id], onDelete: Cascade)
+  user      User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([bandId, userId])
+  @@map("band_join_requests")
+}
+
+model BandInvitation {
+  id                  String               @id @default(uuid()) @db.Uuid
+  bandId              String               @map("band_id") @db.Uuid
+  inviterBandMemberId String               @map("inviter_band_member_id") @db.Uuid
+  inviteeUserId       String               @map("invitee_user_id") @db.Uuid
+  status              BandInvitationStatus @default(PENDING)
+  respondedAt         DateTime?            @map("responded_at") @db.Timestamptz(6)
+  createdAt           DateTime             @default(now()) @map("created_at") @db.Timestamptz(6)
+  message             String?
+  band                Band                 @relation(fields: [bandId], references: [id], onDelete: Cascade)
+  inviteeUser         User                 @relation("BandInvitationInvitee", fields: [inviteeUserId], references: [id], onDelete: Cascade)
+  inviterBandMember   BandMember           @relation("BandInvitationInviter", fields: [inviterBandMemberId], references: [id], onDelete: Cascade)
+
+  @@unique([bandId, inviteeUserId])
+  @@map("band_invitations")
+}
+
+model BandInviteLink {
+  id                 String     @id @default(uuid()) @db.Uuid
+  bandId             String     @map("band_id") @db.Uuid
+  createBandMemberId String     @map("create_band_member_id") @db.Uuid
+  code               String?    @db.VarChar(255)
+  expiredAt          DateTime?  @map("expired_at") @db.Timestamptz(6)
+  createdAt          DateTime   @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt          DateTime   @updatedAt @map("updated_at") @db.Timestamptz(6)
+  band               Band       @relation(fields: [bandId], references: [id], onDelete: Cascade)
+  createBandMember   BandMember @relation("BandInviteLinkCreator", fields: [createBandMemberId], references: [id], onDelete: Cascade)
+
+  @@map("band_invite_link")
+}
+
+model BandMember {
+  id                   String                @id @default(uuid()) @db.Uuid
+  bandId               String                @map("band_id") @db.Uuid
+  userId               String                @map("user_id") @db.Uuid
+  role                 BandMemberRole        @default(MEMBER)
+  joinedAt             DateTime              @default(now()) @map("joined_at") @db.Timestamptz(6)
+  sentInvitations      BandInvitation[]      @relation("BandInvitationInviter")
+  createdInviteLinks   BandInviteLink[]      @relation("BandInviteLinkCreator")
+  band                 Band                  @relation(fields: [bandId], references: [id], onDelete: Cascade)
+  user                 User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdBandSpaces    BandSpace[]           @relation("BandSpaceCreator")
+  scheduleParticipants ScheduleParticipant[]
+  createdSchedules     Schedule[]            @relation("ScheduleCreator")
+  createdSongs         Song[]                @relation("SongCreator")
+  spaceMemberships     SpaceMember[]
+  teamMemberships      TeamMember[]
+  ledTeams             Team[]                @relation("TeamLeader")
+
+  @@unique([bandId, userId])
+  @@map("band_members")
+}
+
+model BandBlacklist {
+  id        String   @id @default(uuid()) @db.Uuid
+  bandId    String   @map("band_id") @db.Uuid
+  userId    String   @map("user_id") @db.Uuid
+  reason    String?
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  band      Band     @relation(fields: [bandId], references: [id], onDelete: Cascade)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([bandId, userId])
+  @@map("band_blacklists")
+}
+
+model Place {
+  id            String     @id @default(uuid()) @db.Uuid
+  bandId        String     @map("band_id") @db.Uuid
+  name          String     @db.VarChar(120)
+  address       String     @db.VarChar(255)
+  detailAddress String?    @map("detail_address") @db.VarChar(255)
+  isActive      Boolean    @default(true) @map("is_active")
+  createdAt     DateTime   @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt     DateTime   @updatedAt @map("updated_at") @db.Timestamptz(6)
+  imageUrl      String?    @map("image_url") @db.VarChar(255)
+  band          Band       @relation(fields: [bandId], references: [id], onDelete: Cascade)
+  schedules     Schedule[]
+
+  @@map("places")
+}
+
+model BandSpace {
+  id                    String          @id @default(uuid()) @db.Uuid
+  bandId                String          @map("band_id") @db.Uuid
+  name                  String          @db.VarChar(150)
+  description           String?
+  spaceType             BandSpaceType?  @map("space_type")
+  status                BandSpaceStatus @default(ACTIVE)
+  startDate             DateTime?       @map("start_date") @db.Timestamptz(6)
+  endDate               DateTime?       @map("end_date") @db.Timestamptz(6)
+  createdByBandMemberId String          @map("created_by_band_member_id") @db.Uuid
+  createdAt             DateTime        @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt             DateTime?       @map("updated_at") @db.Timestamptz(6)
+  deletedAt             DateTime?       @map("deleted_at") @db.Timestamptz(6)
+  bandSpaceTeams        BandSpaceTeam[]
+  band                  Band            @relation(fields: [bandId], references: [id], onDelete: Cascade)
+  createdByBandMember   BandMember      @relation("BandSpaceCreator", fields: [createdByBandMemberId], references: [id])
+  schedules             Schedule[]
+  members               SpaceMember[]
+
+  @@map("band_spaces")
+}
+
+model SpaceMember {
+  id           String                @id @default(uuid()) @db.Uuid
+  bandSpaceId  String                @map("band_space_id") @db.Uuid
+  bandMemberId String                @map("band_member_id") @db.Uuid
+  role         BandSpaceMemberRole   @default(MEMBER)
+  status       BandSpaceMemberStatus @default(ACTIVE)
+  joinedAt     DateTime              @default(now()) @map("joined_at") @db.Timestamptz(6)
+  bandMember   BandMember            @relation(fields: [bandMemberId], references: [id], onDelete: Cascade)
+  bandSpace    BandSpace             @relation(fields: [bandSpaceId], references: [id], onDelete: Cascade)
+
+  @@unique([bandSpaceId, bandMemberId])
+  @@map("space_members")
+}
+
+model Song {
+  id                    String         @id @default(uuid()) @db.Uuid
+  bandId                String         @map("band_id") @db.Uuid
+  title                 String         @db.VarChar(200)
+  artistName            String         @map("artist_name") @db.VarChar(200)
+  key                   SongKey?       @map("key")
+  bpm                   Int?           @db.SmallInt
+  sourceUrl             String?        @map("source_url")
+  sourceType            String?        @map("source_type") @db.VarChar(20)
+  memo                  String?
+  difficultyLevel       Int?           @map("difficulty_level") @db.SmallInt
+  createdByBandMemberId String?        @map("created_by_band_member_id") @db.Uuid
+  createdAt             DateTime       @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt             DateTime       @updatedAt @map("updated_at") @db.Timestamptz(6)
+  scheduleSongs         ScheduleSong[]
+  songSkills            SongSkill[]
+  band                  Band           @relation(fields: [bandId], references: [id], onDelete: Cascade)
+  createdByBandMember   BandMember?    @relation("SongCreator", fields: [createdByBandMemberId], references: [id])
+  teamSongs             TeamSong[]
+
+  @@map("songs")
+}
+
+model SongSkill {
+  id          String    @id @default(uuid()) @db.Uuid
+  songId      String    @map("song_id") @db.Uuid
+  skillTypeId String    @map("skill_type_id") @db.Uuid
+  skillType   SkillType @relation(fields: [skillTypeId], references: [id], onDelete: Cascade)
+  song        Song      @relation(fields: [songId], references: [id], onDelete: Cascade)
+
+  @@unique([songId, skillTypeId])
+  @@map("song_skills")
+}
+
+model Schedule {
+  id                    String                @id @default(uuid()) @db.Uuid
+  bandSpaceId           String                @map("band_space_id") @db.Uuid
+  placeId               String?               @map("place_id") @db.Uuid
+  title                 String                @db.VarChar(150)
+  scheduleType          ScheduleType          @map("schedule_type")
+  startAt               DateTime?             @map("start_at") @db.Timestamptz(6)
+  endAt                 DateTime?             @map("end_at") @db.Timestamptz(6)
+  memo                  String?
+  status                ScheduleStatus        @default(PLANNED)
+  createdByBandMemberId String                @map("created_by_band_member_id") @db.Uuid
+  createdAt             DateTime              @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt             DateTime              @updatedAt @map("updated_at") @db.Timestamptz(6)
+  participants          ScheduleParticipant[]
+  scheduleSongs         ScheduleSong[]
+  scheduleTeams         ScheduleTeam[]
+  bandSpace             BandSpace             @relation(fields: [bandSpaceId], references: [id])
+  createdByBandMember   BandMember            @relation("ScheduleCreator", fields: [createdByBandMemberId], references: [id])
+  place                 Place?                @relation(fields: [placeId], references: [id])
+
+  @@map("schedules")
+}
+
+model ScheduleParticipant {
+  id               String            @id @default(uuid()) @db.Uuid
+  scheduleId       String            @map("schedule_id") @db.Uuid
+  bandMemberId     String            @map("band_member_id") @db.Uuid
+  attendanceStatus AttendanceStatus? @map("attendance_status")
+  note             String?
+  updatedAt        DateTime          @updatedAt @map("updated_at") @db.Timestamptz(6)
+  bandMember       BandMember        @relation(fields: [bandMemberId], references: [id], onDelete: Cascade)
+  schedule         Schedule          @relation(fields: [scheduleId], references: [id], onDelete: Cascade)
+
+  @@unique([scheduleId, bandMemberId])
+  @@map("schedule_participants")
+}
+
+model ScheduleTeam {
+  id         String   @id @default(uuid()) @db.Uuid
+  scheduleId String   @map("schedule_id") @db.Uuid
+  teamId     String   @map("team_id") @db.Uuid
+  schedule   Schedule @relation(fields: [scheduleId], references: [id], onDelete: Cascade)
+  team       Team     @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  @@map("schedule_team")
+}
+
+model ScheduleSong {
+  id         String   @id @default(uuid()) @db.Uuid
+  songId     String   @map("song_id") @db.Uuid
+  scheduleId String   @map("schedule_id") @db.Uuid
+  schedule   Schedule @relation(fields: [scheduleId], references: [id], onDelete: Cascade)
+  song       Song     @relation(fields: [songId], references: [id], onDelete: Cascade)
+
+  @@map("schedule_song")
+}
+
+model Team {
+  id                     String          @id @default(uuid()) @db.Uuid
+  bandId                 String          @map("band_id") @db.Uuid
+  name                   String          @db.VarChar(150)
+  description            String?
+  status                 TeamStatus      @default(ACTIVE)
+  teamLeaderBandMemberId String?         @map("team_leader_band_member_id") @db.Uuid
+  createdAt              DateTime        @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt              DateTime        @updatedAt @map("updated_at") @db.Timestamptz(6)
+  teamCoverUrl           String?         @map("team_cover_url") @db.VarChar(255)
+  bandSpaceTeams         BandSpaceTeam[]
+  scheduleTeams          ScheduleTeam[]
+  members                TeamMember[]
+  teamSongs              TeamSong[]
+  band                   Band            @relation(fields: [bandId], references: [id], onDelete: Cascade)
+  teamLeaderBandMember   BandMember?     @relation("TeamLeader", fields: [teamLeaderBandMemberId], references: [id])
+
+  @@map("teams")
+}
+
+model TeamMember {
+  id           String         @id @default(uuid()) @db.Uuid
+  teamId       String         @map("team_id") @db.Uuid
+  bandMemberId String         @map("band_member_id") @db.Uuid
+  joinedAt     DateTime       @default(now()) @map("joined_at") @db.Timestamptz(6)
+  teamRole     TeamMemberRole @default(MEMBER) @map("team_role")
+  bandMember   BandMember     @relation(fields: [bandMemberId], references: [id], onDelete: Cascade)
+  team         Team           @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  @@unique([teamId, bandMemberId])
+  @@map("team_members")
+}
+
+model TeamSong {
+  id     String @id @default(uuid()) @db.Uuid
+  teamId String @map("team_id") @db.Uuid
+  songId String @map("song_id") @db.Uuid
+  song   Song   @relation(fields: [songId], references: [id], onDelete: Cascade)
+  team   Team   @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  @@unique([teamId, songId])
+  @@map("team_songs")
+}
+
+model BandSpaceTeam {
+  id          String    @id @default(uuid()) @db.Uuid
+  bandSpaceId String    @map("band_space_id") @db.Uuid
+  teamId      String    @map("team_id") @db.Uuid
+  bandSpace   BandSpace @relation(fields: [bandSpaceId], references: [id], onDelete: Cascade)
+  team        Team      @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  @@unique([bandSpaceId, teamId])
+  @@map("band_space_team")
+}
+
 enum UserStatus {
   ACTIVE
   INACTIVE
@@ -40,7 +448,6 @@ enum TeamStatus {
   INACTIVE
 }
 
-// key가 없으면 빈 값을 넣는게 UNKNOWN보다 더 적절하다고 판단되어 삭제
 enum SongKey {
   C
   CM
@@ -88,7 +495,6 @@ enum ScheduleStatus {
   CANCELED
 }
 
-// ETC 타입을 ENUM으로 정의하는 것은 상수 정의에 어긋난다고 판단 & 명확한 ENUM으로 이름 변경 0505
 enum BandSpaceType {
   PERFORMANCE
   PRACTICE
@@ -109,414 +515,4 @@ enum BandMemberRole {
 enum TeamMemberRole {
   LEADER
   MEMBER
-}
-
-model User {
-  id                   String                @id @default(uuid()) @db.Uuid
-  email                String?               @unique @db.VarChar(255)
-  passwordHash         String?               @map("password_hash") @db.VarChar(255)
-  status               UserStatus            @default(ACTIVE)
-  lastLoginAt          DateTime?             @map("last_login_at") @db.Timestamptz(6)
-  createdAt            DateTime              @default(now()) @map("created_at") @db.Timestamptz(6)
-  deletedAt            DateTime?             @map("deleted_at") @db.Timestamptz(6)
-  updatedAt            DateTime              @updatedAt @map("updated_at") @db.Timestamptz(6)
-  profile              UserProfile?
-  notifications        Notification[]
-  userSkills           UserSkill[]
-  favoriteGenres       FavoriteGenre[]
-  managedBands         Band[]                @relation("BandManager")
-  joinRequests         BandJoinRequest[]
-  receivedInvitations  BandInvitation[]      @relation("BandInvitationInvitee")
-  bandMemberships      BandMember[]
-  blacklistedBands     BandBlacklist[]
-
-  @@map("users")
-}
-
-model SkillType {
-  id         String      @id @default(uuid()) @db.Uuid
-  name       String      @db.VarChar(40)
-  userSkills UserSkill[]
-  songSkills SongSkill[]
-
-  @@map("skill_types")
-}
-
-model Genre {
-  id             String          @id @default(uuid()) @db.Uuid
-  name           String          @db.VarChar(20)
-  favoriteGenres FavoriteGenre[]
-  bandGenres     BandGenre[]
-
-  @@map("genres")
-}
-
-model UserProfile {
-  userId          String    @id @map("user_id") @db.Uuid
-  nickname        String    @db.VarChar(255)
-  selfDescription String?   @map("self_description") @db.Text
-  profileMusicUrl String?   @map("profile_music_url") @db.Text
-  avatarUrl       String?   @map("avatar_url") @db.Text
-  updatedAt       DateTime? @map("updated_at") @db.Timestamptz(6)
-  user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@map("user_profiles")
-}
-
-model Notification {
-  id          String           @id @default(uuid()) @db.Uuid
-  userId      String           @map("user_id") @db.Uuid
-  type        NotificationType
-  title       String           @db.VarChar(120)
-  description String?          @db.Text
-  targetPath  String?          @map("target_path") @db.Text
-  isRead      Boolean          @default(false) @map("is_read")
-  remindsAt   DateTime?        @map("reminds_at") @db.Timestamptz(6)
-  createdAt   DateTime?        @default(now()) @map("created_at") @db.Timestamptz(6)
-  user        User             @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@index([userId, isRead])
-  @@index([userId, isRead, type])
-  @@map("notifications")
-}
-
-model UserSkill {
-  id          String         @id @default(uuid()) @db.Uuid
-  skillLevel  SkillLevelType @default(BEGINNER) @map("skill_level")
-  isPrimary   Boolean        @default(false) @map("is_primary")
-  createdAt   DateTime       @default(now()) @map("created_at") @db.Timestamptz(6)
-  skillTypeId String         @map("skill_type_id") @db.Uuid
-  userId      String         @map("user_id") @db.Uuid
-  skillType   SkillType      @relation(fields: [skillTypeId], references: [id], onDelete: Cascade)
-  user        User           @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@map("user_skills")
-  @@unique([userId,skillTypeId])
-}
-
-model FavoriteGenre {
-  id      String @id @default(uuid()) @db.Uuid
-  userId  String @map("user_id") @db.Uuid
-  genreId String @map("genre_id") @db.Uuid
-  user    User   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  genre   Genre  @relation(fields: [genreId], references: [id], onDelete: Cascade)
-
-  @@unique([userId,genreId])
-  @@map("favor_genres")
-}
-
-model BandGenre {
-  id      String @id @default(uuid()) @db.Uuid
-  bandId  String @map("band_id") @db.Uuid
-  genreId String @map("genre_id") @db.Uuid
-  band    Band   @relation(fields: [bandId], references: [id], onDelete: Cascade)
-  genre   Genre  @relation(fields: [genreId], references: [id], onDelete: Cascade)
-
-  @@unique([bandId,genreId])
-  @@map("band_genres")
-}
-
-model Band {
-  id               String            @id @default(uuid()) @db.Uuid
-  name             String            @db.VarChar(40)
-  bandMasterUserId String            @map("bm_id") @db.Uuid
-  description      String?           @db.Text
-  visibility       Boolean           @default(true)
-  coverImgUrl      String?           @map("cover_img_url") @db.Text
-  createdAt        DateTime          @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt        DateTime          @updatedAt @map("updated_at") @db.Timestamptz(6)
-  deletedAt        DateTime?         @map("deleted_at") @db.Timestamptz(6)
-  bandMasterUser   User              @relation("BandManager", fields: [bandMasterUserId], references: [id])
-  joinRequests     BandJoinRequest[]
-  invitations      BandInvitation[]
-  inviteLinks      BandInviteLink[]
-  members          BandMember[]
-  blacklists       BandBlacklist[]
-  bandGenres       BandGenre[]
-  places           Place[]
-  spaces           BandSpace[]
-  songs            Song[]
-  teams            Team[]
-
-  @@map("bands")
-}
-
-model BandJoinRequest {
-  id        String            @id @default(uuid()) @db.Uuid
-  userId    String            @map("user_id") @db.Uuid
-  bandId    String            @map("band_id") @db.Uuid
-  message   String?           @db.Text
-  status    JoinRequestStatus @default(PENDING)
-  createdAt DateTime          @default(now()) @map("created_at") @db.Timestamptz(6)
-  user      User              @relation(fields: [userId], references: [id], onDelete: Cascade)
-  band      Band              @relation(fields: [bandId], references: [id], onDelete: Cascade)
-
-  @@unique([bandId,userId])
-  @@map("band_join_requests")
-}
-
-model BandInvitation {
-  id            String               @id @default(uuid()) @db.Uuid
-  bandId        String               @map("band_id") @db.Uuid
-  inviterBandMemberId String               @map("inviter_band_member_id") @db.Uuid
-  inviteeUserId       String               @map("invitee_user_id") @db.Uuid
-  status              BandInvitationStatus @default(PENDING)
-  respondedAt         DateTime?            @map("responded_at") @db.Timestamptz(6)
-  createdAt           DateTime             @default(now()) @map("created_at") @db.Timestamptz(6)
-  message             String?              @db.Text
-  band                Band                 @relation(fields: [bandId], references: [id], onDelete: Cascade)
-  inviterBandMember   BandMember           @relation("BandInvitationInviter", fields: [inviterBandMemberId], references: [id], onDelete: Cascade)
-  inviteeUser         User                 @relation("BandInvitationInvitee", fields: [inviteeUserId], references: [id], onDelete: Cascade)
-
-  @@unique([bandId,inviteeUserId])
-  @@map("band_invitations")
-}
-
-model BandInviteLink {
-  id           String    @id @default(uuid()) @db.Uuid
-  bandId       String    @map("band_id") @db.Uuid
-  createBandMemberId String     @map("create_band_member_id") @db.Uuid
-  code               String?    @db.VarChar(255)
-  expiredAt          DateTime?  @map("expired_at") @db.Timestamptz(6)
-  createdAt          DateTime   @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt          DateTime   @updatedAt @map("updated_at") @db.Timestamptz(6)
-  band               Band       @relation(fields: [bandId], references: [id], onDelete: Cascade)
-  createBandMember   BandMember @relation("BandInviteLinkCreator", fields: [createBandMemberId], references: [id], onDelete: Cascade)
-
-  @@map("band_invite_link")
-}
-
-model BandMember {
-  id       String         @id @default(uuid()) @db.Uuid
-  bandId   String         @map("band_id") @db.Uuid
-  userId   String         @map("user_id") @db.Uuid
-  role     BandMemberRole @default(MEMBER)
-  joinedAt DateTime       @default(now()) @map("joined_at") @db.Timestamptz(6)
-  sentInvitations      BandInvitation[]      @relation("BandInvitationInviter")
-  createdInviteLinks   BandInviteLink[]      @relation("BandInviteLinkCreator")
-
-  createdBandSpaces    BandSpace[]           @relation("BandSpaceCreator")
-  spaceMemberships     SpaceMember[]
-  createdSongs         Song[]                @relation("SongCreator")
-  createdSchedules     Schedule[]            @relation("ScheduleCreator")
-  scheduleParticipants ScheduleParticipant[]
-  ledTeams             Team[]                @relation("TeamLeader")
-  teamMemberships      TeamMember[]
-
-  band     Band           @relation(fields: [bandId], references: [id], onDelete: Cascade)
-  user     User           @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@map("band_members")
-  @@unique([bandId,userId])
-}
-
-model BandBlacklist {
-  id        String   @id @default(uuid()) @db.Uuid
-  bandId    String   @map("band_id") @db.Uuid
-  userId    String   @map("user_id") @db.Uuid
-  reason    String?  @db.Text
-  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
-  band      Band     @relation(fields: [bandId], references: [id], onDelete: Cascade)
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@unique([bandId,userId])
-  @@map("band_blacklists")
-}
-
-model Place {
-  id            String     @id @default(uuid()) @db.Uuid
-  bandId        String     @map("band_id") @db.Uuid
-  name          String     @db.VarChar(120)
-  address       String     @db.VarChar(255)
-  detailAddress String?    @map("detail_address") @db.VarChar(255)
-  isActive      Boolean    @default(true) @map("is_active")
-  createdAt     DateTime   @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt     DateTime   @updatedAt @map("updated_at") @db.Timestamptz(6)
-  imageUrl      String?    @map("image_url") @db.VarChar(255)
-  band          Band       @relation(fields: [bandId], references: [id], onDelete: Cascade)
-  schedules     Schedule[]
-
-  @@map("places")
-}
-
-model BandSpace {
-  id              String           @id @default(uuid()) @db.Uuid
-  bandId          String           @map("band_id") @db.Uuid
-  name            String           @db.VarChar(150)
-  description     String?          @db.Text
-  spaceType       BandSpaceType?   @map("space_type")
-  status          BandSpaceStatus  @default(ACTIVE)
-  startDate       DateTime?        @map("start_date") @db.Timestamptz(6)
-  endDate         DateTime?        @map("end_date") @db.Timestamptz(6)
-  createdByBandMemberId String           @map("created_by_band_member_id") @db.Uuid
-  createdAt             DateTime         @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt             DateTime?        @map("updated_at") @db.Timestamptz(6)
-  deletedAt             DateTime?        @map("deleted_at") @db.Timestamptz(6)
-  band                  Band             @relation(fields: [bandId], references: [id], onDelete: Cascade)
-  createdByBandMember   BandMember       @relation("BandSpaceCreator", fields: [createdByBandMemberId], references: [id])
-  members         SpaceMember[]
-  schedules       Schedule[]
-  bandSpaceTeams  BandSpaceTeam[]
-
-  @@map("band_spaces")
-}
-
-model SpaceMember {
-  id          String                @id @default(uuid()) @db.Uuid
-  bandSpaceId String                @map("band_space_id") @db.Uuid
-  bandMemberId String                @map("band_member_id") @db.Uuid
-  role         BandSpaceMemberRole   @default(MEMBER)
-  status       BandSpaceMemberStatus @default(ACTIVE)
-  joinedAt     DateTime              @default(now()) @map("joined_at") @db.Timestamptz(6)
-  bandSpace    BandSpace             @relation(fields: [bandSpaceId], references: [id], onDelete: Cascade)
-  bandMember   BandMember            @relation(fields: [bandMemberId], references: [id], onDelete: Cascade)
-
-  @@unique([bandSpaceId,bandMemberId])
-  @@map("space_members")
-}
-//song status 삭제
-model Song {
-  id              String         @id @default(uuid()) @db.Uuid
-  bandId          String         @map("band_id") @db.Uuid
-  title           String         @db.VarChar(200)
-  artistName      String         @map("artist_name") @db.VarChar(200)
-  key             SongKey?       @map("key")
-  bpm             Int?           @db.SmallInt
-  sourceUrl       String?        @map("source_url") @db.Text
-  sourceType      String?        @map("source_type") @db.VarChar(20)
-  memo            String?        @db.Text
-  difficultyLevel Int?           @map("difficulty_level") @db.SmallInt
-  createdByBandMemberId String?        @map("created_by_band_member_id") @db.Uuid
-  createdAt             DateTime       @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt             DateTime       @updatedAt @map("updated_at") @db.Timestamptz(6)
-  band                  Band           @relation(fields: [bandId], references: [id], onDelete: Cascade)
-  createdByBandMember   BandMember?    @relation("SongCreator", fields: [createdByBandMemberId], references: [id])
-  songSkills      SongSkill[]
-  teamSongs       TeamSong[]
-  scheduleSongs   ScheduleSong[]
-
-  @@map("songs")
-}
-
-model SongSkill {
-  id          String    @id @default(uuid()) @db.Uuid
-  songId      String    @map("song_id") @db.Uuid
-  skillTypeId String    @map("skill_type_id") @db.Uuid
-  song        Song      @relation(fields: [songId], references: [id], onDelete: Cascade)
-  skillType   SkillType @relation(fields: [skillTypeId], references: [id], onDelete: Cascade)
-
-  @@unique([songId,skillTypeId])
-  @@map("song_skills")
-}
-
-model Schedule {
-  id              String                @id @default(uuid()) @db.Uuid
-  bandSpaceId     String                @map("band_space_id") @db.Uuid
-  placeId         String?               @map("place_id") @db.Uuid
-  title           String                @db.VarChar(150)
-  scheduleType    ScheduleType          @map("schedule_type")
-  startAt         DateTime?             @map("start_at") @db.Timestamptz(6)
-  endAt           DateTime?             @map("end_at") @db.Timestamptz(6)
-  memo            String?               @db.Text
-  status          ScheduleStatus        @default(PLANNED)
-  createdByBandMemberId String                @map("created_by_band_member_id") @db.Uuid
-  createdAt             DateTime              @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt             DateTime              @updatedAt @map("updated_at") @db.Timestamptz(6)
-  bandSpace             BandSpace             @relation(fields: [bandSpaceId], references: [id])
-  place                 Place?                @relation(fields: [placeId], references: [id])
-  createdByBandMember   BandMember            @relation("ScheduleCreator", fields: [createdByBandMemberId], references: [id])
-  participants    ScheduleParticipant[]
-  scheduleTeams   ScheduleTeam[]
-  scheduleSongs   ScheduleSong[]
-
-  @@map("schedules")
-}
-
-model ScheduleParticipant {
-  id               String            @id @default(uuid()) @db.Uuid
-  scheduleId       String            @map("schedule_id") @db.Uuid
-  bandMemberId     String            @map("band_member_id") @db.Uuid
-  attendanceStatus AttendanceStatus? @map("attendance_status")
-  note             String?           @db.Text
-  updatedAt        DateTime          @updatedAt @map("updated_at") @db.Timestamptz(6)
-  schedule         Schedule          @relation(fields: [scheduleId], references: [id], onDelete: Cascade)
-  bandMember       BandMember        @relation(fields: [bandMemberId], references: [id], onDelete: Cascade)
-
-  @@unique([scheduleId,bandMemberId])
-  @@map("schedule_participants")
-}
-
-model ScheduleTeam {
-  id         String   @id @default(uuid()) @db.Uuid
-  scheduleId String   @map("schedule_id") @db.Uuid
-  teamId     String   @map("team_id") @db.Uuid
-  schedule   Schedule @relation(fields: [scheduleId], references: [id], onDelete: Cascade)
-  team       Team     @relation(fields: [teamId], references: [id], onDelete: Cascade)
-
-  @@map("schedule_team")
-}
-
-model ScheduleSong {
-  id         String   @id @default(uuid()) @db.Uuid
-  songId     String   @map("song_id") @db.Uuid
-  scheduleId String   @map("schedule_id") @db.Uuid
-  song       Song     @relation(fields: [songId], references: [id], onDelete: Cascade)
-  schedule   Schedule @relation(fields: [scheduleId], references: [id], onDelete: Cascade)
-
-  @@map("schedule_song")
-}
-
-model Team {
-  id               String          @id @default(uuid()) @db.Uuid
-  bandId           String          @map("band_id") @db.Uuid
-  name             String          @db.VarChar(150)
-  description      String?         @db.Text
-  status           TeamStatus      @default(ACTIVE)
-  teamLeaderBandMemberId String?         @map("team_leader_band_member_id") @db.Uuid
-  createdAt              DateTime        @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt              DateTime        @updatedAt @map("updated_at") @db.Timestamptz(6)
-  teamCoverUrl           String?         @map("team_cover_url") @db.VarChar(255)
-  band                   Band            @relation(fields: [bandId], references: [id], onDelete: Cascade)
-  teamLeaderBandMember   BandMember?     @relation("TeamLeader", fields: [teamLeaderBandMemberId], references: [id])
-  members          TeamMember[]
-  teamSongs        TeamSong[]
-  scheduleTeams    ScheduleTeam[]
-  bandSpaceTeams   BandSpaceTeam[]
-
-  @@map("teams")
-}
-
-model TeamMember {
-  id       String         @id @default(uuid()) @db.Uuid
-  teamId   String         @map("team_id") @db.Uuid
-  bandMemberId String         @map("band_member_id") @db.Uuid
-  joinedAt     DateTime       @default(now()) @map("joined_at") @db.Timestamptz(6)
-  teamRole     TeamMemberRole @default(MEMBER) @map("team_role")
-  bandMember   BandMember     @relation(fields: [bandMemberId], references: [id], onDelete: Cascade)
-  team         Team           @relation(fields: [teamId], references: [id], onDelete: Cascade)
-
-  @@unique([teamId,bandMemberId])
-  @@map("team_members")
-}
-
-model TeamSong {
-  id     String @id @default(uuid()) @db.Uuid
-  teamId String @map("team_id") @db.Uuid
-  songId String @map("song_id") @db.Uuid
-  team   Team   @relation(fields: [teamId], references: [id], onDelete: Cascade)
-  song   Song   @relation(fields: [songId], references: [id], onDelete: Cascade)
-
-  @@unique([teamId,songId])
-  @@map("team_songs")
-}
-
-model BandSpaceTeam {
-  id          String    @id @default(uuid()) @db.Uuid
-  bandSpaceId String    @map("band_space_id") @db.Uuid
-  teamId      String    @map("team_id") @db.Uuid
-  bandSpace   BandSpace @relation(fields: [bandSpaceId], references: [id], onDelete: Cascade)
-  team        Team      @relation(fields: [teamId], references: [id], onDelete: Cascade)
-
-  @@unique([bandSpaceId,teamId])
-  @@map("band_space_team")
 }

--- a/backend/src/modules/bands/band-invitations.controller.ts
+++ b/backend/src/modules/bands/band-invitations.controller.ts
@@ -5,6 +5,7 @@ import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api
 import type { User } from '../../generated/prisma';
 
 import type { AcceptBandInvitationResult } from './types/accept-band-invitation-result.type';
+import type { DeclineBandInvitationResult } from './types/decline-band-invitation-result.type';
 import { BandsService } from './bands.service';
 
 interface AuthenticatedRequest {
@@ -24,5 +25,16 @@ export class BandInvitationsController {
     const acceptedInvitation = await this.bandsService.acceptBandInvitation(request.user.id, invitationId);
 
     return createSuccessResponse('밴드 초대를 수락했습니다.', acceptedInvitation);
+  }
+
+  @Post(':invitationId/decline')
+  @UseGuards(AccessTokenGuard)
+  async declineBandInvitation(
+    @Req() request: AuthenticatedRequest,
+    @Param('invitationId') invitationId: string,
+  ): Promise<ApiSuccessResponse<DeclineBandInvitationResult>> {
+    const declinedInvitation = await this.bandsService.declineBandInvitation(request.user.id, invitationId);
+
+    return createSuccessResponse('밴드 초대를 거절했습니다.', declinedInvitation);
   }
 }

--- a/backend/src/modules/bands/band-invitations.controller.ts
+++ b/backend/src/modules/bands/band-invitations.controller.ts
@@ -1,12 +1,14 @@
-import { Controller, Delete, Param, Post, Req, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Get, Param, Post, Query, Req, UseGuards } from '@nestjs/common';
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
 import type { User } from '../../generated/prisma';
 
+import { GetReceivedBandInvitationsQueryDto } from './dto/get-received-band-invitations-query.dto';
 import type { AcceptBandInvitationResult } from './types/accept-band-invitation-result.type';
 import type { DeclineBandInvitationResult } from './types/decline-band-invitation-result.type';
 import type { DeleteBandInvitationResult } from './types/delete-band-invitation-result.type';
+import type { GetReceivedBandInvitationsResult } from './types/received-band-invitation-list.type';
 import { BandsService } from './bands.service';
 
 interface AuthenticatedRequest {
@@ -16,6 +18,17 @@ interface AuthenticatedRequest {
 @Controller('invitations')
 export class BandInvitationsController {
   constructor(private readonly bandsService: BandsService) {}
+
+  @Get('received')
+  @UseGuards(AccessTokenGuard)
+  async getReceivedBandInvitations(
+    @Req() request: AuthenticatedRequest,
+    @Query() query: GetReceivedBandInvitationsQueryDto,
+  ): Promise<ApiSuccessResponse<GetReceivedBandInvitationsResult>> {
+    const invitations = await this.bandsService.getReceivedBandInvitations(request.user.id, query);
+
+    return createSuccessResponse('받은 초대 목록 조회 성공', invitations);
+  }
 
   @Post(':invitationId/accept')
   @UseGuards(AccessTokenGuard)

--- a/backend/src/modules/bands/band-invitations.controller.ts
+++ b/backend/src/modules/bands/band-invitations.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Param, Post, Req, UseGuards } from '@nestjs/common';
+
+import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
+import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
+import type { User } from '../../generated/prisma';
+
+import type { AcceptBandInvitationResult } from './types/accept-band-invitation-result.type';
+import { BandsService } from './bands.service';
+
+interface AuthenticatedRequest {
+  user: User;
+}
+
+@Controller('invitations')
+export class BandInvitationsController {
+  constructor(private readonly bandsService: BandsService) {}
+
+  @Post(':invitationId/accept')
+  @UseGuards(AccessTokenGuard)
+  async acceptBandInvitation(
+    @Req() request: AuthenticatedRequest,
+    @Param('invitationId') invitationId: string,
+  ): Promise<ApiSuccessResponse<AcceptBandInvitationResult>> {
+    const acceptedInvitation = await this.bandsService.acceptBandInvitation(request.user.id, invitationId);
+
+    return createSuccessResponse('밴드 초대를 수락했습니다.', acceptedInvitation);
+  }
+}

--- a/backend/src/modules/bands/band-invitations.controller.ts
+++ b/backend/src/modules/bands/band-invitations.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Param, Post, Req, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Param, Post, Req, UseGuards } from '@nestjs/common';
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
@@ -6,6 +6,7 @@ import type { User } from '../../generated/prisma';
 
 import type { AcceptBandInvitationResult } from './types/accept-band-invitation-result.type';
 import type { DeclineBandInvitationResult } from './types/decline-band-invitation-result.type';
+import type { DeleteBandInvitationResult } from './types/delete-band-invitation-result.type';
 import { BandsService } from './bands.service';
 
 interface AuthenticatedRequest {
@@ -36,5 +37,16 @@ export class BandInvitationsController {
     const declinedInvitation = await this.bandsService.declineBandInvitation(request.user.id, invitationId);
 
     return createSuccessResponse('밴드 초대를 거절했습니다.', declinedInvitation);
+  }
+
+  @Delete(':invitationId')
+  @UseGuards(AccessTokenGuard)
+  async deleteBandInvitation(
+    @Req() request: AuthenticatedRequest,
+    @Param('invitationId') invitationId: string,
+  ): Promise<ApiSuccessResponse<DeleteBandInvitationResult>> {
+    const deletedInvitation = await this.bandsService.deleteBandInvitation(request.user.id, invitationId);
+
+    return createSuccessResponse('초대를 취소했습니다.', deletedInvitation);
   }
 }

--- a/backend/src/modules/bands/band-invitations.controller.ts
+++ b/backend/src/modules/bands/band-invitations.controller.ts
@@ -5,10 +5,12 @@ import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api
 import type { User } from '../../generated/prisma';
 
 import { GetReceivedBandInvitationsQueryDto } from './dto/get-received-band-invitations-query.dto';
+import { GetSentBandInvitationsQueryDto } from './dto/get-sent-band-invitations-query.dto';
 import type { AcceptBandInvitationResult } from './types/accept-band-invitation-result.type';
 import type { DeclineBandInvitationResult } from './types/decline-band-invitation-result.type';
 import type { DeleteBandInvitationResult } from './types/delete-band-invitation-result.type';
 import type { GetReceivedBandInvitationsResult } from './types/received-band-invitation-list.type';
+import type { GetSentBandInvitationsResult } from './types/sent-band-invitation-list.type';
 import { BandsService } from './bands.service';
 
 interface AuthenticatedRequest {
@@ -28,6 +30,17 @@ export class BandInvitationsController {
     const invitations = await this.bandsService.getReceivedBandInvitations(request.user.id, query);
 
     return createSuccessResponse('받은 초대 목록 조회 성공', invitations);
+  }
+
+  @Get('sent')
+  @UseGuards(AccessTokenGuard)
+  async getSentBandInvitations(
+    @Req() request: AuthenticatedRequest,
+    @Query() query: GetSentBandInvitationsQueryDto,
+  ): Promise<ApiSuccessResponse<GetSentBandInvitationsResult>> {
+    const invitations = await this.bandsService.getSentBandInvitations(request.user.id, query);
+
+    return createSuccessResponse('보낸 초대 목록 조회 성공', invitations);
   }
 
   @Post(':invitationId/accept')

--- a/backend/src/modules/bands/band-join-requests.controller.ts
+++ b/backend/src/modules/bands/band-join-requests.controller.ts
@@ -1,10 +1,12 @@
-import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Post, Query, Req, UseGuards } from '@nestjs/common';
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
 import type { User } from '../../generated/prisma';
 
 import { GetSentBandJoinRequestsQueryDto } from './dto/get-sent-band-join-requests-query.dto';
+import type { ApproveBandJoinRequestResult } from './types/approve-band-join-request-result.type';
+import type { RejectBandJoinRequestResult } from './types/reject-band-join-request-result.type';
 import type { GetSentBandJoinRequestsResult } from './types/sent-band-join-request-list.type';
 import { BandsService } from './bands.service';
 
@@ -25,5 +27,27 @@ export class BandJoinRequestsController {
     const joinRequests = await this.bandsService.getSentBandJoinRequests(request.user.id, query);
 
     return createSuccessResponse('내가 보낸 가입 요청 목록 조회 완료', joinRequests);
+  }
+
+  @Post(':joinRequestId/approve')
+  @UseGuards(AccessTokenGuard)
+  async approveBandJoinRequest(
+    @Req() request: AuthenticatedRequest,
+    @Param('joinRequestId') joinRequestId: string,
+  ): Promise<ApiSuccessResponse<ApproveBandJoinRequestResult>> {
+    const approvedJoinRequest = await this.bandsService.approveBandJoinRequest(request.user.id, joinRequestId);
+
+    return createSuccessResponse('밴드 가입 요청을 승인했습니다.', approvedJoinRequest);
+  }
+
+  @Post(':joinRequestId/reject')
+  @UseGuards(AccessTokenGuard)
+  async rejectBandJoinRequest(
+    @Req() request: AuthenticatedRequest,
+    @Param('joinRequestId') joinRequestId: string,
+  ): Promise<ApiSuccessResponse<RejectBandJoinRequestResult>> {
+    const rejectedJoinRequest = await this.bandsService.rejectBandJoinRequest(request.user.id, joinRequestId);
+
+    return createSuccessResponse('밴드 가입 요청을 거절했습니다.', rejectedJoinRequest);
   }
 }

--- a/backend/src/modules/bands/band-join-requests.controller.ts
+++ b/backend/src/modules/bands/band-join-requests.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
+
+import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
+import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
+import type { User } from '../../generated/prisma';
+
+import { GetSentBandJoinRequestsQueryDto } from './dto/get-sent-band-join-requests-query.dto';
+import type { GetSentBandJoinRequestsResult } from './types/sent-band-join-request-list.type';
+import { BandsService } from './bands.service';
+
+interface AuthenticatedRequest {
+  user: User;
+}
+
+@Controller('join-requests')
+export class BandJoinRequestsController {
+  constructor(private readonly bandsService: BandsService) {}
+
+  @Get('sent')
+  @UseGuards(AccessTokenGuard)
+  async getSentBandJoinRequests(
+    @Req() request: AuthenticatedRequest,
+    @Query() query: GetSentBandJoinRequestsQueryDto,
+  ): Promise<ApiSuccessResponse<GetSentBandJoinRequestsResult>> {
+    const joinRequests = await this.bandsService.getSentBandJoinRequests(request.user.id, query);
+
+    return createSuccessResponse('내가 보낸 가입 요청 목록 조회 완료', joinRequests);
+  }
+}

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -6,6 +6,7 @@ import type { User } from '../../generated/prisma';
 
 import { CreateBandBodyDto } from './dto/create-band.dto';
 import { CreateBandInvitationBodyDto } from './dto/create-band-invitation.dto';
+import { CreateBandJoinRequestBodyDto } from './dto/create-band-join-request.dto';
 import { GetBandMembersQueryDto } from './dto/get-band-members-query.dto';
 import { GetMyBandsQueryDto } from './dto/get-my-bands-query.dto';
 import { SearchBandsQueryDto } from './dto/search-bands-query.dto';
@@ -14,6 +15,7 @@ import { UpdateBandMemberRoleBodyDto } from './dto/update-band-member-role.dto';
 import type { GetBandMembersResult } from './types/band-member-list.type';
 import type { SearchBandsResult } from './types/band-search-result.type';
 import type { CreateBandInvitationResult } from './types/create-band-invitation-result.type';
+import type { CreateBandJoinRequestResult } from './types/create-band-join-request-result.type';
 import type { CreateBandResult } from './types/create-band-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
 import type { LeaveBandResult } from './types/leave-band-result.type';
@@ -48,6 +50,18 @@ export class BandsController {
     const createdInvitation = await this.bandsService.createBandInvitation(request.user.id, bandId, input);
 
     return createSuccessResponse('밴드 초대 전송 완료', createdInvitation);
+  }
+
+  @Post(':bandId/join-requests')
+  @UseGuards(AccessTokenGuard)
+  async createBandJoinRequest(
+    @Req() request: AuthenticatedRequest,
+    @Param('bandId') bandId: string,
+    @Body() input: CreateBandJoinRequestBodyDto,
+  ): Promise<ApiSuccessResponse<CreateBandJoinRequestResult>> {
+    const createdJoinRequest = await this.bandsService.createBandJoinRequest(request.user.id, bandId, input);
+
+    return createSuccessResponse('밴드 가입 요청 완료', createdJoinRequest);
   }
 
   @Delete(':bandId/me')

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -7,11 +7,13 @@ import type { User } from '../../generated/prisma';
 import { CreateBandBodyDto } from './dto/create-band.dto';
 import { CreateBandInvitationBodyDto } from './dto/create-band-invitation.dto';
 import { CreateBandJoinRequestBodyDto } from './dto/create-band-join-request.dto';
+import { GetBandJoinRequestsQueryDto } from './dto/get-band-join-requests-query.dto';
 import { GetBandMembersQueryDto } from './dto/get-band-members-query.dto';
 import { GetMyBandsQueryDto } from './dto/get-my-bands-query.dto';
 import { SearchBandsQueryDto } from './dto/search-bands-query.dto';
 import { UpdateBandBodyDto } from './dto/update-band.dto';
 import { UpdateBandMemberRoleBodyDto } from './dto/update-band-member-role.dto';
+import type { GetBandJoinRequestsResult } from './types/band-join-request-list.type';
 import type { GetBandMembersResult } from './types/band-member-list.type';
 import type { SearchBandsResult } from './types/band-search-result.type';
 import type { CreateBandInvitationResult } from './types/create-band-invitation-result.type';
@@ -62,6 +64,18 @@ export class BandsController {
     const createdJoinRequest = await this.bandsService.createBandJoinRequest(request.user.id, bandId, input);
 
     return createSuccessResponse('밴드 가입 요청 완료', createdJoinRequest);
+  }
+
+  @Get(':bandId/join-requests')
+  @UseGuards(AccessTokenGuard)
+  async getBandJoinRequests(
+    @Req() request: AuthenticatedRequest,
+    @Param('bandId') bandId: string,
+    @Query() query: GetBandJoinRequestsQueryDto,
+  ): Promise<ApiSuccessResponse<GetBandJoinRequestsResult>> {
+    const joinRequests = await this.bandsService.getBandJoinRequests(request.user.id, bandId, query);
+
+    return createSuccessResponse('밴드 가입 요청 목록 조회 성공', joinRequests);
   }
 
   @Delete(':bandId/me')

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -5,6 +5,7 @@ import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api
 import type { User } from '../../generated/prisma';
 
 import { CreateBandBodyDto } from './dto/create-band.dto';
+import { CreateBandInvitationBodyDto } from './dto/create-band-invitation.dto';
 import { GetBandMembersQueryDto } from './dto/get-band-members-query.dto';
 import { GetMyBandsQueryDto } from './dto/get-my-bands-query.dto';
 import { SearchBandsQueryDto } from './dto/search-bands-query.dto';
@@ -12,6 +13,7 @@ import { UpdateBandBodyDto } from './dto/update-band.dto';
 import { UpdateBandMemberRoleBodyDto } from './dto/update-band-member-role.dto';
 import type { GetBandMembersResult } from './types/band-member-list.type';
 import type { SearchBandsResult } from './types/band-search-result.type';
+import type { CreateBandInvitationResult } from './types/create-band-invitation-result.type';
 import type { CreateBandResult } from './types/create-band-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
 import type { LeaveBandResult } from './types/leave-band-result.type';
@@ -34,6 +36,18 @@ export class BandsController {
     const createdBand = await this.bandsService.createBand(request.user.id, input);
 
     return createSuccessResponse('밴드 생성 성공', createdBand);
+  }
+
+  @Post(':bandId/invitations')
+  @UseGuards(AccessTokenGuard)
+  async createBandInvitation(
+    @Req() request: AuthenticatedRequest,
+    @Param('bandId') bandId: string,
+    @Body() input: CreateBandInvitationBodyDto,
+  ): Promise<ApiSuccessResponse<CreateBandInvitationResult>> {
+    const createdInvitation = await this.bandsService.createBandInvitation(request.user.id, bandId, input);
+
+    return createSuccessResponse('밴드 초대 전송 완료', createdInvitation);
   }
 
   @Delete(':bandId/me')

--- a/backend/src/modules/bands/bands.module.ts
+++ b/backend/src/modules/bands/bands.module.ts
@@ -7,12 +7,13 @@ import { UsersModule } from '../users/users.module';
 import { BandsPrismaRepository } from './repositories/bands.prisma-repository';
 import { BANDS_REPOSITORY } from './repositories/bands.repository';
 import { BandInvitationsController } from './band-invitations.controller';
+import { BandJoinRequestsController } from './band-join-requests.controller';
 import { BandsController } from './bands.controller';
 import { BandsService } from './bands.service';
 
 @Module({
   imports: [AuthModule, UsersModule],
-  controllers: [BandsController, BandInvitationsController],
+  controllers: [BandsController, BandInvitationsController, BandJoinRequestsController],
   providers: [
     AccessTokenGuard,
     BandsService,

--- a/backend/src/modules/bands/bands.module.ts
+++ b/backend/src/modules/bands/bands.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 
 import { AuthModule } from '../../auth/auth.module';
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
+import { NotificationsModule } from '../notifications/notifications.module';
 import { UsersModule } from '../users/users.module';
 
 import { BandsPrismaRepository } from './repositories/bands.prisma-repository';
@@ -12,7 +13,7 @@ import { BandsController } from './bands.controller';
 import { BandsService } from './bands.service';
 
 @Module({
-  imports: [AuthModule, UsersModule],
+  imports: [AuthModule, UsersModule, NotificationsModule],
   controllers: [BandsController, BandInvitationsController, BandJoinRequestsController],
   providers: [
     AccessTokenGuard,

--- a/backend/src/modules/bands/bands.module.ts
+++ b/backend/src/modules/bands/bands.module.ts
@@ -6,12 +6,13 @@ import { UsersModule } from '../users/users.module';
 
 import { BandsPrismaRepository } from './repositories/bands.prisma-repository';
 import { BANDS_REPOSITORY } from './repositories/bands.repository';
+import { BandInvitationsController } from './band-invitations.controller';
 import { BandsController } from './bands.controller';
 import { BandsService } from './bands.service';
 
 @Module({
   imports: [AuthModule, UsersModule],
-  controllers: [BandsController],
+  controllers: [BandsController, BandInvitationsController],
   providers: [
     AccessTokenGuard,
     BandsService,

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -46,7 +46,7 @@ function createBandsRepositoryStub(options?: {
     role: BandMemberRole;
   } | null;
   existingInvitation?: { id: string; status: 'PENDING' } | null;
-  invitationForAccept?: {
+  invitationForResponse?: {
     id: string;
     bandId: string;
     inviteeUserId: string;
@@ -57,10 +57,11 @@ function createBandsRepositoryStub(options?: {
   onCreateBand?: (input: CreateBandRepositoryInput, tx: unknown) => void;
   onCreateBandInvitation?: (input: { bandId: string; inviterBandMemberId: string; inviteeUserId: string; message?: string }, tx: unknown) => void;
   onDeleteBand?: (bandId: string, deletedAt: Date, tx: unknown) => void;
+  onDeclineBandInvitation?: (invitationId: string, respondedAt: Date, tx: unknown) => void;
   onFindBandBlacklistByBandIdAndUserId?: (tx: unknown) => void;
   onFindActiveBandById?: (tx: unknown) => void;
   onFindBandForLeave?: (tx: unknown) => void;
-  onFindBandInvitationForAccept?: (tx: unknown) => void;
+  onFindBandInvitationForResponse?: (tx: unknown) => void;
   onFindBandInvitationByBandIdAndInviteeUserId?: (tx: unknown) => void;
   onFindBandMemberByBandIdAndUserId?: (tx: unknown) => void;
   onFindBandMembers?: (bandId: string, query: GetBandMembersQuery, tx: unknown) => void;
@@ -108,6 +109,17 @@ function createBandsRepositoryStub(options?: {
             failed: [],
           },
         },
+      };
+    },
+    async declineBandInvitation(invitationId, respondedAt, tx) {
+      options?.onDeclineBandInvitation?.(invitationId, respondedAt, tx);
+
+      return {
+        invitationId,
+        bandId: 'band-001',
+        userId: INVITEE_USER_ID,
+        invitationStatus: 'DECLINED',
+        respondedAt: respondedAt.toISOString(),
       };
     },
     async createBandInvitation(input, tx) {
@@ -298,11 +310,11 @@ function createBandsRepositoryStub(options?: {
 
       return options?.existingInvitation ?? null;
     },
-    async findBandInvitationForAccept(_invitationId, tx) {
-      options?.onFindBandInvitationForAccept?.(tx);
+    async findBandInvitationForResponse(_invitationId, tx) {
+      options?.onFindBandInvitationForResponse?.(tx);
 
-      if (options?.invitationForAccept !== undefined) {
-        return options.invitationForAccept;
+      if (options?.invitationForResponse !== undefined) {
+        return options.invitationForResponse;
       }
 
       return {
@@ -767,7 +779,7 @@ describe('BandsService', () => {
 
     it('초대가 없거나 밴드가 삭제되었으면 예외를 던진다', async () => {
       const repository = createBandsRepositoryStub({
-        invitationForAccept: null,
+        invitationForResponse: null,
       });
       const service = new BandsService(repository, createPrismaServiceStub());
 
@@ -783,7 +795,7 @@ describe('BandsService', () => {
 
     it('대기 중인 초대가 아니면 예외를 던진다', async () => {
       const repository = createBandsRepositoryStub({
-        invitationForAccept: {
+        invitationForResponse: {
           id: 'invitation-001',
           bandId: 'band-001',
           inviteeUserId: INVITEE_USER_ID,
@@ -811,7 +823,7 @@ describe('BandsService', () => {
     it('검증과 수락 처리를 같은 transaction client로 실행한다', async () => {
       const capturedTransactions: unknown[] = [];
       const repository = createBandsRepositoryStub({
-        onFindBandInvitationForAccept(tx) {
+        onFindBandInvitationForResponse(tx) {
           capturedTransactions.push(tx);
         },
         onFindBandMemberByBandIdAndUserId(tx) {
@@ -842,6 +854,94 @@ describe('BandsService', () => {
       const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
 
       await service.acceptBandInvitation(INVITEE_USER_ID, 'invitation-001', externalTx as never);
+
+      expect(capturedTransactions).toEqual([externalTx]);
+    });
+  });
+
+  describe('declineBandInvitation', () => {
+    it('초대받은 사용자가 대기 중인 초대를 거절한다', async () => {
+      let capturedRespondedAt: Date | undefined;
+      const repository = createBandsRepositoryStub({
+        onDeclineBandInvitation(_invitationId, respondedAt) {
+          capturedRespondedAt = respondedAt;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.declineBandInvitation(INVITEE_USER_ID, 'invitation-001');
+
+      expect(capturedRespondedAt).toBeInstanceOf(Date);
+      expect(result).toEqual({
+        invitationId: 'invitation-001',
+        bandId: 'band-001',
+        userId: INVITEE_USER_ID,
+        invitationStatus: 'DECLINED',
+        respondedAt: capturedRespondedAt?.toISOString(),
+      });
+    });
+
+    it('초대가 없거나 밴드가 삭제되었으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        invitationForResponse: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.declineBandInvitation(INVITEE_USER_ID, 'invitation-missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('초대받은 사용자가 아니면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.declineBandInvitation(BAND_MASTER_USER_ID, 'invitation-001')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('대기 중인 초대가 아니면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        invitationForResponse: {
+          id: 'invitation-001',
+          bandId: 'band-001',
+          inviteeUserId: INVITEE_USER_ID,
+          status: 'ACCEPTED',
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.declineBandInvitation(INVITEE_USER_ID, 'invitation-001')).rejects.toThrow(ConflictException);
+    });
+
+    it('검증과 거절 처리를 같은 transaction client로 실행한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindBandInvitationForResponse(tx) {
+          capturedTransactions.push(tx);
+        },
+        onDeclineBandInvitation(_invitationId, _respondedAt, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await service.declineBandInvitation(INVITEE_USER_ID, 'invitation-001');
+
+      expect(capturedTransactions).toHaveLength(2);
+      expect(new Set(capturedTransactions).size).toBe(1);
+    });
+
+    it('외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onDeclineBandInvitation(_invitationId, _respondedAt, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.declineBandInvitation(INVITEE_USER_ID, 'invitation-001', externalTx as never);
 
       expect(capturedTransactions).toEqual([externalTx]);
     });

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -46,13 +46,21 @@ function createBandsRepositoryStub(options?: {
     role: BandMemberRole;
   } | null;
   existingInvitation?: { id: string; status: 'PENDING' } | null;
+  invitationForAccept?: {
+    id: string;
+    bandId: string;
+    inviteeUserId: string;
+    status: 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'EXPIRED';
+  } | null;
   bandBlacklist?: { id: string } | null;
+  onAcceptBandInvitation?: (invitationId: string, bandId: string, userId: string, respondedAt: Date, tx: unknown) => void;
   onCreateBand?: (input: CreateBandRepositoryInput, tx: unknown) => void;
   onCreateBandInvitation?: (input: { bandId: string; inviterBandMemberId: string; inviteeUserId: string; message?: string }, tx: unknown) => void;
   onDeleteBand?: (bandId: string, deletedAt: Date, tx: unknown) => void;
   onFindBandBlacklistByBandIdAndUserId?: (tx: unknown) => void;
   onFindActiveBandById?: (tx: unknown) => void;
   onFindBandForLeave?: (tx: unknown) => void;
+  onFindBandInvitationForAccept?: (tx: unknown) => void;
   onFindBandInvitationByBandIdAndInviteeUserId?: (tx: unknown) => void;
   onFindBandMemberByBandIdAndUserId?: (tx: unknown) => void;
   onFindBandMembers?: (bandId: string, query: GetBandMembersQuery, tx: unknown) => void;
@@ -65,6 +73,17 @@ function createBandsRepositoryStub(options?: {
   onUpdateBandMemberRole?: (bandMemberId: string, role: BandMemberRole, tx: unknown) => void;
 }): BandsRepository {
   return {
+    async acceptBandInvitation(invitationId, bandId, userId, respondedAt, tx) {
+      options?.onAcceptBandInvitation?.(invitationId, bandId, userId, respondedAt, tx);
+
+      return {
+        invitationId,
+        bandId,
+        userId,
+        invitationStatus: 'ACCEPTED',
+        joinedAt: '2026-04-30T10:00:00.000Z',
+      };
+    },
     async createBand(input, tx) {
       options?.onCreateBand?.(input, tx);
 
@@ -278,6 +297,20 @@ function createBandsRepositoryStub(options?: {
       options?.onFindBandInvitationByBandIdAndInviteeUserId?.(tx);
 
       return options?.existingInvitation ?? null;
+    },
+    async findBandInvitationForAccept(_invitationId, tx) {
+      options?.onFindBandInvitationForAccept?.(tx);
+
+      if (options?.invitationForAccept !== undefined) {
+        return options.invitationForAccept;
+      }
+
+      return {
+        id: 'invitation-001',
+        bandId: 'band-001',
+        inviteeUserId: INVITEE_USER_ID,
+        status: 'PENDING',
+      };
     },
     async findBandBlacklistByBandIdAndUserId(_bandId, _userId, tx) {
       options?.onFindBandBlacklistByBandIdAndUserId?.(tx);
@@ -705,6 +738,110 @@ describe('BandsService', () => {
         },
         externalTx as never,
       );
+
+      expect(capturedTransactions).toEqual([externalTx]);
+    });
+  });
+
+  describe('acceptBandInvitation', () => {
+    it('초대받은 사용자가 대기 중인 초대를 수락한다', async () => {
+      let capturedRespondedAt: Date | undefined;
+      const repository = createBandsRepositoryStub({
+        onAcceptBandInvitation(_invitationId, _bandId, _userId, respondedAt) {
+          capturedRespondedAt = respondedAt;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.acceptBandInvitation(INVITEE_USER_ID, 'invitation-001');
+
+      expect(capturedRespondedAt).toBeInstanceOf(Date);
+      expect(result).toEqual({
+        invitationId: 'invitation-001',
+        bandId: 'band-001',
+        userId: INVITEE_USER_ID,
+        invitationStatus: 'ACCEPTED',
+        joinedAt: '2026-04-30T10:00:00.000Z',
+      });
+    });
+
+    it('초대가 없거나 밴드가 삭제되었으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        invitationForAccept: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.acceptBandInvitation(INVITEE_USER_ID, 'invitation-missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('초대받은 사용자가 아니면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.acceptBandInvitation(BAND_MASTER_USER_ID, 'invitation-001')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('대기 중인 초대가 아니면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        invitationForAccept: {
+          id: 'invitation-001',
+          bandId: 'band-001',
+          inviteeUserId: INVITEE_USER_ID,
+          status: 'DECLINED',
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.acceptBandInvitation(INVITEE_USER_ID, 'invitation-001')).rejects.toThrow(ConflictException);
+    });
+
+    it('이미 밴드 멤버이면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        inviteeBandMember: {
+          id: 'invitee-member-001',
+          userId: INVITEE_USER_ID,
+          role: BandMemberRole.MEMBER,
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.acceptBandInvitation(INVITEE_USER_ID, 'invitation-001')).rejects.toThrow(ConflictException);
+    });
+
+    it('검증과 수락 처리를 같은 transaction client로 실행한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindBandInvitationForAccept(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandMemberByBandIdAndUserId(tx) {
+          capturedTransactions.push(tx);
+        },
+        onAcceptBandInvitation(_invitationId, _bandId, _userId, _respondedAt, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await service.acceptBandInvitation(INVITEE_USER_ID, 'invitation-001');
+
+      expect(capturedTransactions).toHaveLength(3);
+      expect(new Set(capturedTransactions).size).toBe(1);
+    });
+
+    it('외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onAcceptBandInvitation(_invitationId, _bandId, _userId, _respondedAt, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.acceptBandInvitation(INVITEE_USER_ID, 'invitation-001', externalTx as never);
 
       expect(capturedTransactions).toEqual([externalTx]);
     });

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -5,6 +5,7 @@ import { BandMemberRole } from 'src/generated/prisma';
 import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
 import type { GetReceivedBandInvitationsQuery } from './dto/get-received-band-invitations-query.dto';
+import type { GetSentBandInvitationsQuery } from './dto/get-sent-band-invitations-query.dto';
 import type { SearchBandsQuery } from './dto/search-bands-query.dto';
 import type { UpdateBandInput } from './dto/update-band.dto';
 import type { BandsRepository, CreateBandRepositoryInput } from './repositories/bands.repository';
@@ -77,6 +78,7 @@ function createBandsRepositoryStub(options?: {
   onFindExistingUserIds?: (tx: unknown) => void;
   onFindMyBands?: (userId: string, query: GetMyBandsQuery, tx: unknown) => void;
   onFindReceivedBandInvitations?: (userId: string, query: GetReceivedBandInvitationsQuery, tx: unknown) => void;
+  onFindSentBandInvitations?: (userId: string, query: GetSentBandInvitationsQuery, tx: unknown) => void;
   onLeaveBand?: (bandMemberId: string, tx: unknown) => void;
   onSearchBands?: (query: SearchBandsQuery, tx: unknown) => void;
   onUpdateBand?: (bandId: string, input: UpdateBandInput, tx: unknown) => void;
@@ -273,6 +275,40 @@ function createBandsRepositoryStub(options?: {
             message: '같이 밴드 하실래요?',
             invitationStatus: query.where__invitation_status,
             createdAt: '2026-04-30T10:00:00.000Z',
+          },
+        ],
+        meta: {
+          count: 1,
+          take: query.take,
+          cursor: {
+            id: 'invitation-001',
+          },
+          next: null,
+        },
+      };
+    },
+    async findSentBandInvitations(userId, query, tx) {
+      options?.onFindSentBandInvitations?.(userId, query, tx);
+
+      return {
+        items: [
+          {
+            invitationId: 'invitation-001',
+            band: {
+              bandId: 'band-001',
+              name: 'Rocking Stars',
+              description: '직장인 밴드',
+              memberCount: 5,
+            },
+            invitee: {
+              userId: INVITEE_USER_ID,
+              nickname: 'Choi',
+              avatarUrl: null,
+            },
+            invitationStatus: query.where__invitation_status,
+            message: '같이 합주해요!',
+            createdAt: '2026-04-30T10:00:00.000Z',
+            respondedAt: null,
           },
         ],
         meta: {
@@ -1342,6 +1378,61 @@ describe('BandsService', () => {
 
       await service.getReceivedBandInvitations(
         INVITEE_USER_ID,
+        {
+          where__invitation_status: 'PENDING',
+          order__created_at: 'desc',
+          order__id: 'desc',
+          take: 20,
+        },
+        externalTx as never,
+      );
+
+      expect(capturedTransaction).toBe(externalTx);
+    });
+  });
+
+  describe('getSentBandInvitations', () => {
+    it('인증 사용자가 직접 보낸 초대 목록을 조회한다', async () => {
+      let capturedUserId: string | undefined;
+      let capturedQuery: GetSentBandInvitationsQuery | undefined;
+      const query: GetSentBandInvitationsQuery = {
+        where__invitation_status: 'PENDING',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      };
+      const repository = createBandsRepositoryStub({
+        onFindSentBandInvitations(userId, inputQuery) {
+          capturedUserId = userId;
+          capturedQuery = inputQuery;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.getSentBandInvitations(BAND_MASTER_USER_ID, query);
+
+      expect(capturedUserId).toBe(BAND_MASTER_USER_ID);
+      expect(capturedQuery).toBe(query);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].invitationStatus).toBe('PENDING');
+      expect(result.items[0].band.memberCount).toBe(5);
+      expect(result.meta.take).toBe(20);
+    });
+
+    it('외부 transaction client를 repository로 전달한다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      let capturedTransaction: unknown;
+      const repository = createBandsRepositoryStub({
+        onFindSentBandInvitations(_userId, _query, tx) {
+          capturedTransaction = tx;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.getSentBandInvitations(
+        BAND_MASTER_USER_ID,
         {
           where__invitation_status: 'PENDING',
           order__created_at: 'desc',

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -64,6 +64,7 @@ function createBandsRepositoryStub(options?: {
   invitationForResponse?: {
     id: string;
     bandId: string;
+    inviterUserId: string;
     inviteeUserId: string;
     status: 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'EXPIRED';
   } | null;
@@ -91,6 +92,7 @@ function createBandsRepositoryStub(options?: {
   onFindBandInvitationByBandIdAndInviteeUserId?: (tx: unknown) => void;
   onFindBandJoinRequestByBandIdAndUserId?: (tx: unknown) => void;
   onFindBandJoinRequestForResponse?: (tx: unknown) => void;
+  onFindBandManagerUserIdsByBandId?: (bandId: string, tx: unknown) => void;
   onFindBandJoinRequests?: (bandId: string, query: GetBandJoinRequestsQuery, tx: unknown) => void;
   onFindBandMemberByBandIdAndUserId?: (tx: unknown) => void;
   onFindBandMembers?: (bandId: string, query: GetBandMembersQuery, tx: unknown) => void;
@@ -532,6 +534,11 @@ function createBandsRepositoryStub(options?: {
         status: 'PENDING',
       };
     },
+    async findBandManagerUserIdsByBandId(bandId, tx) {
+      options?.onFindBandManagerUserIdsByBandId?.(bandId, tx);
+
+      return [BAND_MASTER_USER_ID, ADMIN_USER_ID];
+    },
     async findBandInvitationForResponse(_invitationId, tx) {
       options?.onFindBandInvitationForResponse?.(tx);
 
@@ -542,6 +549,7 @@ function createBandsRepositoryStub(options?: {
       return {
         id: 'invitation-001',
         bandId: 'band-001',
+        inviterUserId: BAND_MASTER_USER_ID,
         inviteeUserId: INVITEE_USER_ID,
         status: 'PENDING',
       };
@@ -1198,6 +1206,7 @@ describe('BandsService', () => {
         invitationForResponse: {
           id: 'invitation-001',
           bandId: 'band-001',
+          inviterUserId: BAND_MASTER_USER_ID,
           inviteeUserId: INVITEE_USER_ID,
           status: 'DECLINED',
         },
@@ -1526,6 +1535,7 @@ describe('BandsService', () => {
         invitationForResponse: {
           id: 'invitation-001',
           bandId: 'band-001',
+          inviterUserId: BAND_MASTER_USER_ID,
           inviteeUserId: INVITEE_USER_ID,
           status: 'ACCEPTED',
         },

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -25,6 +25,10 @@ function createBandsRepositoryStub(options?: {
     id: string;
     bandMasterUserId: string;
   } | null;
+  bandForJoinRequest?: {
+    id: string;
+    visibility: boolean;
+  } | null;
   bandForLeave?: {
     id: string;
     member: {
@@ -48,6 +52,7 @@ function createBandsRepositoryStub(options?: {
     role: BandMemberRole;
   } | null;
   existingInvitation?: { id: string; status: 'PENDING' } | null;
+  existingJoinRequest?: { id: string; status: 'PENDING' | 'APPROVED' | 'REJECTED' } | null;
   invitationForResponse?: {
     id: string;
     bandId: string;
@@ -63,15 +68,18 @@ function createBandsRepositoryStub(options?: {
   onAcceptBandInvitation?: (invitationId: string, bandId: string, userId: string, respondedAt: Date, tx: unknown) => void;
   onCreateBand?: (input: CreateBandRepositoryInput, tx: unknown) => void;
   onCreateBandInvitation?: (input: { bandId: string; inviterBandMemberId: string; inviteeUserId: string; message?: string }, tx: unknown) => void;
+  onCreateBandJoinRequest?: (input: { bandId: string; userId: string; message?: string }, tx: unknown) => void;
   onDeleteBand?: (bandId: string, deletedAt: Date, tx: unknown) => void;
   onDeleteBandInvitation?: (invitationId: string, tx: unknown) => void;
   onDeclineBandInvitation?: (invitationId: string, respondedAt: Date, tx: unknown) => void;
   onFindBandBlacklistByBandIdAndUserId?: (tx: unknown) => void;
   onFindActiveBandById?: (tx: unknown) => void;
   onFindBandForLeave?: (tx: unknown) => void;
+  onFindBandForJoinRequest?: (tx: unknown) => void;
   onFindBandInvitationForDelete?: (tx: unknown) => void;
   onFindBandInvitationForResponse?: (tx: unknown) => void;
   onFindBandInvitationByBandIdAndInviteeUserId?: (tx: unknown) => void;
+  onFindBandJoinRequestByBandIdAndUserId?: (tx: unknown) => void;
   onFindBandMemberByBandIdAndUserId?: (tx: unknown) => void;
   onFindBandMembers?: (bandId: string, query: GetBandMembersQuery, tx: unknown) => void;
   onFindExistingGenreIds?: (tx: unknown) => void;
@@ -145,6 +153,17 @@ function createBandsRepositoryStub(options?: {
         createdAt: '2026-04-10T12:00:00.000Z',
       };
     },
+    async createBandJoinRequest(input, tx) {
+      options?.onCreateBandJoinRequest?.(input, tx);
+
+      return {
+        joinRequestId: 'join-request-001',
+        bandId: input.bandId,
+        userId: input.userId,
+        joinRequestStatus: 'PENDING',
+        createdAt: '2026-04-30T10:00:00.000Z',
+      };
+    },
     async deleteBand(bandId, deletedAt, tx) {
       options?.onDeleteBand?.(bandId, deletedAt, tx);
 
@@ -185,6 +204,18 @@ function createBandsRepositoryStub(options?: {
           id: 'band-member-001',
           role: BandMemberRole.MEMBER,
         },
+      };
+    },
+    async findBandForJoinRequest(_bandId, tx) {
+      options?.onFindBandForJoinRequest?.(tx);
+
+      if (options?.bandForJoinRequest !== undefined) {
+        return options.bandForJoinRequest;
+      }
+
+      return {
+        id: 'band-001',
+        visibility: true,
       };
     },
     async leaveBand(bandMemberId, tx) {
@@ -392,6 +423,11 @@ function createBandsRepositoryStub(options?: {
       options?.onFindBandInvitationByBandIdAndInviteeUserId?.(tx);
 
       return options?.existingInvitation ?? null;
+    },
+    async findBandJoinRequestByBandIdAndUserId(_bandId, _userId, tx) {
+      options?.onFindBandJoinRequestByBandIdAndUserId?.(tx);
+
+      return options?.existingJoinRequest ?? null;
     },
     async findBandInvitationForResponse(_invitationId, tx) {
       options?.onFindBandInvitationForResponse?.(tx);
@@ -846,6 +882,151 @@ describe('BandsService', () => {
         },
         externalTx as never,
       );
+
+      expect(capturedTransactions).toEqual([externalTx]);
+    });
+  });
+
+  describe('createBandJoinRequest', () => {
+    it('인증 사용자가 공개 밴드에 가입 요청을 보낸다', async () => {
+      let capturedInput: { bandId: string; userId: string; message?: string } | undefined;
+      const repository = createBandsRepositoryStub({
+        onCreateBandJoinRequest(input) {
+          capturedInput = input;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.createBandJoinRequest(INVITEE_USER_ID, 'band-001', {
+        message: '기타로 합류하고 싶습니다!',
+      });
+
+      expect(capturedInput).toEqual({
+        bandId: 'band-001',
+        userId: INVITEE_USER_ID,
+        message: '기타로 합류하고 싶습니다!',
+      });
+      expect(result).toEqual({
+        joinRequestId: 'join-request-001',
+        bandId: 'band-001',
+        userId: INVITEE_USER_ID,
+        joinRequestStatus: 'PENDING',
+        createdAt: '2026-04-30T10:00:00.000Z',
+      });
+    });
+
+    it('밴드가 없거나 삭제되었으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandForJoinRequest: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.createBandJoinRequest(INVITEE_USER_ID, 'band-missing', {})).rejects.toThrow(NotFoundException);
+    });
+
+    it('비공개 밴드에는 가입 요청을 보낼 수 없다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandForJoinRequest: {
+          id: 'band-001',
+          visibility: false,
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.createBandJoinRequest(INVITEE_USER_ID, 'band-001', {})).rejects.toThrow(ForbiddenException);
+    });
+
+    it('이미 밴드 멤버이면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        inviteeBandMember: {
+          id: 'band-member-002',
+          userId: INVITEE_USER_ID,
+          role: BandMemberRole.MEMBER,
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.createBandJoinRequest(INVITEE_USER_ID, 'band-001', {})).rejects.toThrow(ConflictException);
+    });
+
+    it('차단된 사용자는 가입 요청을 보낼 수 없다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandBlacklist: {
+          id: 'blacklist-001',
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.createBandJoinRequest(INVITEE_USER_ID, 'band-001', {})).rejects.toThrow(ForbiddenException);
+    });
+
+    it('기존 초대가 있으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        existingInvitation: {
+          id: 'invitation-001',
+          status: 'PENDING',
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.createBandJoinRequest(INVITEE_USER_ID, 'band-001', {})).rejects.toThrow(ConflictException);
+    });
+
+    it('기존 가입 요청이 있으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        existingJoinRequest: {
+          id: 'join-request-001',
+          status: 'PENDING',
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.createBandJoinRequest(INVITEE_USER_ID, 'band-001', {})).rejects.toThrow(ConflictException);
+    });
+
+    it('검증과 가입 요청 생성을 같은 transaction client로 실행한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindBandForJoinRequest(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandMemberByBandIdAndUserId(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandBlacklistByBandIdAndUserId(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandInvitationByBandIdAndInviteeUserId(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandJoinRequestByBandIdAndUserId(tx) {
+          capturedTransactions.push(tx);
+        },
+        onCreateBandJoinRequest(_input, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await service.createBandJoinRequest(INVITEE_USER_ID, 'band-001', {});
+
+      expect(capturedTransactions).toHaveLength(6);
+      expect(new Set(capturedTransactions).size).toBe(1);
+    });
+
+    it('외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onCreateBandJoinRequest(_input, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.createBandJoinRequest(INVITEE_USER_ID, 'band-001', {}, externalTx as never);
 
       expect(capturedTransactions).toEqual([externalTx]);
     });

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -4,6 +4,7 @@ import { BandMemberRole } from 'src/generated/prisma';
 
 import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
+import type { GetReceivedBandInvitationsQuery } from './dto/get-received-band-invitations-query.dto';
 import type { SearchBandsQuery } from './dto/search-bands-query.dto';
 import type { UpdateBandInput } from './dto/update-band.dto';
 import type { BandsRepository, CreateBandRepositoryInput } from './repositories/bands.repository';
@@ -75,6 +76,7 @@ function createBandsRepositoryStub(options?: {
   onFindExistingGenreIds?: (tx: unknown) => void;
   onFindExistingUserIds?: (tx: unknown) => void;
   onFindMyBands?: (userId: string, query: GetMyBandsQuery, tx: unknown) => void;
+  onFindReceivedBandInvitations?: (userId: string, query: GetReceivedBandInvitationsQuery, tx: unknown) => void;
   onLeaveBand?: (bandMemberId: string, tx: unknown) => void;
   onSearchBands?: (query: SearchBandsQuery, tx: unknown) => void;
   onUpdateBand?: (bandId: string, input: UpdateBandInput, tx: unknown) => void;
@@ -247,6 +249,37 @@ function createBandsRepositoryStub(options?: {
           cursor: {
             createdAt: '2026-03-01T12:00:00.000Z',
             id: 'band-001',
+          },
+          next: null,
+        },
+      };
+    },
+    async findReceivedBandInvitations(userId, query, tx) {
+      options?.onFindReceivedBandInvitations?.(userId, query, tx);
+
+      return {
+        items: [
+          {
+            invitationId: 'invitation-001',
+            band: {
+              bandId: 'band-001',
+              name: 'Rocking Stars',
+              description: '직장인 밴드',
+            },
+            inviter: {
+              userId: BAND_MASTER_USER_ID,
+              nickname: 'Jun',
+            },
+            message: '같이 밴드 하실래요?',
+            invitationStatus: query.where__invitation_status,
+            createdAt: '2026-04-30T10:00:00.000Z',
+          },
+        ],
+        meta: {
+          count: 1,
+          take: query.take,
+          cursor: {
+            id: 'invitation-001',
           },
           next: null,
         },
@@ -1259,6 +1292,60 @@ describe('BandsService', () => {
       await service.getMyBands(
         BAND_MASTER_USER_ID,
         {
+          take: 20,
+        },
+        externalTx as never,
+      );
+
+      expect(capturedTransaction).toBe(externalTx);
+    });
+  });
+
+  describe('getReceivedBandInvitations', () => {
+    it('인증 사용자가 받은 초대 목록을 조회한다', async () => {
+      let capturedUserId: string | undefined;
+      let capturedQuery: GetReceivedBandInvitationsQuery | undefined;
+      const query: GetReceivedBandInvitationsQuery = {
+        where__invitation_status: 'PENDING',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      };
+      const repository = createBandsRepositoryStub({
+        onFindReceivedBandInvitations(userId, inputQuery) {
+          capturedUserId = userId;
+          capturedQuery = inputQuery;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.getReceivedBandInvitations(INVITEE_USER_ID, query);
+
+      expect(capturedUserId).toBe(INVITEE_USER_ID);
+      expect(capturedQuery).toBe(query);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].invitationStatus).toBe('PENDING');
+      expect(result.meta.take).toBe(20);
+    });
+
+    it('외부 transaction client를 repository로 전달한다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      let capturedTransaction: unknown;
+      const repository = createBandsRepositoryStub({
+        onFindReceivedBandInvitations(_userId, _query, tx) {
+          capturedTransaction = tx;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.getReceivedBandInvitations(
+        INVITEE_USER_ID,
+        {
+          where__invitation_status: 'PENDING',
+          order__created_at: 'desc',
+          order__id: 'desc',
           take: 20,
         },
         externalTx as never,

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -931,6 +931,23 @@ describe('BandsService', () => {
       ).rejects.toThrow(ConflictException);
     });
 
+    it('기존 가입 요청이 있으면 초대할 수 없다', async () => {
+      const repository = createBandsRepositoryStub({
+        existingUserIds: [INVITEE_USER_ID],
+        existingJoinRequest: {
+          id: 'join-request-001',
+          status: 'PENDING',
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.createBandInvitation(BAND_MASTER_USER_ID, 'band-001', {
+          inviteeUserId: INVITEE_USER_ID,
+        }),
+      ).rejects.toThrow(ConflictException);
+    });
+
     it('검증과 초대 생성을 같은 transaction client로 실행한다', async () => {
       const capturedTransactions: unknown[] = [];
       const repository = createBandsRepositoryStub({
@@ -950,6 +967,9 @@ describe('BandsService', () => {
         onFindBandInvitationByBandIdAndInviteeUserId(tx) {
           capturedTransactions.push(tx);
         },
+        onFindBandJoinRequestByBandIdAndUserId(tx) {
+          capturedTransactions.push(tx);
+        },
         onCreateBandInvitation(_input, tx) {
           capturedTransactions.push(tx);
         },
@@ -960,7 +980,7 @@ describe('BandsService', () => {
         inviteeUserId: INVITEE_USER_ID,
       });
 
-      expect(capturedTransactions).toHaveLength(7);
+      expect(capturedTransactions).toHaveLength(8);
       expect(new Set(capturedTransactions).size).toBe(1);
     });
 

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException, ConflictException, ForbiddenException, NotFoundExc
 import type { PrismaService } from 'src/database/prisma';
 import { BandMemberRole } from 'src/generated/prisma';
 
+import type { GetBandJoinRequestsQuery } from './dto/get-band-join-requests-query.dto';
 import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
 import type { GetReceivedBandInvitationsQuery } from './dto/get-received-band-invitations-query.dto';
@@ -54,6 +55,12 @@ function createBandsRepositoryStub(options?: {
   } | null;
   existingInvitation?: { id: string; status: 'PENDING' } | null;
   existingJoinRequest?: { id: string; status: 'PENDING' | 'APPROVED' | 'REJECTED' } | null;
+  joinRequestForResponse?: {
+    id: string;
+    bandId: string;
+    userId: string;
+    status: 'PENDING' | 'APPROVED' | 'REJECTED';
+  } | null;
   invitationForResponse?: {
     id: string;
     bandId: string;
@@ -67,12 +74,14 @@ function createBandsRepositoryStub(options?: {
   } | null;
   bandBlacklist?: { id: string } | null;
   onAcceptBandInvitation?: (invitationId: string, bandId: string, userId: string, respondedAt: Date, tx: unknown) => void;
+  onApproveBandJoinRequest?: (joinRequestId: string, bandId: string, userId: string, tx: unknown) => void;
   onCreateBand?: (input: CreateBandRepositoryInput, tx: unknown) => void;
   onCreateBandInvitation?: (input: { bandId: string; inviterBandMemberId: string; inviteeUserId: string; message?: string }, tx: unknown) => void;
   onCreateBandJoinRequest?: (input: { bandId: string; userId: string; message?: string }, tx: unknown) => void;
   onDeleteBand?: (bandId: string, deletedAt: Date, tx: unknown) => void;
   onDeleteBandInvitation?: (invitationId: string, tx: unknown) => void;
   onDeclineBandInvitation?: (invitationId: string, respondedAt: Date, tx: unknown) => void;
+  onRejectBandJoinRequest?: (joinRequestId: string, tx: unknown) => void;
   onFindBandBlacklistByBandIdAndUserId?: (tx: unknown) => void;
   onFindActiveBandById?: (tx: unknown) => void;
   onFindBandForLeave?: (tx: unknown) => void;
@@ -81,6 +90,8 @@ function createBandsRepositoryStub(options?: {
   onFindBandInvitationForResponse?: (tx: unknown) => void;
   onFindBandInvitationByBandIdAndInviteeUserId?: (tx: unknown) => void;
   onFindBandJoinRequestByBandIdAndUserId?: (tx: unknown) => void;
+  onFindBandJoinRequestForResponse?: (tx: unknown) => void;
+  onFindBandJoinRequests?: (bandId: string, query: GetBandJoinRequestsQuery, tx: unknown) => void;
   onFindBandMemberByBandIdAndUserId?: (tx: unknown) => void;
   onFindBandMembers?: (bandId: string, query: GetBandMembersQuery, tx: unknown) => void;
   onFindExistingGenreIds?: (tx: unknown) => void;
@@ -103,6 +114,17 @@ function createBandsRepositoryStub(options?: {
         bandId,
         userId,
         invitationStatus: 'ACCEPTED',
+        joinedAt: '2026-04-30T10:00:00.000Z',
+      };
+    },
+    async approveBandJoinRequest(joinRequestId, bandId, userId, tx) {
+      options?.onApproveBandJoinRequest?.(joinRequestId, bandId, userId, tx);
+
+      return {
+        joinRequestId,
+        bandId,
+        userId,
+        joinRequestStatus: 'APPROVED',
         joinedAt: '2026-04-30T10:00:00.000Z',
       };
     },
@@ -141,6 +163,16 @@ function createBandsRepositoryStub(options?: {
         userId: INVITEE_USER_ID,
         invitationStatus: 'DECLINED',
         respondedAt: respondedAt.toISOString(),
+      };
+    },
+    async rejectBandJoinRequest(joinRequestId, tx) {
+      options?.onRejectBandJoinRequest?.(joinRequestId, tx);
+
+      return {
+        joinRequestId,
+        bandId: 'band-001',
+        userId: INVITEE_USER_ID,
+        joinRequestStatus: 'REJECTED',
       };
     },
     async createBandInvitation(input, tx) {
@@ -382,6 +414,33 @@ function createBandsRepositoryStub(options?: {
         },
       };
     },
+    async findBandJoinRequests(bandId, query, tx) {
+      options?.onFindBandJoinRequests?.(bandId, query, tx);
+
+      return {
+        items: [
+          {
+            joinRequestId: 'join-request-001',
+            requester: {
+              userId: INVITEE_USER_ID,
+              nickname: 'Choi',
+              avatarUrl: null,
+            },
+            joinRequestStatus: query.where__join_request_status,
+            message: '기타로 합류하고 싶습니다!',
+            createdAt: '2026-04-30T10:00:00.000Z',
+          },
+        ],
+        meta: {
+          count: 1,
+          take: query.take,
+          cursor: {
+            id: 'join-request-001',
+          },
+          next: null,
+        },
+      };
+    },
     async searchBands(query, tx) {
       options?.onSearchBands?.(query, tx);
 
@@ -458,6 +517,20 @@ function createBandsRepositoryStub(options?: {
       options?.onFindBandJoinRequestByBandIdAndUserId?.(tx);
 
       return options?.existingJoinRequest ?? null;
+    },
+    async findBandJoinRequestForResponse(_joinRequestId, tx) {
+      options?.onFindBandJoinRequestForResponse?.(tx);
+
+      if (options?.joinRequestForResponse !== undefined) {
+        return options.joinRequestForResponse;
+      }
+
+      return {
+        id: 'join-request-001',
+        bandId: 'band-001',
+        userId: INVITEE_USER_ID,
+        status: 'PENDING',
+      };
     },
     async findBandInvitationForResponse(_invitationId, tx) {
       options?.onFindBandInvitationForResponse?.(tx);
@@ -1166,6 +1239,230 @@ describe('BandsService', () => {
     });
   });
 
+  describe('approveBandJoinRequest', () => {
+    it('BM이 대기 중인 가입 요청을 승인하고 멤버로 가입시킨다', async () => {
+      let capturedInput: { joinRequestId: string; bandId: string; userId: string } | undefined;
+      const repository = createBandsRepositoryStub({
+        onApproveBandJoinRequest(joinRequestId, bandId, userId) {
+          capturedInput = { joinRequestId, bandId, userId };
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.approveBandJoinRequest(BAND_MASTER_USER_ID, 'join-request-001');
+
+      expect(capturedInput).toEqual({
+        joinRequestId: 'join-request-001',
+        bandId: 'band-001',
+        userId: INVITEE_USER_ID,
+      });
+      expect(result).toEqual({
+        joinRequestId: 'join-request-001',
+        bandId: 'band-001',
+        userId: INVITEE_USER_ID,
+        joinRequestStatus: 'APPROVED',
+        joinedAt: '2026-04-30T10:00:00.000Z',
+      });
+    });
+
+    it('가입 요청이 없거나 밴드/사용자가 삭제되었으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        joinRequestForResponse: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.approveBandJoinRequest(BAND_MASTER_USER_ID, 'join-request-missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('밴드 운영 권한이 없으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        requesterBandMember: {
+          id: 'member-001',
+          userId: BAND_MASTER_USER_ID,
+          role: BandMemberRole.MEMBER,
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.approveBandJoinRequest(BAND_MASTER_USER_ID, 'join-request-001')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('대기 중인 가입 요청이 아니면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        joinRequestForResponse: {
+          id: 'join-request-001',
+          bandId: 'band-001',
+          userId: INVITEE_USER_ID,
+          status: 'REJECTED',
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.approveBandJoinRequest(BAND_MASTER_USER_ID, 'join-request-001')).rejects.toThrow(ConflictException);
+    });
+
+    it('요청자가 이미 밴드 멤버이면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        inviteeBandMember: {
+          id: 'member-002',
+          userId: INVITEE_USER_ID,
+          role: BandMemberRole.MEMBER,
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.approveBandJoinRequest(BAND_MASTER_USER_ID, 'join-request-001')).rejects.toThrow(ConflictException);
+    });
+
+    it('차단된 사용자의 가입 요청은 승인할 수 없다', async () => {
+      const repository = createBandsRepositoryStub({
+        bandBlacklist: {
+          id: 'blacklist-001',
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.approveBandJoinRequest(BAND_MASTER_USER_ID, 'join-request-001')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('검증과 승인을 같은 transaction client로 실행한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindBandJoinRequestForResponse(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandMemberByBandIdAndUserId(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandBlacklistByBandIdAndUserId(tx) {
+          capturedTransactions.push(tx);
+        },
+        onApproveBandJoinRequest(_joinRequestId, _bandId, _userId, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await service.approveBandJoinRequest(BAND_MASTER_USER_ID, 'join-request-001');
+
+      expect(capturedTransactions).toHaveLength(5);
+      expect(new Set(capturedTransactions).size).toBe(1);
+    });
+
+    it('외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onApproveBandJoinRequest(_joinRequestId, _bandId, _userId, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.approveBandJoinRequest(BAND_MASTER_USER_ID, 'join-request-001', externalTx as never);
+
+      expect(capturedTransactions).toEqual([externalTx]);
+    });
+  });
+
+  describe('rejectBandJoinRequest', () => {
+    it('BM이 대기 중인 가입 요청을 거절한다', async () => {
+      let capturedJoinRequestId: string | undefined;
+      const repository = createBandsRepositoryStub({
+        onRejectBandJoinRequest(joinRequestId) {
+          capturedJoinRequestId = joinRequestId;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.rejectBandJoinRequest(BAND_MASTER_USER_ID, 'join-request-001');
+
+      expect(capturedJoinRequestId).toBe('join-request-001');
+      expect(result).toEqual({
+        joinRequestId: 'join-request-001',
+        bandId: 'band-001',
+        userId: INVITEE_USER_ID,
+        joinRequestStatus: 'REJECTED',
+      });
+    });
+
+    it('가입 요청이 없거나 밴드/사용자가 삭제되었으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        joinRequestForResponse: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.rejectBandJoinRequest(BAND_MASTER_USER_ID, 'join-request-missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('밴드 운영 권한이 없으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        requesterBandMember: {
+          id: 'member-001',
+          userId: BAND_MASTER_USER_ID,
+          role: BandMemberRole.MEMBER,
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.rejectBandJoinRequest(BAND_MASTER_USER_ID, 'join-request-001')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('대기 중인 가입 요청이 아니면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        joinRequestForResponse: {
+          id: 'join-request-001',
+          bandId: 'band-001',
+          userId: INVITEE_USER_ID,
+          status: 'APPROVED',
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.rejectBandJoinRequest(BAND_MASTER_USER_ID, 'join-request-001')).rejects.toThrow(ConflictException);
+    });
+
+    it('검증과 거절을 같은 transaction client로 실행한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindBandJoinRequestForResponse(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandMemberByBandIdAndUserId(tx) {
+          capturedTransactions.push(tx);
+        },
+        onRejectBandJoinRequest(_joinRequestId, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await service.rejectBandJoinRequest(BAND_MASTER_USER_ID, 'join-request-001');
+
+      expect(capturedTransactions).toHaveLength(3);
+      expect(new Set(capturedTransactions).size).toBe(1);
+    });
+
+    it('외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onRejectBandJoinRequest(_joinRequestId, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.rejectBandJoinRequest(BAND_MASTER_USER_ID, 'join-request-001', externalTx as never);
+
+      expect(capturedTransactions).toEqual([externalTx]);
+    });
+  });
+
   describe('declineBandInvitation', () => {
     it('초대받은 사용자가 대기 중인 초대를 거절한다', async () => {
       let capturedRespondedAt: Date | undefined;
@@ -1709,6 +2006,124 @@ describe('BandsService', () => {
       );
 
       expect(capturedTransaction).toBe(externalTx);
+    });
+  });
+
+  describe('getBandJoinRequests', () => {
+    it('밴드 운영자가 밴드로 들어온 가입 요청 목록을 조회한다', async () => {
+      let capturedBandId: string | undefined;
+      let capturedQuery: GetBandJoinRequestsQuery | undefined;
+      const query: GetBandJoinRequestsQuery = {
+        where__join_request_status: 'PENDING',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      };
+      const repository = createBandsRepositoryStub({
+        onFindBandJoinRequests(bandId, inputQuery) {
+          capturedBandId = bandId;
+          capturedQuery = inputQuery;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.getBandJoinRequests(BAND_MASTER_USER_ID, 'band-001', query);
+
+      expect(capturedBandId).toBe('band-001');
+      expect(capturedQuery).toBe(query);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].requester.userId).toBe(INVITEE_USER_ID);
+      expect(result.items[0].joinRequestStatus).toBe('PENDING');
+      expect(result.meta.take).toBe(20);
+    });
+
+    it('밴드가 없거나 삭제되었으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        activeBand: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.getBandJoinRequests(BAND_MASTER_USER_ID, 'band-missing', {
+          where__join_request_status: 'PENDING',
+          order__created_at: 'desc',
+          order__id: 'desc',
+          take: 20,
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('밴드 운영 권한이 없으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        requesterBandMember: {
+          id: 'member-001',
+          userId: BAND_MASTER_USER_ID,
+          role: BandMemberRole.MEMBER,
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.getBandJoinRequests(BAND_MASTER_USER_ID, 'band-001', {
+          where__join_request_status: 'PENDING',
+          order__created_at: 'desc',
+          order__id: 'desc',
+          take: 20,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('검증과 목록 조회를 같은 transaction client로 실행한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindActiveBandById(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandMemberByBandIdAndUserId(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandJoinRequests(_bandId, _query, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await service.getBandJoinRequests(BAND_MASTER_USER_ID, 'band-001', {
+        where__join_request_status: 'PENDING',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      });
+
+      expect(capturedTransactions).toHaveLength(3);
+      expect(new Set(capturedTransactions).size).toBe(1);
+    });
+
+    it('외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindBandJoinRequests(_bandId, _query, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.getBandJoinRequests(
+        BAND_MASTER_USER_ID,
+        'band-001',
+        {
+          where__join_request_status: 'PENDING',
+          order__created_at: 'desc',
+          order__id: 'desc',
+          take: 20,
+        },
+        externalTx as never,
+      );
+
+      expect(capturedTransactions).toEqual([externalTx]);
     });
   });
 

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import type { PrismaService } from 'src/database/prisma';
 import { BandMemberRole } from 'src/generated/prisma';
 
@@ -14,6 +14,7 @@ const ROCK_GENRE_ID = '22222222-2222-4222-8222-222222222222';
 const JAZZ_GENRE_ID = '33333333-3333-4333-8333-333333333333';
 const INVITEE_USER_ID = '44444444-4444-4444-8444-444444444444';
 const MISSING_USER_ID = '55555555-5555-4555-8555-555555555555';
+const ADMIN_USER_ID = '66666666-6666-4666-8666-666666666666';
 
 function createBandsRepositoryStub(options?: {
   existingGenreIds?: string[];
@@ -32,11 +33,27 @@ function createBandsRepositoryStub(options?: {
   bandMemberForRoleUpdate?: {
     id: string;
     userId: string;
+    role: BandMemberRole;
   } | null;
+  requesterBandMember?: {
+    id: string;
+    userId: string;
+    role: BandMemberRole;
+  } | null;
+  inviteeBandMember?: {
+    id: string;
+    userId: string;
+    role: BandMemberRole;
+  } | null;
+  existingInvitation?: { id: string; status: 'PENDING' } | null;
+  bandBlacklist?: { id: string } | null;
   onCreateBand?: (input: CreateBandRepositoryInput, tx: unknown) => void;
+  onCreateBandInvitation?: (input: { bandId: string; inviterBandMemberId: string; inviteeUserId: string; message?: string }, tx: unknown) => void;
   onDeleteBand?: (bandId: string, deletedAt: Date, tx: unknown) => void;
+  onFindBandBlacklistByBandIdAndUserId?: (tx: unknown) => void;
   onFindActiveBandById?: (tx: unknown) => void;
   onFindBandForLeave?: (tx: unknown) => void;
+  onFindBandInvitationByBandIdAndInviteeUserId?: (tx: unknown) => void;
   onFindBandMemberByBandIdAndUserId?: (tx: unknown) => void;
   onFindBandMembers?: (bandId: string, query: GetBandMembersQuery, tx: unknown) => void;
   onFindExistingGenreIds?: (tx: unknown) => void;
@@ -72,6 +89,18 @@ function createBandsRepositoryStub(options?: {
             failed: [],
           },
         },
+      };
+    },
+    async createBandInvitation(input, tx) {
+      options?.onCreateBandInvitation?.(input, tx);
+
+      return {
+        invitationId: 'invitation-001',
+        bandId: input.bandId,
+        inviterUserId: BAND_MASTER_USER_ID,
+        inviteeUserId: input.inviteeUserId,
+        invitationStatus: 'PENDING',
+        createdAt: '2026-04-10T12:00:00.000Z',
       };
     },
     async deleteBand(bandId, deletedAt, tx) {
@@ -223,6 +252,18 @@ function createBandsRepositoryStub(options?: {
     async findBandMemberByBandIdAndUserId(_bandId, userId, tx) {
       options?.onFindBandMemberByBandIdAndUserId?.(tx);
 
+      if (userId === BAND_MASTER_USER_ID && options?.requesterBandMember !== undefined) {
+        return options.requesterBandMember;
+      }
+
+      if (userId === ADMIN_USER_ID && options?.requesterBandMember !== undefined) {
+        return options.requesterBandMember;
+      }
+
+      if (userId === INVITEE_USER_ID) {
+        return options?.inviteeBandMember ?? null;
+      }
+
       if (options?.bandMemberForRoleUpdate !== undefined) {
         return options.bandMemberForRoleUpdate;
       }
@@ -230,7 +271,18 @@ function createBandsRepositoryStub(options?: {
       return {
         id: 'band-member-001',
         userId,
+        role: userId === BAND_MASTER_USER_ID ? BandMemberRole.BM : BandMemberRole.MEMBER,
       };
+    },
+    async findBandInvitationByBandIdAndInviteeUserId(_bandId, _inviteeUserId, tx) {
+      options?.onFindBandInvitationByBandIdAndInviteeUserId?.(tx);
+
+      return options?.existingInvitation ?? null;
+    },
+    async findBandBlacklistByBandIdAndUserId(_bandId, _userId, tx) {
+      options?.onFindBandBlacklistByBandIdAndUserId?.(tx);
+
+      return options?.bandBlacklist ?? null;
     },
     async findExistingGenreIds(genreIds, tx) {
       options?.onFindExistingGenreIds?.(tx);
@@ -435,6 +487,226 @@ describe('BandsService', () => {
       expect(capturedTransactions[0]).toBe(externalTx);
       expect(capturedTransactions[1]).toBe(externalTx);
       expect(capturedTransactions[2]).toBe(externalTx);
+    });
+  });
+
+  describe('createBandInvitation', () => {
+    it('BM이 활성 사용자에게 밴드 초대를 보낸다', async () => {
+      let capturedInput: { bandId: string; inviterBandMemberId: string; inviteeUserId: string; message?: string } | undefined;
+      const repository = createBandsRepositoryStub({
+        existingUserIds: [INVITEE_USER_ID],
+        onCreateBandInvitation(input) {
+          capturedInput = input;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.createBandInvitation(BAND_MASTER_USER_ID, 'band-001', {
+        inviteeUserId: INVITEE_USER_ID,
+        message: '같이 밴드 하실래요?',
+      });
+
+      expect(capturedInput).toEqual({
+        bandId: 'band-001',
+        inviterBandMemberId: 'band-member-001',
+        inviteeUserId: INVITEE_USER_ID,
+        message: '같이 밴드 하실래요?',
+      });
+      expect(result.invitationStatus).toBe('PENDING');
+    });
+
+    it('ADMIN도 밴드 초대를 보낼 수 있다', async () => {
+      const repository = createBandsRepositoryStub({
+        existingUserIds: [INVITEE_USER_ID],
+        requesterBandMember: {
+          id: 'admin-member-001',
+          userId: ADMIN_USER_ID,
+          role: BandMemberRole.ADMIN,
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.createBandInvitation(ADMIN_USER_ID, 'band-001', {
+        inviteeUserId: INVITEE_USER_ID,
+      });
+
+      expect(result.inviteeUserId).toBe(INVITEE_USER_ID);
+    });
+
+    it('자기 자신에게 초대하면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.createBandInvitation(BAND_MASTER_USER_ID, 'band-001', {
+          inviteeUserId: BAND_MASTER_USER_ID,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('밴드가 없거나 삭제되었으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        activeBand: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.createBandInvitation(BAND_MASTER_USER_ID, 'band-missing', {
+          inviteeUserId: INVITEE_USER_ID,
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('요청자가 밴드 멤버가 아니면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        requesterBandMember: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.createBandInvitation(BAND_MASTER_USER_ID, 'band-001', {
+          inviteeUserId: INVITEE_USER_ID,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('일반 멤버가 초대하면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        requesterBandMember: {
+          id: 'member-001',
+          userId: BAND_MASTER_USER_ID,
+          role: BandMemberRole.MEMBER,
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.createBandInvitation(BAND_MASTER_USER_ID, 'band-001', {
+          inviteeUserId: INVITEE_USER_ID,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('존재하지 않거나 비활성화된 사용자를 초대하면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        existingUserIds: [],
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.createBandInvitation(BAND_MASTER_USER_ID, 'band-001', {
+          inviteeUserId: MISSING_USER_ID,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('이미 밴드 멤버인 사용자를 초대하면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        existingUserIds: [INVITEE_USER_ID],
+        inviteeBandMember: {
+          id: 'invitee-member-001',
+          userId: INVITEE_USER_ID,
+          role: BandMemberRole.MEMBER,
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.createBandInvitation(BAND_MASTER_USER_ID, 'band-001', {
+          inviteeUserId: INVITEE_USER_ID,
+        }),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('차단된 사용자를 초대하면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        existingUserIds: [INVITEE_USER_ID],
+        bandBlacklist: {
+          id: 'blacklist-001',
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.createBandInvitation(BAND_MASTER_USER_ID, 'band-001', {
+          inviteeUserId: INVITEE_USER_ID,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('기존 초대가 있으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        existingUserIds: [INVITEE_USER_ID],
+        existingInvitation: {
+          id: 'invitation-001',
+          status: 'PENDING',
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(
+        service.createBandInvitation(BAND_MASTER_USER_ID, 'band-001', {
+          inviteeUserId: INVITEE_USER_ID,
+        }),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('검증과 초대 생성을 같은 transaction client로 실행한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        existingUserIds: [INVITEE_USER_ID],
+        onFindActiveBandById(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandMemberByBandIdAndUserId(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindExistingUserIds(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandBlacklistByBandIdAndUserId(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandInvitationByBandIdAndInviteeUserId(tx) {
+          capturedTransactions.push(tx);
+        },
+        onCreateBandInvitation(_input, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await service.createBandInvitation(BAND_MASTER_USER_ID, 'band-001', {
+        inviteeUserId: INVITEE_USER_ID,
+      });
+
+      expect(capturedTransactions).toHaveLength(7);
+      expect(new Set(capturedTransactions).size).toBe(1);
+    });
+
+    it('외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        existingUserIds: [INVITEE_USER_ID],
+        onCreateBandInvitation(_input, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.createBandInvitation(
+        BAND_MASTER_USER_ID,
+        'band-001',
+        {
+          inviteeUserId: INVITEE_USER_ID,
+        },
+        externalTx as never,
+      );
+
+      expect(capturedTransactions).toEqual([externalTx]);
     });
   });
 

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -6,6 +6,7 @@ import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
 import type { GetReceivedBandInvitationsQuery } from './dto/get-received-band-invitations-query.dto';
 import type { GetSentBandInvitationsQuery } from './dto/get-sent-band-invitations-query.dto';
+import type { GetSentBandJoinRequestsQuery } from './dto/get-sent-band-join-requests-query.dto';
 import type { SearchBandsQuery } from './dto/search-bands-query.dto';
 import type { UpdateBandInput } from './dto/update-band.dto';
 import type { BandsRepository, CreateBandRepositoryInput } from './repositories/bands.repository';
@@ -86,6 +87,7 @@ function createBandsRepositoryStub(options?: {
   onFindExistingUserIds?: (tx: unknown) => void;
   onFindMyBands?: (userId: string, query: GetMyBandsQuery, tx: unknown) => void;
   onFindReceivedBandInvitations?: (userId: string, query: GetReceivedBandInvitationsQuery, tx: unknown) => void;
+  onFindSentBandJoinRequests?: (userId: string, query: GetSentBandJoinRequestsQuery, tx: unknown) => void;
   onFindSentBandInvitations?: (userId: string, query: GetSentBandInvitationsQuery, tx: unknown) => void;
   onLeaveBand?: (bandMemberId: string, tx: unknown) => void;
   onSearchBands?: (query: SearchBandsQuery, tx: unknown) => void;
@@ -347,6 +349,34 @@ function createBandsRepositoryStub(options?: {
           take: query.take,
           cursor: {
             id: 'invitation-001',
+          },
+          next: null,
+        },
+      };
+    },
+    async findSentBandJoinRequests(userId, query, tx) {
+      options?.onFindSentBandJoinRequests?.(userId, query, tx);
+
+      return {
+        items: [
+          {
+            joinRequestId: 'join-request-001',
+            band: {
+              bandId: 'band-001',
+              name: 'Rocking Stars',
+              description: '직장인 밴드',
+              visibility: true,
+            },
+            joinRequestStatus: query.where__join_request_status,
+            message: '기타로 합류하고 싶습니다!',
+            createdAt: '2026-04-30T10:00:00.000Z',
+          },
+        ],
+        meta: {
+          count: 1,
+          take: query.take,
+          cursor: {
+            id: 'join-request-001',
           },
           next: null,
         },
@@ -1616,6 +1646,61 @@ describe('BandsService', () => {
         BAND_MASTER_USER_ID,
         {
           where__invitation_status: 'PENDING',
+          order__created_at: 'desc',
+          order__id: 'desc',
+          take: 20,
+        },
+        externalTx as never,
+      );
+
+      expect(capturedTransaction).toBe(externalTx);
+    });
+  });
+
+  describe('getSentBandJoinRequests', () => {
+    it('인증 사용자가 직접 보낸 가입 요청 목록을 조회한다', async () => {
+      let capturedUserId: string | undefined;
+      let capturedQuery: GetSentBandJoinRequestsQuery | undefined;
+      const query: GetSentBandJoinRequestsQuery = {
+        where__join_request_status: 'PENDING',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      };
+      const repository = createBandsRepositoryStub({
+        onFindSentBandJoinRequests(userId, inputQuery) {
+          capturedUserId = userId;
+          capturedQuery = inputQuery;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.getSentBandJoinRequests(INVITEE_USER_ID, query);
+
+      expect(capturedUserId).toBe(INVITEE_USER_ID);
+      expect(capturedQuery).toBe(query);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].joinRequestStatus).toBe('PENDING');
+      expect(result.items[0].band.visibility).toBe(true);
+      expect(result.meta.take).toBe(20);
+    });
+
+    it('외부 transaction client를 repository로 전달한다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      let capturedTransaction: unknown;
+      const repository = createBandsRepositoryStub({
+        onFindSentBandJoinRequests(_userId, _query, tx) {
+          capturedTransaction = tx;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.getSentBandJoinRequests(
+        INVITEE_USER_ID,
+        {
+          where__join_request_status: 'PENDING',
           order__created_at: 'desc',
           order__id: 'desc',
           take: 20,

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -52,15 +52,22 @@ function createBandsRepositoryStub(options?: {
     inviteeUserId: string;
     status: 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'EXPIRED';
   } | null;
+  invitationForDelete?: {
+    id: string;
+    status: 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'EXPIRED';
+    inviterUserId: string;
+  } | null;
   bandBlacklist?: { id: string } | null;
   onAcceptBandInvitation?: (invitationId: string, bandId: string, userId: string, respondedAt: Date, tx: unknown) => void;
   onCreateBand?: (input: CreateBandRepositoryInput, tx: unknown) => void;
   onCreateBandInvitation?: (input: { bandId: string; inviterBandMemberId: string; inviteeUserId: string; message?: string }, tx: unknown) => void;
   onDeleteBand?: (bandId: string, deletedAt: Date, tx: unknown) => void;
+  onDeleteBandInvitation?: (invitationId: string, tx: unknown) => void;
   onDeclineBandInvitation?: (invitationId: string, respondedAt: Date, tx: unknown) => void;
   onFindBandBlacklistByBandIdAndUserId?: (tx: unknown) => void;
   onFindActiveBandById?: (tx: unknown) => void;
   onFindBandForLeave?: (tx: unknown) => void;
+  onFindBandInvitationForDelete?: (tx: unknown) => void;
   onFindBandInvitationForResponse?: (tx: unknown) => void;
   onFindBandInvitationByBandIdAndInviteeUserId?: (tx: unknown) => void;
   onFindBandMemberByBandIdAndUserId?: (tx: unknown) => void;
@@ -140,6 +147,13 @@ function createBandsRepositoryStub(options?: {
       return {
         bandId,
         deletedAt: deletedAt.toISOString(),
+      };
+    },
+    async deleteBandInvitation(invitationId, tx) {
+      options?.onDeleteBandInvitation?.(invitationId, tx);
+
+      return {
+        invitationId,
       };
     },
     async findActiveBandById(_bandId, tx) {
@@ -322,6 +336,19 @@ function createBandsRepositoryStub(options?: {
         bandId: 'band-001',
         inviteeUserId: INVITEE_USER_ID,
         status: 'PENDING',
+      };
+    },
+    async findBandInvitationForDelete(_invitationId, tx) {
+      options?.onFindBandInvitationForDelete?.(tx);
+
+      if (options?.invitationForDelete !== undefined) {
+        return options.invitationForDelete;
+      }
+
+      return {
+        id: 'invitation-001',
+        status: 'PENDING',
+        inviterUserId: BAND_MASTER_USER_ID,
       };
     },
     async findBandBlacklistByBandIdAndUserId(_bandId, _userId, tx) {
@@ -942,6 +969,89 @@ describe('BandsService', () => {
       const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
 
       await service.declineBandInvitation(INVITEE_USER_ID, 'invitation-001', externalTx as never);
+
+      expect(capturedTransactions).toEqual([externalTx]);
+    });
+  });
+
+  describe('deleteBandInvitation', () => {
+    it('초대를 보낸 사용자가 대기 중인 초대를 취소한다', async () => {
+      let capturedInvitationId: string | undefined;
+      const repository = createBandsRepositoryStub({
+        onDeleteBandInvitation(invitationId) {
+          capturedInvitationId = invitationId;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.deleteBandInvitation(BAND_MASTER_USER_ID, 'invitation-001');
+
+      expect(capturedInvitationId).toBe('invitation-001');
+      expect(result).toEqual({
+        invitationId: 'invitation-001',
+      });
+    });
+
+    it('초대가 없거나 밴드가 삭제되었으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        invitationForDelete: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.deleteBandInvitation(BAND_MASTER_USER_ID, 'invitation-missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('초대를 보낸 사용자가 아니면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.deleteBandInvitation(INVITEE_USER_ID, 'invitation-001')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('대기 중인 초대가 아니면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        invitationForDelete: {
+          id: 'invitation-001',
+          status: 'ACCEPTED',
+          inviterUserId: BAND_MASTER_USER_ID,
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.deleteBandInvitation(BAND_MASTER_USER_ID, 'invitation-001')).rejects.toThrow(ConflictException);
+    });
+
+    it('검증과 삭제를 같은 transaction client로 실행한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindBandInvitationForDelete(tx) {
+          capturedTransactions.push(tx);
+        },
+        onDeleteBandInvitation(_invitationId, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await service.deleteBandInvitation(BAND_MASTER_USER_ID, 'invitation-001');
+
+      expect(capturedTransactions).toHaveLength(2);
+      expect(new Set(capturedTransactions).size).toBe(1);
+    });
+
+    it('외부 transaction client가 있으면 새 transaction을 열지 않는다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onDeleteBandInvitation(_invitationId, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.deleteBandInvitation(BAND_MASTER_USER_ID, 'invitation-001', externalTx as never);
 
       expect(capturedTransactions).toEqual([externalTx]);
     });

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -5,6 +5,7 @@ import { BandMemberRole, type Prisma } from '../../generated/prisma';
 
 import type { CreateBandInput } from './dto/create-band.dto';
 import type { CreateBandInvitationInput } from './dto/create-band-invitation.dto';
+import type { CreateBandJoinRequestInput } from './dto/create-band-join-request.dto';
 import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
 import type { GetReceivedBandInvitationsQuery } from './dto/get-received-band-invitations-query.dto';
@@ -17,6 +18,7 @@ import type { AcceptBandInvitationResult } from './types/accept-band-invitation-
 import type { GetBandMembersResult } from './types/band-member-list.type';
 import type { SearchBandsResult } from './types/band-search-result.type';
 import type { CreateBandInvitationResult } from './types/create-band-invitation-result.type';
+import type { CreateBandJoinRequestResult } from './types/create-band-join-request-result.type';
 import type { CreateBandInvitationFailedItem, CreateBandResult } from './types/create-band-result.type';
 import type { DeclineBandInvitationResult } from './types/decline-band-invitation-result.type';
 import type { DeleteBandInvitationResult } from './types/delete-band-invitation-result.type';
@@ -148,6 +150,73 @@ export class BandsService {
           ...input,
           bandId,
           inviterBandMemberId: requesterMember.id,
+        },
+        client,
+      );
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
+  /**
+   * 인증 사용자는 공개 밴드에만 가입 요청을 보낼 수 있다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} bandId - 가입 요청을 보낼 밴드 ID
+   * @param {CreateBandJoinRequestInput} input - 검증이 끝난 가입 요청값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<CreateBandJoinRequestResult>} 생성된 가입 요청 정보
+   */
+  async createBandJoinRequest(
+    userId: string,
+    bandId: string,
+    input: CreateBandJoinRequestInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<CreateBandJoinRequestResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<CreateBandJoinRequestResult> => {
+      const band = await this.bandsRepository.findBandForJoinRequest(bandId, client);
+
+      if (band === null) {
+        throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
+      }
+
+      if (!band.visibility) {
+        throw new ForbiddenException('비공개 밴드에는 가입 요청을 보낼 수 없습니다.');
+      }
+
+      const member = await this.bandsRepository.findBandMemberByBandIdAndUserId(bandId, userId, client);
+
+      if (member !== null) {
+        throw new ConflictException('이미 밴드 멤버인 사용자입니다.');
+      }
+
+      const blacklist = await this.bandsRepository.findBandBlacklistByBandIdAndUserId(bandId, userId, client);
+
+      if (blacklist !== null) {
+        throw new ForbiddenException('밴드에서 차단된 사용자는 가입 요청을 보낼 수 없습니다.');
+      }
+
+      const existingInvitation = await this.bandsRepository.findBandInvitationByBandIdAndInviteeUserId(bandId, userId, client);
+
+      if (existingInvitation !== null) {
+        throw new ConflictException('이미 밴드 초대가 존재합니다.');
+      }
+
+      const existingJoinRequest = await this.bandsRepository.findBandJoinRequestByBandIdAndUserId(bandId, userId, client);
+
+      if (existingJoinRequest !== null) {
+        throw new ConflictException('이미 밴드 가입 요청이 존재합니다.');
+      }
+
+      return this.bandsRepository.createBandJoinRequest(
+        {
+          ...input,
+          bandId,
+          userId,
         },
         client,
       );

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -11,6 +11,7 @@ import type { SearchBandsQuery } from './dto/search-bands-query.dto';
 import type { UpdateBandInput } from './dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from './dto/update-band-member-role.dto';
 import { BANDS_REPOSITORY, type BandsRepository } from './repositories/bands.repository';
+import type { AcceptBandInvitationResult } from './types/accept-band-invitation-result.type';
 import type { GetBandMembersResult } from './types/band-member-list.type';
 import type { SearchBandsResult } from './types/band-search-result.type';
 import type { CreateBandInvitationResult } from './types/create-band-invitation-result.type';
@@ -144,6 +145,46 @@ export class BandsService {
         },
         client,
       );
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
+  /**
+   * 초대받은 사용자만 대기 중인 초대를 수락하고 일반 멤버로 가입할 수 있다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} invitationId - 수락할 초대 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<AcceptBandInvitationResult>} 초대 수락 결과
+   */
+  async acceptBandInvitation(userId: string, invitationId: string, tx?: Prisma.TransactionClient): Promise<AcceptBandInvitationResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<AcceptBandInvitationResult> => {
+      const invitation = await this.bandsRepository.findBandInvitationForAccept(invitationId, client);
+
+      if (invitation === null) {
+        throw new NotFoundException('요청한 밴드 초대를 찾을 수 없습니다.');
+      }
+
+      if (invitation.inviteeUserId !== userId) {
+        throw new ForbiddenException('밴드 초대 수락 권한이 없습니다.');
+      }
+
+      if (invitation.status !== 'PENDING') {
+        throw new ConflictException('대기 중인 밴드 초대만 수락할 수 있습니다.');
+      }
+
+      const existingMember = await this.bandsRepository.findBandMemberByBandIdAndUserId(invitation.bandId, userId, client);
+
+      if (existingMember !== null) {
+        throw new ConflictException('이미 밴드 멤버인 사용자입니다.');
+      }
+
+      return this.bandsRepository.acceptBandInvitation(invitation.id, invitation.bandId, userId, new Date(), client);
     };
 
     if (tx !== undefined) {

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -10,6 +10,7 @@ import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
 import type { GetReceivedBandInvitationsQuery } from './dto/get-received-band-invitations-query.dto';
 import type { GetSentBandInvitationsQuery } from './dto/get-sent-band-invitations-query.dto';
+import type { GetSentBandJoinRequestsQuery } from './dto/get-sent-band-join-requests-query.dto';
 import type { SearchBandsQuery } from './dto/search-bands-query.dto';
 import type { UpdateBandInput } from './dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from './dto/update-band-member-role.dto';
@@ -27,6 +28,7 @@ import type { LeaveBandResult } from './types/leave-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
 import type { GetReceivedBandInvitationsResult } from './types/received-band-invitation-list.type';
 import type { GetSentBandInvitationsResult } from './types/sent-band-invitation-list.type';
+import type { GetSentBandJoinRequestsResult } from './types/sent-band-join-request-list.type';
 import type { UpdateBandMemberRoleResult } from './types/update-band-member-role-result.type';
 import type { UpdateBandResult } from './types/update-band-result.type';
 
@@ -259,6 +261,22 @@ export class BandsService {
     tx?: Prisma.TransactionClient,
   ): Promise<GetSentBandInvitationsResult> {
     return this.bandsRepository.findSentBandInvitations(userId, query, tx);
+  }
+
+  /**
+   * 인증 사용자가 직접 보낸 가입 요청을 상태 필터와 커서 기준으로 조회한다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {GetSentBandJoinRequestsQuery} query - 상태 필터와 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetSentBandJoinRequestsResult>} 보낸 가입 요청 목록
+   */
+  async getSentBandJoinRequests(
+    userId: string,
+    query: GetSentBandJoinRequestsQuery,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetSentBandJoinRequestsResult> {
+    return this.bandsRepository.findSentBandJoinRequests(userId, query, tx);
   }
 
   /**

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -16,6 +16,7 @@ import type { GetBandMembersResult } from './types/band-member-list.type';
 import type { SearchBandsResult } from './types/band-search-result.type';
 import type { CreateBandInvitationResult } from './types/create-band-invitation-result.type';
 import type { CreateBandInvitationFailedItem, CreateBandResult } from './types/create-band-result.type';
+import type { DeclineBandInvitationResult } from './types/decline-band-invitation-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
 import type { LeaveBandResult } from './types/leave-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
@@ -164,7 +165,7 @@ export class BandsService {
    */
   async acceptBandInvitation(userId: string, invitationId: string, tx?: Prisma.TransactionClient): Promise<AcceptBandInvitationResult> {
     const run = async (client: Prisma.TransactionClient): Promise<AcceptBandInvitationResult> => {
-      const invitation = await this.bandsRepository.findBandInvitationForAccept(invitationId, client);
+      const invitation = await this.bandsRepository.findBandInvitationForResponse(invitationId, client);
 
       if (invitation === null) {
         throw new NotFoundException('요청한 밴드 초대를 찾을 수 없습니다.');
@@ -185,6 +186,40 @@ export class BandsService {
       }
 
       return this.bandsRepository.acceptBandInvitation(invitation.id, invitation.bandId, userId, new Date(), client);
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
+  /**
+   * 초대받은 사용자만 대기 중인 초대를 거절할 수 있다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} invitationId - 거절할 초대 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<DeclineBandInvitationResult>} 초대 거절 결과
+   */
+  async declineBandInvitation(userId: string, invitationId: string, tx?: Prisma.TransactionClient): Promise<DeclineBandInvitationResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<DeclineBandInvitationResult> => {
+      const invitation = await this.bandsRepository.findBandInvitationForResponse(invitationId, client);
+
+      if (invitation === null) {
+        throw new NotFoundException('요청한 밴드 초대를 찾을 수 없습니다.');
+      }
+
+      if (invitation.inviteeUserId !== userId) {
+        throw new ForbiddenException('밴드 초대 거절 권한이 없습니다.');
+      }
+
+      if (invitation.status !== 'PENDING') {
+        throw new ConflictException('대기 중인 밴드 초대만 거절할 수 있습니다.');
+      }
+
+      return this.bandsRepository.declineBandInvitation(invitation.id, new Date(), client);
     };
 
     if (tx !== undefined) {

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -6,6 +6,7 @@ import { BandMemberRole, type Prisma } from '../../generated/prisma';
 import type { CreateBandInput } from './dto/create-band.dto';
 import type { CreateBandInvitationInput } from './dto/create-band-invitation.dto';
 import type { CreateBandJoinRequestInput } from './dto/create-band-join-request.dto';
+import type { GetBandJoinRequestsQuery } from './dto/get-band-join-requests-query.dto';
 import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
 import type { GetReceivedBandInvitationsQuery } from './dto/get-received-band-invitations-query.dto';
@@ -16,6 +17,8 @@ import type { UpdateBandInput } from './dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from './dto/update-band-member-role.dto';
 import { BANDS_REPOSITORY, type BandsRepository } from './repositories/bands.repository';
 import type { AcceptBandInvitationResult } from './types/accept-band-invitation-result.type';
+import type { ApproveBandJoinRequestResult } from './types/approve-band-join-request-result.type';
+import type { GetBandJoinRequestsResult } from './types/band-join-request-list.type';
 import type { GetBandMembersResult } from './types/band-member-list.type';
 import type { SearchBandsResult } from './types/band-search-result.type';
 import type { CreateBandInvitationResult } from './types/create-band-invitation-result.type';
@@ -27,6 +30,7 @@ import type { DeleteBandResult } from './types/delete-band-result.type';
 import type { LeaveBandResult } from './types/leave-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
 import type { GetReceivedBandInvitationsResult } from './types/received-band-invitation-list.type';
+import type { RejectBandJoinRequestResult } from './types/reject-band-join-request-result.type';
 import type { GetSentBandInvitationsResult } from './types/sent-band-invitation-list.type';
 import type { GetSentBandJoinRequestsResult } from './types/sent-band-join-request-list.type';
 import type { UpdateBandMemberRoleResult } from './types/update-band-member-role-result.type';
@@ -277,6 +281,116 @@ export class BandsService {
     tx?: Prisma.TransactionClient,
   ): Promise<GetSentBandJoinRequestsResult> {
     return this.bandsRepository.findSentBandJoinRequests(userId, query, tx);
+  }
+
+  /**
+   * 밴드 운영 권한이 있는 멤버만 밴드로 들어온 가입 요청을 조회할 수 있다.
+   *
+   * @param {string} requesterUserId - 인증된 사용자 ID
+   * @param {string} bandId - 가입 요청을 조회할 밴드 ID
+   * @param {GetBandJoinRequestsQuery} query - 상태 필터와 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetBandJoinRequestsResult>} 밴드 가입 요청 목록
+   */
+  async getBandJoinRequests(
+    requesterUserId: string,
+    bandId: string,
+    query: GetBandJoinRequestsQuery,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetBandJoinRequestsResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<GetBandJoinRequestsResult> => {
+      const band = await this.bandsRepository.findActiveBandById(bandId, client);
+
+      if (band === null) {
+        throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
+      }
+
+      await this.validateBandJoinRequestManager(bandId, requesterUserId, client);
+
+      return this.bandsRepository.findBandJoinRequests(bandId, query, client);
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
+  /**
+   * 밴드 운영 권한이 있는 멤버만 대기 중인 가입 요청을 승인하고 일반 멤버로 가입시킬 수 있다.
+   *
+   * @param {string} requesterUserId - 인증된 사용자 ID
+   * @param {string} joinRequestId - 승인할 가입 요청 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<ApproveBandJoinRequestResult>} 가입 요청 승인 결과
+   */
+  async approveBandJoinRequest(requesterUserId: string, joinRequestId: string, tx?: Prisma.TransactionClient): Promise<ApproveBandJoinRequestResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<ApproveBandJoinRequestResult> => {
+      const joinRequest = await this.bandsRepository.findBandJoinRequestForResponse(joinRequestId, client);
+
+      if (joinRequest === null) {
+        throw new NotFoundException('요청한 밴드 가입 요청을 찾을 수 없습니다.');
+      }
+
+      await this.validateBandJoinRequestManager(joinRequest.bandId, requesterUserId, client);
+
+      if (joinRequest.status !== 'PENDING') {
+        throw new ConflictException('대기 중인 밴드 가입 요청만 승인할 수 있습니다.');
+      }
+
+      const existingMember = await this.bandsRepository.findBandMemberByBandIdAndUserId(joinRequest.bandId, joinRequest.userId, client);
+
+      if (existingMember !== null) {
+        throw new ConflictException('이미 밴드 멤버인 사용자입니다.');
+      }
+
+      const blacklist = await this.bandsRepository.findBandBlacklistByBandIdAndUserId(joinRequest.bandId, joinRequest.userId, client);
+
+      if (blacklist !== null) {
+        throw new ForbiddenException('밴드에서 차단된 사용자는 가입 요청을 승인할 수 없습니다.');
+      }
+
+      return this.bandsRepository.approveBandJoinRequest(joinRequest.id, joinRequest.bandId, joinRequest.userId, client);
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
+  /**
+   * 밴드 운영 권한이 있는 멤버만 대기 중인 가입 요청을 거절할 수 있다.
+   *
+   * @param {string} requesterUserId - 인증된 사용자 ID
+   * @param {string} joinRequestId - 거절할 가입 요청 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<RejectBandJoinRequestResult>} 가입 요청 거절 결과
+   */
+  async rejectBandJoinRequest(requesterUserId: string, joinRequestId: string, tx?: Prisma.TransactionClient): Promise<RejectBandJoinRequestResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<RejectBandJoinRequestResult> => {
+      const joinRequest = await this.bandsRepository.findBandJoinRequestForResponse(joinRequestId, client);
+
+      if (joinRequest === null) {
+        throw new NotFoundException('요청한 밴드 가입 요청을 찾을 수 없습니다.');
+      }
+
+      await this.validateBandJoinRequestManager(joinRequest.bandId, requesterUserId, client);
+
+      if (joinRequest.status !== 'PENDING') {
+        throw new ConflictException('대기 중인 밴드 가입 요청만 거절할 수 있습니다.');
+      }
+
+      return this.bandsRepository.rejectBandJoinRequest(joinRequest.id, client);
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
   }
 
   /**
@@ -581,6 +695,20 @@ export class BandsService {
     }
 
     return this.prisma.$transaction(run);
+  }
+
+  private async validateBandJoinRequestManager(bandId: string, userId: string, tx?: Prisma.TransactionClient): Promise<void> {
+    const member = await this.bandsRepository.findBandMemberByBandIdAndUserId(bandId, userId, tx);
+
+    if (member === null) {
+      throw new ForbiddenException('밴드 가입 요청 관리 권한이 없습니다.');
+    }
+
+    const canManageJoinRequest = member.role === BandMemberRole.BM || member.role === BandMemberRole.ADMIN;
+
+    if (!canManageJoinRequest) {
+      throw new ForbiddenException('밴드 가입 요청 관리 권한이 없습니다.');
+    }
   }
 
   private async validateGenres(genreIds: string[], tx: Prisma.TransactionClient): Promise<void> {

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -1,7 +1,8 @@
-import { BadRequestException, ConflictException, ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, ForbiddenException, Inject, Injectable, NotFoundException, Optional } from '@nestjs/common';
 
 import { PrismaService } from '../../database/prisma';
-import { BandMemberRole, type Prisma } from '../../generated/prisma';
+import { BandMemberRole, NotificationType, type Prisma } from '../../generated/prisma';
+import { NotificationsService } from '../notifications/notifications.service';
 
 import type { CreateBandInput } from './dto/create-band.dto';
 import type { CreateBandInvitationInput } from './dto/create-band-invitation.dto';
@@ -41,6 +42,7 @@ export class BandsService {
   constructor(
     @Inject(BANDS_REPOSITORY) private readonly bandsRepository: BandsRepository,
     private readonly prisma: PrismaService,
+    @Optional() private readonly notificationsService?: NotificationsService,
   ) {}
 
   /**
@@ -157,7 +159,7 @@ export class BandsService {
         throw new ConflictException('이미 밴드 가입 요청이 존재합니다.');
       }
 
-      return this.bandsRepository.createBandInvitation(
+      const result = await this.bandsRepository.createBandInvitation(
         {
           ...input,
           bandId,
@@ -165,6 +167,18 @@ export class BandsService {
         },
         client,
       );
+
+      await this.createBandNotification(
+        {
+          userId: input.inviteeUserId,
+          title: '밴드 초대가 도착했습니다.',
+          description: '새 밴드 초대가 도착했습니다.',
+          targetPath: '/invitations/received',
+        },
+        client,
+      );
+
+      return result;
     };
 
     if (tx !== undefined) {
@@ -224,7 +238,7 @@ export class BandsService {
         throw new ConflictException('이미 밴드 가입 요청이 존재합니다.');
       }
 
-      return this.bandsRepository.createBandJoinRequest(
+      const result = await this.bandsRepository.createBandJoinRequest(
         {
           ...input,
           bandId,
@@ -232,6 +246,21 @@ export class BandsService {
         },
         client,
       );
+
+      const managerUserIds = await this.bandsRepository.findBandManagerUserIdsByBandId(bandId, client);
+      const targetUserIds = managerUserIds.filter(managerUserId => managerUserId !== userId);
+
+      await this.createBandNotifications(
+        targetUserIds.map(managerUserId => ({
+          userId: managerUserId,
+          title: '밴드 가입 요청이 도착했습니다.',
+          description: '새 밴드 가입 요청이 도착했습니다.',
+          targetPath: `/bands/${bandId}/join-requests`,
+        })),
+        client,
+      );
+
+      return result;
     };
 
     if (tx !== undefined) {
@@ -357,7 +386,19 @@ export class BandsService {
         throw new ForbiddenException('밴드에서 차단된 사용자는 가입 요청을 승인할 수 없습니다.');
       }
 
-      return this.bandsRepository.approveBandJoinRequest(joinRequest.id, joinRequest.bandId, joinRequest.userId, client);
+      const result = await this.bandsRepository.approveBandJoinRequest(joinRequest.id, joinRequest.bandId, joinRequest.userId, client);
+
+      await this.createBandNotification(
+        {
+          userId: joinRequest.userId,
+          title: '밴드 가입 요청이 승인되었습니다.',
+          description: '보낸 밴드 가입 요청이 승인되었습니다.',
+          targetPath: `/bands/${joinRequest.bandId}`,
+        },
+        client,
+      );
+
+      return result;
     };
 
     if (tx !== undefined) {
@@ -389,7 +430,19 @@ export class BandsService {
         throw new ConflictException('대기 중인 밴드 가입 요청만 거절할 수 있습니다.');
       }
 
-      return this.bandsRepository.rejectBandJoinRequest(joinRequest.id, client);
+      const result = await this.bandsRepository.rejectBandJoinRequest(joinRequest.id, client);
+
+      await this.createBandNotification(
+        {
+          userId: joinRequest.userId,
+          title: '밴드 가입 요청이 거절되었습니다.',
+          description: '보낸 밴드 가입 요청이 거절되었습니다.',
+          targetPath: '/join-requests/sent',
+        },
+        client,
+      );
+
+      return result;
     };
 
     if (tx !== undefined) {
@@ -429,7 +482,19 @@ export class BandsService {
         throw new ConflictException('이미 밴드 멤버인 사용자입니다.');
       }
 
-      return this.bandsRepository.acceptBandInvitation(invitation.id, invitation.bandId, userId, new Date(), client);
+      const result = await this.bandsRepository.acceptBandInvitation(invitation.id, invitation.bandId, userId, new Date(), client);
+
+      await this.createBandNotification(
+        {
+          userId: invitation.inviterUserId,
+          title: '밴드 초대를 수락했습니다.',
+          description: '보낸 밴드 초대가 수락되었습니다.',
+          targetPath: `/bands/${invitation.bandId}/members`,
+        },
+        client,
+      );
+
+      return result;
     };
 
     if (tx !== undefined) {
@@ -463,7 +528,19 @@ export class BandsService {
         throw new ConflictException('대기 중인 밴드 초대만 거절할 수 있습니다.');
       }
 
-      return this.bandsRepository.declineBandInvitation(invitation.id, new Date(), client);
+      const result = await this.bandsRepository.declineBandInvitation(invitation.id, new Date(), client);
+
+      await this.createBandNotification(
+        {
+          userId: invitation.inviterUserId,
+          title: '밴드 초대를 거절했습니다.',
+          description: '보낸 밴드 초대가 거절되었습니다.',
+          targetPath: '/invitations/sent',
+        },
+        client,
+      );
+
+      return result;
     };
 
     if (tx !== undefined) {
@@ -715,6 +792,56 @@ export class BandsService {
     if (!canManageJoinRequest) {
       throw new ForbiddenException('밴드 가입 요청 관리 권한이 없습니다.');
     }
+  }
+
+  private async createBandNotification(
+    input: {
+      userId: string;
+      title: string;
+      description: string;
+      targetPath: string;
+    },
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    if (this.notificationsService === undefined) {
+      return;
+    }
+
+    await this.notificationsService.createNotification(
+      {
+        userId: input.userId,
+        type: NotificationType.INVITE,
+        title: input.title,
+        description: input.description,
+        targetPath: input.targetPath,
+      },
+      tx,
+    );
+  }
+
+  private async createBandNotifications(
+    inputs: Array<{
+      userId: string;
+      title: string;
+      description: string;
+      targetPath: string;
+    }>,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    if (this.notificationsService === undefined || inputs.length === 0) {
+      return;
+    }
+
+    await this.notificationsService.createManyNotifications(
+      inputs.map(input => ({
+        userId: input.userId,
+        type: NotificationType.INVITE,
+        title: input.title,
+        description: input.description,
+        targetPath: input.targetPath,
+      })),
+      tx,
+    );
   }
 
   private async validateGenres(genreIds: string[], tx: Prisma.TransactionClient): Promise<void> {

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -17,6 +17,7 @@ import type { SearchBandsResult } from './types/band-search-result.type';
 import type { CreateBandInvitationResult } from './types/create-band-invitation-result.type';
 import type { CreateBandInvitationFailedItem, CreateBandResult } from './types/create-band-result.type';
 import type { DeclineBandInvitationResult } from './types/decline-band-invitation-result.type';
+import type { DeleteBandInvitationResult } from './types/delete-band-invitation-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
 import type { LeaveBandResult } from './types/leave-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
@@ -220,6 +221,40 @@ export class BandsService {
       }
 
       return this.bandsRepository.declineBandInvitation(invitation.id, new Date(), client);
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
+  /**
+   * 초대를 보낸 사용자만 대기 중인 초대를 취소할 수 있다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} invitationId - 취소할 초대 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<DeleteBandInvitationResult>} 초대 취소 결과
+   */
+  async deleteBandInvitation(userId: string, invitationId: string, tx?: Prisma.TransactionClient): Promise<DeleteBandInvitationResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<DeleteBandInvitationResult> => {
+      const invitation = await this.bandsRepository.findBandInvitationForDelete(invitationId, client);
+
+      if (invitation === null) {
+        throw new NotFoundException('요청한 밴드 초대를 찾을 수 없습니다.');
+      }
+
+      if (invitation.inviterUserId !== userId) {
+        throw new ForbiddenException('밴드 초대 취소 권한이 없습니다.');
+      }
+
+      if (invitation.status !== 'PENDING') {
+        throw new ConflictException('대기 중인 밴드 초대만 취소할 수 있습니다.');
+      }
+
+      return this.bandsRepository.deleteBandInvitation(invitation.id, client);
     };
 
     if (tx !== undefined) {

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -8,6 +8,7 @@ import type { CreateBandInvitationInput } from './dto/create-band-invitation.dto
 import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
 import type { GetReceivedBandInvitationsQuery } from './dto/get-received-band-invitations-query.dto';
+import type { GetSentBandInvitationsQuery } from './dto/get-sent-band-invitations-query.dto';
 import type { SearchBandsQuery } from './dto/search-bands-query.dto';
 import type { UpdateBandInput } from './dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from './dto/update-band-member-role.dto';
@@ -23,6 +24,7 @@ import type { DeleteBandResult } from './types/delete-band-result.type';
 import type { LeaveBandResult } from './types/leave-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
 import type { GetReceivedBandInvitationsResult } from './types/received-band-invitation-list.type';
+import type { GetSentBandInvitationsResult } from './types/sent-band-invitation-list.type';
 import type { UpdateBandMemberRoleResult } from './types/update-band-member-role-result.type';
 import type { UpdateBandResult } from './types/update-band-result.type';
 
@@ -172,6 +174,22 @@ export class BandsService {
     tx?: Prisma.TransactionClient,
   ): Promise<GetReceivedBandInvitationsResult> {
     return this.bandsRepository.findReceivedBandInvitations(userId, query, tx);
+  }
+
+  /**
+   * 인증 사용자가 직접 보낸 초대를 상태 필터와 커서 기준으로 조회한다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {GetSentBandInvitationsQuery} query - 상태 필터와 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetSentBandInvitationsResult>} 보낸 초대 목록
+   */
+  async getSentBandInvitations(
+    userId: string,
+    query: GetSentBandInvitationsQuery,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetSentBandInvitationsResult> {
+    return this.bandsRepository.findSentBandInvitations(userId, query, tx);
   }
 
   /**

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -151,6 +151,12 @@ export class BandsService {
         throw new ConflictException('이미 밴드 초대가 존재합니다.');
       }
 
+      const existingJoinRequest = await this.bandsRepository.findBandJoinRequestByBandIdAndUserId(bandId, input.inviteeUserId, client);
+
+      if (existingJoinRequest !== null) {
+        throw new ConflictException('이미 밴드 가입 요청이 존재합니다.');
+      }
+
       return this.bandsRepository.createBandInvitation(
         {
           ...input,

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -1,9 +1,10 @@
-import { BadRequestException, ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 
 import { PrismaService } from '../../database/prisma';
 import { BandMemberRole, type Prisma } from '../../generated/prisma';
 
 import type { CreateBandInput } from './dto/create-band.dto';
+import type { CreateBandInvitationInput } from './dto/create-band-invitation.dto';
 import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
 import type { SearchBandsQuery } from './dto/search-bands-query.dto';
@@ -12,6 +13,7 @@ import type { UpdateBandMemberRoleInput } from './dto/update-band-member-role.dt
 import { BANDS_REPOSITORY, type BandsRepository } from './repositories/bands.repository';
 import type { GetBandMembersResult } from './types/band-member-list.type';
 import type { SearchBandsResult } from './types/band-search-result.type';
+import type { CreateBandInvitationResult } from './types/create-band-invitation-result.type';
 import type { CreateBandInvitationFailedItem, CreateBandResult } from './types/create-band-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
 import type { LeaveBandResult } from './types/leave-band-result.type';
@@ -63,6 +65,85 @@ export class BandsService {
           },
         },
       };
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
+  /**
+   * 밴드 운영 권한이 있는 멤버만 아직 가입하지 않은 활성 사용자에게 초대를 보낼 수 있다.
+   *
+   * @param {string} requesterUserId - 인증된 사용자 ID
+   * @param {string} bandId - 초대를 보낼 밴드 ID
+   * @param {CreateBandInvitationInput} input - 검증이 끝난 초대 요청값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<CreateBandInvitationResult>} 생성된 초대 정보
+   */
+  async createBandInvitation(
+    requesterUserId: string,
+    bandId: string,
+    input: CreateBandInvitationInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<CreateBandInvitationResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<CreateBandInvitationResult> => {
+      if (requesterUserId === input.inviteeUserId) {
+        throw new BadRequestException('자기 자신에게 밴드 초대를 보낼 수 없습니다.');
+      }
+
+      const band = await this.bandsRepository.findActiveBandById(bandId, client);
+
+      if (band === null) {
+        throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
+      }
+
+      const requesterMember = await this.bandsRepository.findBandMemberByBandIdAndUserId(bandId, requesterUserId, client);
+
+      if (requesterMember === null) {
+        throw new ForbiddenException('밴드 초대 권한이 없습니다.');
+      }
+
+      const canInvite = requesterMember.role === BandMemberRole.BM || requesterMember.role === BandMemberRole.ADMIN;
+
+      if (!canInvite) {
+        throw new ForbiddenException('밴드 초대 권한이 없습니다.');
+      }
+
+      const existingInviteeUserIds = await this.bandsRepository.findExistingUserIds([input.inviteeUserId], client);
+
+      if (existingInviteeUserIds.length === 0) {
+        throw new BadRequestException('존재하지 않거나 비활성화된 사용자입니다.');
+      }
+
+      const inviteeMember = await this.bandsRepository.findBandMemberByBandIdAndUserId(bandId, input.inviteeUserId, client);
+
+      if (inviteeMember !== null) {
+        throw new ConflictException('이미 밴드 멤버인 사용자입니다.');
+      }
+
+      const blacklist = await this.bandsRepository.findBandBlacklistByBandIdAndUserId(bandId, input.inviteeUserId, client);
+
+      if (blacklist !== null) {
+        throw new ForbiddenException('밴드에서 차단된 사용자는 초대할 수 없습니다.');
+      }
+
+      const existingInvitation = await this.bandsRepository.findBandInvitationByBandIdAndInviteeUserId(bandId, input.inviteeUserId, client);
+
+      if (existingInvitation !== null) {
+        throw new ConflictException('이미 밴드 초대가 존재합니다.');
+      }
+
+      return this.bandsRepository.createBandInvitation(
+        {
+          ...input,
+          bandId,
+          inviterBandMemberId: requesterMember.id,
+        },
+        client,
+      );
     };
 
     if (tx !== undefined) {

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -7,6 +7,7 @@ import type { CreateBandInput } from './dto/create-band.dto';
 import type { CreateBandInvitationInput } from './dto/create-band-invitation.dto';
 import type { GetBandMembersQuery } from './dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from './dto/get-my-bands-query.dto';
+import type { GetReceivedBandInvitationsQuery } from './dto/get-received-band-invitations-query.dto';
 import type { SearchBandsQuery } from './dto/search-bands-query.dto';
 import type { UpdateBandInput } from './dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from './dto/update-band-member-role.dto';
@@ -21,6 +22,7 @@ import type { DeleteBandInvitationResult } from './types/delete-band-invitation-
 import type { DeleteBandResult } from './types/delete-band-result.type';
 import type { LeaveBandResult } from './types/leave-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
+import type { GetReceivedBandInvitationsResult } from './types/received-band-invitation-list.type';
 import type { UpdateBandMemberRoleResult } from './types/update-band-member-role-result.type';
 import type { UpdateBandResult } from './types/update-band-result.type';
 
@@ -154,6 +156,22 @@ export class BandsService {
     }
 
     return this.prisma.$transaction(run);
+  }
+
+  /**
+   * 인증 사용자가 받은 초대를 상태 필터와 커서 기준으로 조회한다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {GetReceivedBandInvitationsQuery} query - 상태 필터와 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetReceivedBandInvitationsResult>} 받은 초대 목록
+   */
+  async getReceivedBandInvitations(
+    userId: string,
+    query: GetReceivedBandInvitationsQuery,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetReceivedBandInvitationsResult> {
+    return this.bandsRepository.findReceivedBandInvitations(userId, query, tx);
   }
 
   /**

--- a/backend/src/modules/bands/dto/create-band-invitation.dto.ts
+++ b/backend/src/modules/bands/dto/create-band-invitation.dto.ts
@@ -1,0 +1,26 @@
+import { Transform } from 'class-transformer';
+import { IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
+
+import { normalizeOptionalStringValue } from '../../../common/validation/transform.util';
+import { lengthValidationMessage } from '../../../common/validation-message/length-validation.message';
+import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
+import { uuidValidationMessage } from '../../../common/validation-message/uuid-validation.message';
+
+export class CreateBandInvitationBodyDto {
+  @IsUUID('4', {
+    message: uuidValidationMessage,
+  })
+  inviteeUserId!: string;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({
+    message: stringValidationMessage,
+  })
+  @MaxLength(500, {
+    message: lengthValidationMessage,
+  })
+  message?: string;
+}
+
+export type CreateBandInvitationInput = CreateBandInvitationBodyDto;

--- a/backend/src/modules/bands/dto/create-band-join-request.dto.ts
+++ b/backend/src/modules/bands/dto/create-band-join-request.dto.ts
@@ -1,0 +1,20 @@
+import { Transform } from 'class-transformer';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+import { normalizeOptionalStringValue } from '../../../common/validation/transform.util';
+import { lengthValidationMessage } from '../../../common/validation-message/length-validation.message';
+import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
+
+export class CreateBandJoinRequestBodyDto {
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({
+    message: stringValidationMessage,
+  })
+  @MaxLength(500, {
+    message: lengthValidationMessage,
+  })
+  message?: string;
+}
+
+export type CreateBandJoinRequestInput = CreateBandJoinRequestBodyDto;

--- a/backend/src/modules/bands/dto/get-band-join-requests-query.dto.ts
+++ b/backend/src/modules/bands/dto/get-band-join-requests-query.dto.ts
@@ -1,0 +1,42 @@
+import { Transform } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsUUID, Min } from 'class-validator';
+import { normalizeOptionalStringValue, parseOptionalPositiveIntegerValue } from 'src/common/validation/transform.util';
+import { enumValidationMessage } from 'src/common/validation-message/enum-validation.message';
+import { intValidationMessage } from 'src/common/validation-message/int-validation.message';
+import { minValidationMessage } from 'src/common/validation-message/min-validation.message';
+import { uuidValidationMessage } from 'src/common/validation-message/uuid-validation.message';
+
+import { JoinRequestStatus } from '../../../generated/prisma';
+
+const ORDER_DIRECTIONS = ['asc', 'desc'] as const;
+export type BandJoinRequestOrderDirection = (typeof ORDER_DIRECTIONS)[number];
+
+export const BAND_JOIN_REQUEST_STATUSES = Object.values(JoinRequestStatus);
+export type BandJoinRequestStatus = JoinRequestStatus;
+
+export class GetBandJoinRequestsQueryDto {
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsEnum(BAND_JOIN_REQUEST_STATUSES, { message: enumValidationMessage })
+  where__join_request_status: BandJoinRequestStatus = JoinRequestStatus.PENDING;
+
+  @IsOptional()
+  @IsEnum(ORDER_DIRECTIONS, { message: enumValidationMessage })
+  order__created_at: BandJoinRequestOrderDirection = 'desc';
+
+  @IsOptional()
+  @IsEnum(ORDER_DIRECTIONS, { message: enumValidationMessage })
+  order__id: BandJoinRequestOrderDirection = 'desc';
+
+  @Transform(parseOptionalPositiveIntegerValue)
+  @IsInt({ message: intValidationMessage })
+  @Min(1, { message: minValidationMessage })
+  take: number = 20;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  cursor__id?: string;
+}
+
+export type GetBandJoinRequestsQuery = GetBandJoinRequestsQueryDto;

--- a/backend/src/modules/bands/dto/get-received-band-invitations-query.dto.ts
+++ b/backend/src/modules/bands/dto/get-received-band-invitations-query.dto.ts
@@ -1,0 +1,42 @@
+import { Transform } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsUUID, Min } from 'class-validator';
+import { normalizeOptionalStringValue, parseOptionalPositiveIntegerValue } from 'src/common/validation/transform.util';
+import { enumValidationMessage } from 'src/common/validation-message/enum-validation.message';
+import { intValidationMessage } from 'src/common/validation-message/int-validation.message';
+import { minValidationMessage } from 'src/common/validation-message/min-validation.message';
+import { uuidValidationMessage } from 'src/common/validation-message/uuid-validation.message';
+
+import { BandInvitationStatus } from '../../../generated/prisma';
+
+const ORDER_DIRECTIONS = ['asc', 'desc'] as const;
+export type ReceivedBandInvitationOrderDirection = (typeof ORDER_DIRECTIONS)[number];
+
+export const RECEIVED_BAND_INVITATION_STATUSES = Object.values(BandInvitationStatus);
+export type ReceivedBandInvitationStatus = BandInvitationStatus;
+
+export class GetReceivedBandInvitationsQueryDto {
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsEnum(RECEIVED_BAND_INVITATION_STATUSES, { message: enumValidationMessage })
+  where__invitation_status: ReceivedBandInvitationStatus = BandInvitationStatus.PENDING;
+
+  @IsOptional()
+  @IsEnum(ORDER_DIRECTIONS, { message: enumValidationMessage })
+  order__created_at: ReceivedBandInvitationOrderDirection = 'desc';
+
+  @IsOptional()
+  @IsEnum(ORDER_DIRECTIONS, { message: enumValidationMessage })
+  order__id: ReceivedBandInvitationOrderDirection = 'desc';
+
+  @Transform(parseOptionalPositiveIntegerValue)
+  @IsInt({ message: intValidationMessage })
+  @Min(1, { message: minValidationMessage })
+  take: number = 20;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  cursor__id?: string;
+}
+
+export type GetReceivedBandInvitationsQuery = GetReceivedBandInvitationsQueryDto;

--- a/backend/src/modules/bands/dto/get-sent-band-invitations-query.dto.ts
+++ b/backend/src/modules/bands/dto/get-sent-band-invitations-query.dto.ts
@@ -1,0 +1,42 @@
+import { Transform } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsUUID, Min } from 'class-validator';
+import { normalizeOptionalStringValue, parseOptionalPositiveIntegerValue } from 'src/common/validation/transform.util';
+import { enumValidationMessage } from 'src/common/validation-message/enum-validation.message';
+import { intValidationMessage } from 'src/common/validation-message/int-validation.message';
+import { minValidationMessage } from 'src/common/validation-message/min-validation.message';
+import { uuidValidationMessage } from 'src/common/validation-message/uuid-validation.message';
+
+import { BandInvitationStatus } from '../../../generated/prisma';
+
+const ORDER_DIRECTIONS = ['asc', 'desc'] as const;
+export type SentBandInvitationOrderDirection = (typeof ORDER_DIRECTIONS)[number];
+
+export const SENT_BAND_INVITATION_STATUSES = Object.values(BandInvitationStatus);
+export type SentBandInvitationStatus = BandInvitationStatus;
+
+export class GetSentBandInvitationsQueryDto {
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsEnum(SENT_BAND_INVITATION_STATUSES, { message: enumValidationMessage })
+  where__invitation_status: SentBandInvitationStatus = BandInvitationStatus.PENDING;
+
+  @IsOptional()
+  @IsEnum(ORDER_DIRECTIONS, { message: enumValidationMessage })
+  order__created_at: SentBandInvitationOrderDirection = 'desc';
+
+  @IsOptional()
+  @IsEnum(ORDER_DIRECTIONS, { message: enumValidationMessage })
+  order__id: SentBandInvitationOrderDirection = 'desc';
+
+  @Transform(parseOptionalPositiveIntegerValue)
+  @IsInt({ message: intValidationMessage })
+  @Min(1, { message: minValidationMessage })
+  take: number = 20;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  cursor__id?: string;
+}
+
+export type GetSentBandInvitationsQuery = GetSentBandInvitationsQueryDto;

--- a/backend/src/modules/bands/dto/get-sent-band-join-requests-query.dto.ts
+++ b/backend/src/modules/bands/dto/get-sent-band-join-requests-query.dto.ts
@@ -1,0 +1,42 @@
+import { Transform } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsUUID, Min } from 'class-validator';
+import { normalizeOptionalStringValue, parseOptionalPositiveIntegerValue } from 'src/common/validation/transform.util';
+import { enumValidationMessage } from 'src/common/validation-message/enum-validation.message';
+import { intValidationMessage } from 'src/common/validation-message/int-validation.message';
+import { minValidationMessage } from 'src/common/validation-message/min-validation.message';
+import { uuidValidationMessage } from 'src/common/validation-message/uuid-validation.message';
+
+import { JoinRequestStatus } from '../../../generated/prisma';
+
+const ORDER_DIRECTIONS = ['asc', 'desc'] as const;
+export type SentBandJoinRequestOrderDirection = (typeof ORDER_DIRECTIONS)[number];
+
+export const SENT_BAND_JOIN_REQUEST_STATUSES = Object.values(JoinRequestStatus);
+export type SentBandJoinRequestStatus = JoinRequestStatus;
+
+export class GetSentBandJoinRequestsQueryDto {
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsEnum(SENT_BAND_JOIN_REQUEST_STATUSES, { message: enumValidationMessage })
+  where__join_request_status: SentBandJoinRequestStatus = JoinRequestStatus.PENDING;
+
+  @IsOptional()
+  @IsEnum(ORDER_DIRECTIONS, { message: enumValidationMessage })
+  order__created_at: SentBandJoinRequestOrderDirection = 'desc';
+
+  @IsOptional()
+  @IsEnum(ORDER_DIRECTIONS, { message: enumValidationMessage })
+  order__id: SentBandJoinRequestOrderDirection = 'desc';
+
+  @Transform(parseOptionalPositiveIntegerValue)
+  @IsInt({ message: intValidationMessage })
+  @Min(1, { message: minValidationMessage })
+  take: number = 20;
+
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  cursor__id?: string;
+}
+
+export type GetSentBandJoinRequestsQuery = GetSentBandJoinRequestsQueryDto;

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
@@ -24,6 +24,165 @@ function createPrismaMock() {
 }
 
 describe('BandsPrismaRepository', () => {
+  describe('findSentBandInvitations', () => {
+    it('보낸 초대 목록을 상태와 커서 기준으로 조회하고 매핑한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.findMany.mockResolvedValue([
+        {
+          id: 'invitation-001',
+          message: '같이 합주해요!',
+          status: 'PENDING',
+          createdAt: mockCreatedAt,
+          respondedAt: null,
+          band: {
+            id: 'band-001',
+            name: 'Rocking Stars',
+            description: '직장인 밴드',
+            _count: {
+              members: 5,
+            },
+          },
+          inviteeUserId: 'user-002',
+          inviteeUser: {
+            profile: {
+              nickname: 'Choi',
+              avatarUrl: 'https://cdn.example.com/avatar.png',
+            },
+          },
+        },
+      ]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findSentBandInvitations('user-001', {
+        where__invitation_status: 'PENDING',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      });
+
+      expect(prisma.bandInvitation.findMany).toHaveBeenCalledWith({
+        where: {
+          status: 'PENDING',
+          band: {
+            deletedAt: null,
+          },
+          inviterBandMember: {
+            userId: 'user-001',
+          },
+          inviteeUser: {
+            deletedAt: null,
+          },
+        },
+        include: {
+          band: {
+            include: {
+              _count: {
+                select: {
+                  members: true,
+                },
+              },
+            },
+          },
+          inviteeUser: {
+            include: {
+              profile: {
+                select: {
+                  nickname: true,
+                  avatarUrl: true,
+                },
+              },
+            },
+          },
+        },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: 21,
+      });
+      expect(result.items).toEqual([
+        {
+          invitationId: 'invitation-001',
+          band: {
+            bandId: 'band-001',
+            name: 'Rocking Stars',
+            description: '직장인 밴드',
+            memberCount: 5,
+          },
+          invitee: {
+            userId: 'user-002',
+            nickname: 'Choi',
+            avatarUrl: 'https://cdn.example.com/avatar.png',
+          },
+          invitationStatus: 'PENDING',
+          message: '같이 합주해요!',
+          createdAt: '2026-04-10T12:00:00.000Z',
+          respondedAt: null,
+        },
+      ]);
+      expect(result.meta).toEqual({
+        count: 1,
+        take: 20,
+        cursor: {
+          id: 'invitation-001',
+        },
+        next: null,
+      });
+    });
+
+    it('cursor__id가 있으면 Prisma cursor와 skip을 사용한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.findMany.mockResolvedValue([]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      await repository.findSentBandInvitations('user-001', {
+        where__invitation_status: 'DECLINED',
+        order__created_at: 'asc',
+        order__id: 'asc',
+        take: 10,
+        cursor__id: 'invitation-001',
+      });
+
+      expect(prisma.bandInvitation.findMany).toHaveBeenCalledWith(expect.objectContaining({ cursor: { id: 'invitation-001' }, skip: 1 }));
+    });
+
+    it('take보다 많이 조회되면 next cursor를 반환한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.findMany.mockResolvedValue([
+        {
+          id: 'invitation-001',
+          message: null,
+          status: 'PENDING',
+          createdAt: mockCreatedAt,
+          respondedAt: null,
+          band: { id: 'band-001', name: 'Rocking Stars', description: null, _count: { members: 5 } },
+          inviteeUserId: 'user-002',
+          inviteeUser: { profile: null },
+        },
+        {
+          id: 'invitation-002',
+          message: null,
+          status: 'PENDING',
+          createdAt: new Date('2026-04-09T12:00:00.000Z'),
+          respondedAt: null,
+          band: { id: 'band-002', name: 'Jazz Stars', description: null, _count: { members: 4 } },
+          inviteeUserId: 'user-003',
+          inviteeUser: { profile: null },
+        },
+      ]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findSentBandInvitations('user-001', {
+        where__invitation_status: 'PENDING',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 1,
+      });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.meta.next).toEqual({
+        id: 'invitation-001',
+      });
+    });
+  });
+
   describe('findReceivedBandInvitations', () => {
     it('받은 초대 목록을 상태와 커서 기준으로 조회하고 매핑한다', async () => {
       const prisma = createPrismaMock();

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
@@ -9,17 +9,93 @@ function createPrismaMock() {
     bandInvitation: {
       create: jest.fn(),
       findFirst: jest.fn(),
+      update: jest.fn(),
     },
     bandBlacklist: {
       findFirst: jest.fn(),
     },
     bandMember: {
+      create: jest.fn(),
       findFirst: jest.fn(),
     },
   };
 }
 
 describe('BandsPrismaRepository', () => {
+  describe('acceptBandInvitation', () => {
+    it('초대 상태를 수락으로 변경하고 밴드 멤버를 생성한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.update.mockResolvedValue({
+        id: 'invitation-001',
+        bandId: 'band-001',
+        inviteeUserId: 'user-002',
+        status: 'ACCEPTED',
+      });
+      prisma.bandMember.create.mockResolvedValue({
+        joinedAt: new Date('2026-04-30T10:00:00.000Z'),
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+      const respondedAt = new Date('2026-04-30T09:59:00.000Z');
+
+      const result = await repository.acceptBandInvitation('invitation-001', 'band-001', 'user-002', respondedAt);
+
+      expect(prisma.bandInvitation.update).toHaveBeenCalledWith({
+        where: {
+          id: 'invitation-001',
+        },
+        data: {
+          status: 'ACCEPTED',
+          respondedAt,
+        },
+        select: {
+          id: true,
+          bandId: true,
+          inviteeUserId: true,
+          status: true,
+        },
+      });
+      expect(prisma.bandMember.create).toHaveBeenCalledWith({
+        data: {
+          bandId: 'band-001',
+          userId: 'user-002',
+          role: 'MEMBER',
+        },
+        select: {
+          joinedAt: true,
+        },
+      });
+      expect(result).toEqual({
+        invitationId: 'invitation-001',
+        bandId: 'band-001',
+        userId: 'user-002',
+        invitationStatus: 'ACCEPTED',
+        joinedAt: '2026-04-30T10:00:00.000Z',
+      });
+    });
+
+    it('tx가 있으면 tx client로 수락 처리한다', async () => {
+      const prisma = createPrismaMock();
+      const tx = createPrismaMock();
+      tx.bandInvitation.update.mockResolvedValue({
+        id: 'invitation-001',
+        bandId: 'band-001',
+        inviteeUserId: 'user-002',
+        status: 'ACCEPTED',
+      });
+      tx.bandMember.create.mockResolvedValue({
+        joinedAt: new Date('2026-04-30T10:00:00.000Z'),
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      await repository.acceptBandInvitation('invitation-001', 'band-001', 'user-002', new Date('2026-04-30T09:59:00.000Z'), tx as never);
+
+      expect(tx.bandInvitation.update).toHaveBeenCalled();
+      expect(tx.bandMember.create).toHaveBeenCalled();
+      expect(prisma.bandInvitation.update).not.toHaveBeenCalled();
+      expect(prisma.bandMember.create).not.toHaveBeenCalled();
+    });
+  });
+
   describe('createBandInvitation', () => {
     it('밴드 초대를 생성하고 응답 필드로 매핑한다', async () => {
       const prisma = createPrismaMock();
@@ -124,6 +200,42 @@ describe('BandsPrismaRepository', () => {
       });
       expect(result).toEqual({
         id: 'invitation-001',
+        status: 'PENDING',
+      });
+    });
+  });
+
+  describe('findBandInvitationForAccept', () => {
+    it('삭제되지 않은 밴드의 초대만 조회한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.findFirst.mockResolvedValue({
+        id: 'invitation-001',
+        bandId: 'band-001',
+        inviteeUserId: 'user-002',
+        status: 'PENDING',
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findBandInvitationForAccept('invitation-001');
+
+      expect(prisma.bandInvitation.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 'invitation-001',
+          band: {
+            deletedAt: null,
+          },
+        },
+        select: {
+          id: true,
+          bandId: true,
+          inviteeUserId: true,
+          status: true,
+        },
+      });
+      expect(result).toEqual({
+        id: 'invitation-001',
+        bandId: 'band-001',
+        inviteeUserId: 'user-002',
         status: 'PENDING',
       });
     });

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
@@ -13,6 +13,13 @@ function createPrismaMock() {
       findFirst: jest.fn(),
       update: jest.fn(),
     },
+    bandJoinRequest: {
+      create: jest.fn(),
+      findFirst: jest.fn(),
+    },
+    band: {
+      findFirst: jest.fn(),
+    },
     bandBlacklist: {
       findFirst: jest.fn(),
     },
@@ -576,6 +583,128 @@ describe('BandsPrismaRepository', () => {
 
       expect(tx.bandInvitation.create).toHaveBeenCalled();
       expect(prisma.bandInvitation.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createBandJoinRequest', () => {
+    it('밴드 가입 요청을 생성하고 응답 필드로 매핑한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandJoinRequest.create.mockResolvedValue({
+        id: 'join-request-001',
+        bandId: 'band-001',
+        userId: 'user-002',
+        status: 'PENDING',
+        createdAt: mockCreatedAt,
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.createBandJoinRequest({
+        bandId: 'band-001',
+        userId: 'user-002',
+        message: '기타로 합류하고 싶습니다!',
+      });
+
+      expect(prisma.bandJoinRequest.create).toHaveBeenCalledWith({
+        data: {
+          bandId: 'band-001',
+          userId: 'user-002',
+          message: '기타로 합류하고 싶습니다!',
+        },
+        select: {
+          id: true,
+          bandId: true,
+          userId: true,
+          status: true,
+          createdAt: true,
+        },
+      });
+      expect(result).toEqual({
+        joinRequestId: 'join-request-001',
+        bandId: 'band-001',
+        userId: 'user-002',
+        joinRequestStatus: 'PENDING',
+        createdAt: '2026-04-10T12:00:00.000Z',
+      });
+    });
+
+    it('tx가 있으면 tx client로 가입 요청을 생성한다', async () => {
+      const prisma = createPrismaMock();
+      const tx = createPrismaMock();
+      tx.bandJoinRequest.create.mockResolvedValue({
+        id: 'join-request-001',
+        bandId: 'band-001',
+        userId: 'user-002',
+        status: 'PENDING',
+        createdAt: mockCreatedAt,
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      await repository.createBandJoinRequest(
+        {
+          bandId: 'band-001',
+          userId: 'user-002',
+        },
+        tx as never,
+      );
+
+      expect(tx.bandJoinRequest.create).toHaveBeenCalled();
+      expect(prisma.bandJoinRequest.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findBandForJoinRequest', () => {
+    it('삭제되지 않은 밴드의 공개 상태를 조회한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.band.findFirst.mockResolvedValue({
+        id: 'band-001',
+        visibility: true,
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findBandForJoinRequest('band-001');
+
+      expect(prisma.band.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 'band-001',
+          deletedAt: null,
+        },
+        select: {
+          id: true,
+          visibility: true,
+        },
+      });
+      expect(result).toEqual({
+        id: 'band-001',
+        visibility: true,
+      });
+    });
+  });
+
+  describe('findBandJoinRequestByBandIdAndUserId', () => {
+    it('밴드와 사용자 기준으로 기존 가입 요청을 조회한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandJoinRequest.findFirst.mockResolvedValue({
+        id: 'join-request-001',
+        status: 'PENDING',
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findBandJoinRequestByBandIdAndUserId('band-001', 'user-002');
+
+      expect(prisma.bandJoinRequest.findFirst).toHaveBeenCalledWith({
+        where: {
+          bandId: 'band-001',
+          userId: 'user-002',
+        },
+        select: {
+          id: true,
+          status: true,
+        },
+      });
+      expect(result).toEqual({
+        id: 'join-request-001',
+        status: 'PENDING',
+      });
     });
   });
 

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
@@ -9,6 +9,7 @@ function createPrismaMock() {
     bandInvitation: {
       create: jest.fn(),
       delete: jest.fn(),
+      findMany: jest.fn(),
       findFirst: jest.fn(),
       update: jest.fn(),
     },
@@ -23,6 +24,156 @@ function createPrismaMock() {
 }
 
 describe('BandsPrismaRepository', () => {
+  describe('findReceivedBandInvitations', () => {
+    it('받은 초대 목록을 상태와 커서 기준으로 조회하고 매핑한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.findMany.mockResolvedValue([
+        {
+          id: 'invitation-001',
+          message: '같이 밴드 하실래요?',
+          status: 'PENDING',
+          createdAt: mockCreatedAt,
+          band: {
+            id: 'band-001',
+            name: 'Rocking Stars',
+            description: '직장인 밴드',
+          },
+          inviterBandMember: {
+            userId: 'user-001',
+            user: {
+              profile: {
+                nickname: 'Jun',
+              },
+            },
+          },
+        },
+      ]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findReceivedBandInvitations('user-002', {
+        where__invitation_status: 'PENDING',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      });
+
+      expect(prisma.bandInvitation.findMany).toHaveBeenCalledWith({
+        where: {
+          inviteeUserId: 'user-002',
+          status: 'PENDING',
+          band: {
+            deletedAt: null,
+          },
+          inviterBandMember: {
+            user: {
+              deletedAt: null,
+            },
+          },
+        },
+        include: {
+          band: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+            },
+          },
+          inviterBandMember: {
+            include: {
+              user: {
+                include: {
+                  profile: {
+                    select: {
+                      nickname: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: 21,
+      });
+      expect(result.items).toEqual([
+        {
+          invitationId: 'invitation-001',
+          band: {
+            bandId: 'band-001',
+            name: 'Rocking Stars',
+            description: '직장인 밴드',
+          },
+          inviter: {
+            userId: 'user-001',
+            nickname: 'Jun',
+          },
+          message: '같이 밴드 하실래요?',
+          invitationStatus: 'PENDING',
+          createdAt: '2026-04-10T12:00:00.000Z',
+        },
+      ]);
+      expect(result.meta).toEqual({
+        count: 1,
+        take: 20,
+        cursor: {
+          id: 'invitation-001',
+        },
+        next: null,
+      });
+    });
+
+    it('cursor__id가 있으면 Prisma cursor와 skip을 사용한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.findMany.mockResolvedValue([]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      await repository.findReceivedBandInvitations('user-002', {
+        where__invitation_status: 'DECLINED',
+        order__created_at: 'asc',
+        order__id: 'asc',
+        take: 10,
+        cursor__id: 'invitation-001',
+      });
+
+      expect(prisma.bandInvitation.findMany).toHaveBeenCalledWith(expect.objectContaining({ cursor: { id: 'invitation-001' }, skip: 1 }));
+    });
+
+    it('take보다 많이 조회되면 next cursor를 반환한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.findMany.mockResolvedValue([
+        {
+          id: 'invitation-001',
+          message: null,
+          status: 'PENDING',
+          createdAt: mockCreatedAt,
+          band: { id: 'band-001', name: 'Rocking Stars', description: null },
+          inviterBandMember: { userId: 'user-001', user: { profile: null } },
+        },
+        {
+          id: 'invitation-002',
+          message: null,
+          status: 'PENDING',
+          createdAt: new Date('2026-04-09T12:00:00.000Z'),
+          band: { id: 'band-002', name: 'Jazz Stars', description: null },
+          inviterBandMember: { userId: 'user-003', user: { profile: null } },
+        },
+      ]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findReceivedBandInvitations('user-002', {
+        where__invitation_status: 'PENDING',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 1,
+      });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.meta.next).toEqual({
+        id: 'invitation-001',
+      });
+    });
+  });
+
   describe('acceptBandInvitation', () => {
     it('초대 상태를 수락으로 변경하고 밴드 멤버를 생성한다', async () => {
       const prisma = createPrismaMock();

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
@@ -8,6 +8,7 @@ function createPrismaMock() {
   return {
     bandInvitation: {
       create: jest.fn(),
+      delete: jest.fn(),
       findFirst: jest.fn(),
       update: jest.fn(),
     },
@@ -156,6 +157,37 @@ describe('BandsPrismaRepository', () => {
     });
   });
 
+  describe('deleteBandInvitation', () => {
+    it('초대 row를 삭제하고 invitationId를 반환한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.delete.mockResolvedValue(undefined);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.deleteBandInvitation('invitation-001');
+
+      expect(prisma.bandInvitation.delete).toHaveBeenCalledWith({
+        where: {
+          id: 'invitation-001',
+        },
+      });
+      expect(result).toEqual({
+        invitationId: 'invitation-001',
+      });
+    });
+
+    it('tx가 있으면 tx client로 초대를 삭제한다', async () => {
+      const prisma = createPrismaMock();
+      const tx = createPrismaMock();
+      tx.bandInvitation.delete.mockResolvedValue(undefined);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      await repository.deleteBandInvitation('invitation-001', tx as never);
+
+      expect(tx.bandInvitation.delete).toHaveBeenCalled();
+      expect(prisma.bandInvitation.delete).not.toHaveBeenCalled();
+    });
+  });
+
   describe('createBandInvitation', () => {
     it('밴드 초대를 생성하고 응답 필드로 매핑한다', async () => {
       const prisma = createPrismaMock();
@@ -298,6 +330,55 @@ describe('BandsPrismaRepository', () => {
         inviteeUserId: 'user-002',
         status: 'PENDING',
       });
+    });
+  });
+
+  describe('findBandInvitationForDelete', () => {
+    it('삭제되지 않은 밴드의 초대와 초대한 사용자 ID를 조회한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.findFirst.mockResolvedValue({
+        id: 'invitation-001',
+        status: 'PENDING',
+        inviterBandMember: {
+          userId: 'user-001',
+        },
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findBandInvitationForDelete('invitation-001');
+
+      expect(prisma.bandInvitation.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 'invitation-001',
+          band: {
+            deletedAt: null,
+          },
+        },
+        select: {
+          id: true,
+          status: true,
+          inviterBandMember: {
+            select: {
+              userId: true,
+            },
+          },
+        },
+      });
+      expect(result).toEqual({
+        id: 'invitation-001',
+        status: 'PENDING',
+        inviterUserId: 'user-001',
+      });
+    });
+
+    it('초대가 없으면 null을 반환한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.findFirst.mockResolvedValue(null);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findBandInvitationForDelete('invitation-missing');
+
+      expect(result).toBeNull();
     });
   });
 

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
@@ -27,6 +27,7 @@ function createPrismaMock() {
     },
     bandMember: {
       create: jest.fn(),
+      findMany: jest.fn(),
       findFirst: jest.fn(),
     },
   };
@@ -592,37 +593,17 @@ describe('BandsPrismaRepository', () => {
   });
 
   describe('acceptBandInvitation', () => {
-    it('초대 상태를 수락으로 변경하고 밴드 멤버를 생성한다', async () => {
+    it('밴드 멤버를 생성하고 수락한 초대 row를 삭제한다', async () => {
       const prisma = createPrismaMock();
-      prisma.bandInvitation.update.mockResolvedValue({
-        id: 'invitation-001',
-        bandId: 'band-001',
-        inviteeUserId: 'user-002',
-        status: 'ACCEPTED',
-      });
       prisma.bandMember.create.mockResolvedValue({
         joinedAt: new Date('2026-04-30T10:00:00.000Z'),
       });
+      prisma.bandInvitation.delete.mockResolvedValue(undefined);
       const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
       const respondedAt = new Date('2026-04-30T09:59:00.000Z');
 
       const result = await repository.acceptBandInvitation('invitation-001', 'band-001', 'user-002', respondedAt);
 
-      expect(prisma.bandInvitation.update).toHaveBeenCalledWith({
-        where: {
-          id: 'invitation-001',
-        },
-        data: {
-          status: 'ACCEPTED',
-          respondedAt,
-        },
-        select: {
-          id: true,
-          bandId: true,
-          inviteeUserId: true,
-          status: true,
-        },
-      });
       expect(prisma.bandMember.create).toHaveBeenCalledWith({
         data: {
           bandId: 'band-001',
@@ -633,6 +614,12 @@ describe('BandsPrismaRepository', () => {
           joinedAt: true,
         },
       });
+      expect(prisma.bandInvitation.delete).toHaveBeenCalledWith({
+        where: {
+          id: 'invitation-001',
+        },
+      });
+      expect(prisma.bandInvitation.update).not.toHaveBeenCalled();
       expect(result).toEqual({
         invitationId: 'invitation-001',
         bandId: 'band-001',
@@ -645,23 +632,18 @@ describe('BandsPrismaRepository', () => {
     it('tx가 있으면 tx client로 수락 처리한다', async () => {
       const prisma = createPrismaMock();
       const tx = createPrismaMock();
-      tx.bandInvitation.update.mockResolvedValue({
-        id: 'invitation-001',
-        bandId: 'band-001',
-        inviteeUserId: 'user-002',
-        status: 'ACCEPTED',
-      });
       tx.bandMember.create.mockResolvedValue({
         joinedAt: new Date('2026-04-30T10:00:00.000Z'),
       });
+      tx.bandInvitation.delete.mockResolvedValue(undefined);
       const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
 
       await repository.acceptBandInvitation('invitation-001', 'band-001', 'user-002', new Date('2026-04-30T09:59:00.000Z'), tx as never);
 
-      expect(tx.bandInvitation.update).toHaveBeenCalled();
       expect(tx.bandMember.create).toHaveBeenCalled();
-      expect(prisma.bandInvitation.update).not.toHaveBeenCalled();
+      expect(tx.bandInvitation.delete).toHaveBeenCalled();
       expect(prisma.bandMember.create).not.toHaveBeenCalled();
+      expect(prisma.bandInvitation.delete).not.toHaveBeenCalled();
     });
   });
 
@@ -1157,6 +1139,9 @@ describe('BandsPrismaRepository', () => {
       prisma.bandInvitation.findFirst.mockResolvedValue({
         id: 'invitation-001',
         bandId: 'band-001',
+        inviterBandMember: {
+          userId: 'user-001',
+        },
         inviteeUserId: 'user-002',
         status: 'PENDING',
       });
@@ -1176,11 +1161,17 @@ describe('BandsPrismaRepository', () => {
           bandId: true,
           inviteeUserId: true,
           status: true,
+          inviterBandMember: {
+            select: {
+              userId: true,
+            },
+          },
         },
       });
       expect(result).toEqual({
         id: 'invitation-001',
         bandId: 'band-001',
+        inviterUserId: 'user-001',
         inviteeUserId: 'user-002',
         status: 'PENDING',
       });

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
@@ -96,6 +96,66 @@ describe('BandsPrismaRepository', () => {
     });
   });
 
+  describe('declineBandInvitation', () => {
+    it('초대 상태를 거절로 변경하고 응답 시각을 반환한다', async () => {
+      const prisma = createPrismaMock();
+      const respondedAt = new Date('2026-04-30T10:00:00.000Z');
+      prisma.bandInvitation.update.mockResolvedValue({
+        id: 'invitation-001',
+        bandId: 'band-001',
+        inviteeUserId: 'user-002',
+        status: 'DECLINED',
+        respondedAt,
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.declineBandInvitation('invitation-001', respondedAt);
+
+      expect(prisma.bandInvitation.update).toHaveBeenCalledWith({
+        where: {
+          id: 'invitation-001',
+        },
+        data: {
+          status: 'DECLINED',
+          respondedAt,
+        },
+        select: {
+          id: true,
+          bandId: true,
+          inviteeUserId: true,
+          status: true,
+          respondedAt: true,
+        },
+      });
+      expect(result).toEqual({
+        invitationId: 'invitation-001',
+        bandId: 'band-001',
+        userId: 'user-002',
+        invitationStatus: 'DECLINED',
+        respondedAt: '2026-04-30T10:00:00.000Z',
+      });
+    });
+
+    it('tx가 있으면 tx client로 거절 처리한다', async () => {
+      const prisma = createPrismaMock();
+      const tx = createPrismaMock();
+      const respondedAt = new Date('2026-04-30T10:00:00.000Z');
+      tx.bandInvitation.update.mockResolvedValue({
+        id: 'invitation-001',
+        bandId: 'band-001',
+        inviteeUserId: 'user-002',
+        status: 'DECLINED',
+        respondedAt,
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      await repository.declineBandInvitation('invitation-001', respondedAt, tx as never);
+
+      expect(tx.bandInvitation.update).toHaveBeenCalled();
+      expect(prisma.bandInvitation.update).not.toHaveBeenCalled();
+    });
+  });
+
   describe('createBandInvitation', () => {
     it('밴드 초대를 생성하고 응답 필드로 매핑한다', async () => {
       const prisma = createPrismaMock();
@@ -205,7 +265,7 @@ describe('BandsPrismaRepository', () => {
     });
   });
 
-  describe('findBandInvitationForAccept', () => {
+  describe('findBandInvitationForResponse', () => {
     it('삭제되지 않은 밴드의 초대만 조회한다', async () => {
       const prisma = createPrismaMock();
       prisma.bandInvitation.findFirst.mockResolvedValue({
@@ -216,7 +276,7 @@ describe('BandsPrismaRepository', () => {
       });
       const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
 
-      const result = await repository.findBandInvitationForAccept('invitation-001');
+      const result = await repository.findBandInvitationForResponse('invitation-001');
 
       expect(prisma.bandInvitation.findFirst).toHaveBeenCalledWith({
         where: {

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
@@ -1,0 +1,187 @@
+import type { PrismaService } from '../../../database/prisma';
+
+import { BandsPrismaRepository } from './bands.prisma-repository';
+
+const mockCreatedAt = new Date('2026-04-10T12:00:00.000Z');
+
+function createPrismaMock() {
+  return {
+    bandInvitation: {
+      create: jest.fn(),
+      findFirst: jest.fn(),
+    },
+    bandBlacklist: {
+      findFirst: jest.fn(),
+    },
+    bandMember: {
+      findFirst: jest.fn(),
+    },
+  };
+}
+
+describe('BandsPrismaRepository', () => {
+  describe('createBandInvitation', () => {
+    it('밴드 초대를 생성하고 응답 필드로 매핑한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.create.mockResolvedValue({
+        id: 'invitation-001',
+        bandId: 'band-001',
+        inviteeUserId: 'user-002',
+        status: 'PENDING',
+        createdAt: mockCreatedAt,
+        inviterBandMember: {
+          userId: 'user-001',
+        },
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.createBandInvitation({
+        bandId: 'band-001',
+        inviterBandMemberId: 'band-member-001',
+        inviteeUserId: 'user-002',
+        message: '같이 밴드 하실래요?',
+      });
+
+      expect(prisma.bandInvitation.create).toHaveBeenCalledWith({
+        data: {
+          bandId: 'band-001',
+          inviterBandMemberId: 'band-member-001',
+          inviteeUserId: 'user-002',
+          message: '같이 밴드 하실래요?',
+        },
+        select: {
+          id: true,
+          bandId: true,
+          inviteeUserId: true,
+          status: true,
+          createdAt: true,
+          inviterBandMember: {
+            select: {
+              userId: true,
+            },
+          },
+        },
+      });
+      expect(result).toEqual({
+        invitationId: 'invitation-001',
+        bandId: 'band-001',
+        inviterUserId: 'user-001',
+        inviteeUserId: 'user-002',
+        invitationStatus: 'PENDING',
+        createdAt: '2026-04-10T12:00:00.000Z',
+      });
+    });
+
+    it('tx가 있으면 tx client로 초대를 생성한다', async () => {
+      const prisma = createPrismaMock();
+      const tx = createPrismaMock();
+      tx.bandInvitation.create.mockResolvedValue({
+        id: 'invitation-001',
+        bandId: 'band-001',
+        inviteeUserId: 'user-002',
+        status: 'PENDING',
+        createdAt: mockCreatedAt,
+        inviterBandMember: {
+          userId: 'user-001',
+        },
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      await repository.createBandInvitation(
+        {
+          bandId: 'band-001',
+          inviterBandMemberId: 'band-member-001',
+          inviteeUserId: 'user-002',
+        },
+        tx as never,
+      );
+
+      expect(tx.bandInvitation.create).toHaveBeenCalled();
+      expect(prisma.bandInvitation.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findBandInvitationByBandIdAndInviteeUserId', () => {
+    it('밴드와 초대 대상 기준으로 기존 초대를 조회한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.findFirst.mockResolvedValue({
+        id: 'invitation-001',
+        status: 'PENDING',
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findBandInvitationByBandIdAndInviteeUserId('band-001', 'user-002');
+
+      expect(prisma.bandInvitation.findFirst).toHaveBeenCalledWith({
+        where: {
+          bandId: 'band-001',
+          inviteeUserId: 'user-002',
+        },
+        select: {
+          id: true,
+          status: true,
+        },
+      });
+      expect(result).toEqual({
+        id: 'invitation-001',
+        status: 'PENDING',
+      });
+    });
+  });
+
+  describe('findBandBlacklistByBandIdAndUserId', () => {
+    it('밴드와 사용자 기준으로 차단 정보를 조회한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandBlacklist.findFirst.mockResolvedValue({
+        id: 'blacklist-001',
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findBandBlacklistByBandIdAndUserId('band-001', 'user-002');
+
+      expect(prisma.bandBlacklist.findFirst).toHaveBeenCalledWith({
+        where: {
+          bandId: 'band-001',
+          userId: 'user-002',
+        },
+        select: {
+          id: true,
+        },
+      });
+      expect(result).toEqual({
+        id: 'blacklist-001',
+      });
+    });
+  });
+
+  describe('findBandMemberByBandIdAndUserId', () => {
+    it('밴드 멤버 역할까지 조회한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandMember.findFirst.mockResolvedValue({
+        id: 'band-member-001',
+        userId: 'user-001',
+        role: 'BM',
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findBandMemberByBandIdAndUserId('band-001', 'user-001');
+
+      expect(prisma.bandMember.findFirst).toHaveBeenCalledWith({
+        where: {
+          bandId: 'band-001',
+          userId: 'user-001',
+        },
+        select: {
+          id: true,
+          userId: true,
+          role: true,
+        },
+      });
+      expect(result).toEqual({
+        id: 'band-member-001',
+        userId: 'user-001',
+        role: 'BM',
+      });
+    });
+  });
+});

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
@@ -17,6 +17,7 @@ function createPrismaMock() {
       create: jest.fn(),
       findMany: jest.fn(),
       findFirst: jest.fn(),
+      update: jest.fn(),
     },
     band: {
       findFirst: jest.fn(),
@@ -312,6 +313,134 @@ describe('BandsPrismaRepository', () => {
     });
   });
 
+  describe('findBandJoinRequests', () => {
+    it('밴드로 들어온 가입 요청 목록을 상태와 커서 기준으로 조회하고 매핑한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandJoinRequest.findMany.mockResolvedValue([
+        {
+          id: 'join-request-001',
+          userId: 'user-002',
+          message: '보컬로 참여하고 싶습니다.',
+          status: 'PENDING',
+          createdAt: mockCreatedAt,
+          user: {
+            profile: {
+              nickname: 'Choi',
+              avatarUrl: 'https://cdn.example.com/avatar.png',
+            },
+          },
+        },
+      ]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findBandJoinRequests('band-001', {
+        where__join_request_status: 'PENDING',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      });
+
+      expect(prisma.bandJoinRequest.findMany).toHaveBeenCalledWith({
+        where: {
+          bandId: 'band-001',
+          status: 'PENDING',
+          band: {
+            deletedAt: null,
+          },
+          user: {
+            deletedAt: null,
+          },
+        },
+        include: {
+          user: {
+            include: {
+              profile: {
+                select: {
+                  nickname: true,
+                  avatarUrl: true,
+                },
+              },
+            },
+          },
+        },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: 21,
+      });
+      expect(result.items).toEqual([
+        {
+          joinRequestId: 'join-request-001',
+          requester: {
+            userId: 'user-002',
+            nickname: 'Choi',
+            avatarUrl: 'https://cdn.example.com/avatar.png',
+          },
+          joinRequestStatus: 'PENDING',
+          message: '보컬로 참여하고 싶습니다.',
+          createdAt: '2026-04-10T12:00:00.000Z',
+        },
+      ]);
+      expect(result.meta).toEqual({
+        count: 1,
+        take: 20,
+        cursor: {
+          id: 'join-request-001',
+        },
+        next: null,
+      });
+    });
+
+    it('cursor__id가 있으면 Prisma cursor와 skip을 사용한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandJoinRequest.findMany.mockResolvedValue([]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      await repository.findBandJoinRequests('band-001', {
+        where__join_request_status: 'APPROVED',
+        order__created_at: 'asc',
+        order__id: 'asc',
+        take: 10,
+        cursor__id: 'join-request-001',
+      });
+
+      expect(prisma.bandJoinRequest.findMany).toHaveBeenCalledWith(expect.objectContaining({ cursor: { id: 'join-request-001' }, skip: 1 }));
+    });
+
+    it('take보다 많이 조회되면 next cursor를 반환한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandJoinRequest.findMany.mockResolvedValue([
+        {
+          id: 'join-request-001',
+          userId: 'user-002',
+          message: null,
+          status: 'PENDING',
+          createdAt: mockCreatedAt,
+          user: { profile: null },
+        },
+        {
+          id: 'join-request-002',
+          userId: 'user-003',
+          message: null,
+          status: 'PENDING',
+          createdAt: new Date('2026-04-09T12:00:00.000Z'),
+          user: { profile: null },
+        },
+      ]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findBandJoinRequests('band-001', {
+        where__join_request_status: 'PENDING',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 1,
+      });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.meta.next).toEqual({
+        id: 'join-request-001',
+      });
+    });
+  });
+
   describe('findReceivedBandInvitations', () => {
     it('받은 초대 목록을 상태와 커서 기준으로 조회하고 매핑한다', async () => {
       const prisma = createPrismaMock();
@@ -536,6 +665,78 @@ describe('BandsPrismaRepository', () => {
     });
   });
 
+  describe('approveBandJoinRequest', () => {
+    it('가입 요청 상태를 승인으로 변경하고 밴드 멤버를 생성한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandJoinRequest.update.mockResolvedValue({
+        id: 'join-request-001',
+        bandId: 'band-001',
+        userId: 'user-002',
+        status: 'APPROVED',
+      });
+      prisma.bandMember.create.mockResolvedValue({
+        joinedAt: new Date('2026-04-30T10:00:00.000Z'),
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.approveBandJoinRequest('join-request-001', 'band-001', 'user-002');
+
+      expect(prisma.bandJoinRequest.update).toHaveBeenCalledWith({
+        where: {
+          id: 'join-request-001',
+        },
+        data: {
+          status: 'APPROVED',
+        },
+        select: {
+          id: true,
+          bandId: true,
+          userId: true,
+          status: true,
+        },
+      });
+      expect(prisma.bandMember.create).toHaveBeenCalledWith({
+        data: {
+          bandId: 'band-001',
+          userId: 'user-002',
+          role: 'MEMBER',
+        },
+        select: {
+          joinedAt: true,
+        },
+      });
+      expect(result).toEqual({
+        joinRequestId: 'join-request-001',
+        bandId: 'band-001',
+        userId: 'user-002',
+        joinRequestStatus: 'APPROVED',
+        joinedAt: '2026-04-30T10:00:00.000Z',
+      });
+    });
+
+    it('tx가 있으면 tx client로 승인 처리한다', async () => {
+      const prisma = createPrismaMock();
+      const tx = createPrismaMock();
+      tx.bandJoinRequest.update.mockResolvedValue({
+        id: 'join-request-001',
+        bandId: 'band-001',
+        userId: 'user-002',
+        status: 'APPROVED',
+      });
+      tx.bandMember.create.mockResolvedValue({
+        joinedAt: new Date('2026-04-30T10:00:00.000Z'),
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      await repository.approveBandJoinRequest('join-request-001', 'band-001', 'user-002', tx as never);
+
+      expect(tx.bandJoinRequest.update).toHaveBeenCalled();
+      expect(tx.bandMember.create).toHaveBeenCalled();
+      expect(prisma.bandJoinRequest.update).not.toHaveBeenCalled();
+      expect(prisma.bandMember.create).not.toHaveBeenCalled();
+    });
+  });
+
   describe('declineBandInvitation', () => {
     it('초대 상태를 거절로 변경하고 응답 시각을 반환한다', async () => {
       const prisma = createPrismaMock();
@@ -593,6 +794,59 @@ describe('BandsPrismaRepository', () => {
 
       expect(tx.bandInvitation.update).toHaveBeenCalled();
       expect(prisma.bandInvitation.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rejectBandJoinRequest', () => {
+    it('가입 요청 상태를 거절로 변경하고 결과를 반환한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandJoinRequest.update.mockResolvedValue({
+        id: 'join-request-001',
+        bandId: 'band-001',
+        userId: 'user-002',
+        status: 'REJECTED',
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.rejectBandJoinRequest('join-request-001');
+
+      expect(prisma.bandJoinRequest.update).toHaveBeenCalledWith({
+        where: {
+          id: 'join-request-001',
+        },
+        data: {
+          status: 'REJECTED',
+        },
+        select: {
+          id: true,
+          bandId: true,
+          userId: true,
+          status: true,
+        },
+      });
+      expect(result).toEqual({
+        joinRequestId: 'join-request-001',
+        bandId: 'band-001',
+        userId: 'user-002',
+        joinRequestStatus: 'REJECTED',
+      });
+    });
+
+    it('tx가 있으면 tx client로 거절 처리한다', async () => {
+      const prisma = createPrismaMock();
+      const tx = createPrismaMock();
+      tx.bandJoinRequest.update.mockResolvedValue({
+        id: 'join-request-001',
+        bandId: 'band-001',
+        userId: 'user-002',
+        status: 'REJECTED',
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      await repository.rejectBandJoinRequest('join-request-001', tx as never);
+
+      expect(tx.bandJoinRequest.update).toHaveBeenCalled();
+      expect(prisma.bandJoinRequest.update).not.toHaveBeenCalled();
     });
   });
 
@@ -825,6 +1079,45 @@ describe('BandsPrismaRepository', () => {
       });
       expect(result).toEqual({
         id: 'join-request-001',
+        status: 'PENDING',
+      });
+    });
+  });
+
+  describe('findBandJoinRequestForResponse', () => {
+    it('삭제되지 않은 밴드와 활성 사용자에 연결된 가입 요청만 조회한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandJoinRequest.findFirst.mockResolvedValue({
+        id: 'join-request-001',
+        bandId: 'band-001',
+        userId: 'user-002',
+        status: 'PENDING',
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findBandJoinRequestForResponse('join-request-001');
+
+      expect(prisma.bandJoinRequest.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 'join-request-001',
+          band: {
+            deletedAt: null,
+          },
+          user: {
+            deletedAt: null,
+          },
+        },
+        select: {
+          id: true,
+          bandId: true,
+          userId: true,
+          status: true,
+        },
+      });
+      expect(result).toEqual({
+        id: 'join-request-001',
+        bandId: 'band-001',
+        userId: 'user-002',
         status: 'PENDING',
       });
     });

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
@@ -15,6 +15,7 @@ function createPrismaMock() {
     },
     bandJoinRequest: {
       create: jest.fn(),
+      findMany: jest.fn(),
       findFirst: jest.fn(),
     },
     band: {
@@ -186,6 +187,127 @@ describe('BandsPrismaRepository', () => {
       expect(result.items).toHaveLength(1);
       expect(result.meta.next).toEqual({
         id: 'invitation-001',
+      });
+    });
+  });
+
+  describe('findSentBandJoinRequests', () => {
+    it('보낸 가입 요청 목록을 상태와 커서 기준으로 조회하고 매핑한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandJoinRequest.findMany.mockResolvedValue([
+        {
+          id: 'join-request-001',
+          message: '기타로 합류하고 싶습니다!',
+          status: 'PENDING',
+          createdAt: mockCreatedAt,
+          band: {
+            id: 'band-001',
+            name: 'Rocking Stars',
+            description: '직장인 밴드',
+            visibility: true,
+          },
+        },
+      ]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findSentBandJoinRequests('user-001', {
+        where__join_request_status: 'PENDING',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      });
+
+      expect(prisma.bandJoinRequest.findMany).toHaveBeenCalledWith({
+        where: {
+          userId: 'user-001',
+          status: 'PENDING',
+          band: {
+            deletedAt: null,
+          },
+        },
+        include: {
+          band: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+              visibility: true,
+            },
+          },
+        },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: 21,
+      });
+      expect(result.items).toEqual([
+        {
+          joinRequestId: 'join-request-001',
+          band: {
+            bandId: 'band-001',
+            name: 'Rocking Stars',
+            description: '직장인 밴드',
+            visibility: true,
+          },
+          joinRequestStatus: 'PENDING',
+          message: '기타로 합류하고 싶습니다!',
+          createdAt: '2026-04-10T12:00:00.000Z',
+        },
+      ]);
+      expect(result.meta).toEqual({
+        count: 1,
+        take: 20,
+        cursor: {
+          id: 'join-request-001',
+        },
+        next: null,
+      });
+    });
+
+    it('cursor__id가 있으면 Prisma cursor와 skip을 사용한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandJoinRequest.findMany.mockResolvedValue([]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      await repository.findSentBandJoinRequests('user-001', {
+        where__join_request_status: 'REJECTED',
+        order__created_at: 'asc',
+        order__id: 'asc',
+        take: 10,
+        cursor__id: 'join-request-001',
+      });
+
+      expect(prisma.bandJoinRequest.findMany).toHaveBeenCalledWith(expect.objectContaining({ cursor: { id: 'join-request-001' }, skip: 1 }));
+    });
+
+    it('take보다 많이 조회되면 next cursor를 반환한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandJoinRequest.findMany.mockResolvedValue([
+        {
+          id: 'join-request-001',
+          message: null,
+          status: 'PENDING',
+          createdAt: mockCreatedAt,
+          band: { id: 'band-001', name: 'Rocking Stars', description: null, visibility: true },
+        },
+        {
+          id: 'join-request-002',
+          message: null,
+          status: 'PENDING',
+          createdAt: new Date('2026-04-09T12:00:00.000Z'),
+          band: { id: 'band-002', name: 'Jazz Stars', description: null, visibility: false },
+        },
+      ]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findSentBandJoinRequests('user-001', {
+        where__join_request_status: 'PENDING',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 1,
+      });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.meta.next).toEqual({
+        id: 'join-request-001',
       });
     });
   });

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from '../../../database/prisma';
-import type { BandMemberRole, Prisma } from '../../../generated/prisma';
+import type { BandInvitationStatus, BandMemberRole, Prisma } from '../../../generated/prisma';
 import type { BandMemberOrderDirection, GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { BandSearchOrderDirection, SearchBandsQuery } from '../dto/search-bands-query.dto';
@@ -9,6 +9,7 @@ import type { UpdateBandInput } from '../dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
 import type { BandMemberListItem, GetBandMembersResult } from '../types/band-member-list.type';
 import type { BandSearchListItem, SearchBandsResult } from '../types/band-search-result.type';
+import type { CreateBandInvitationResult } from '../types/create-band-invitation-result.type';
 import type { BandGenreItem, CreateBandInvitationSuccessItem } from '../types/create-band-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { LeaveBandResult } from '../types/leave-band-result.type';
@@ -16,7 +17,7 @@ import type { GetMyBandsResult, MyBandListItem } from '../types/my-band-list.typ
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
 import type { UpdateBandResult } from '../types/update-band-result.type';
 
-import type { BandsRepository, CreateBandRepositoryInput, CreateBandRepositoryResult } from './bands.repository';
+import type { BandsRepository, CreateBandInvitationRepositoryInput, CreateBandRepositoryInput, CreateBandRepositoryResult } from './bands.repository';
 
 @Injectable()
 export class BandsPrismaRepository implements BandsRepository {
@@ -102,6 +103,47 @@ export class BandsPrismaRepository implements BandsRepository {
           failed: [],
         },
       },
+    };
+  }
+
+  /**
+   * 초대자 밴드 멤버 ID를 기준으로 밴드 초대를 생성한다.
+   *
+   * @param {CreateBandInvitationRepositoryInput} input - Service 정책 검증이 끝난 초대 입력값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<CreateBandInvitationResult>} 생성된 초대 정보
+   */
+  async createBandInvitation(input: CreateBandInvitationRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandInvitationResult> {
+    const client = tx ?? this.prisma;
+
+    const invitation = await client.bandInvitation.create({
+      data: {
+        bandId: input.bandId,
+        inviterBandMemberId: input.inviterBandMemberId,
+        inviteeUserId: input.inviteeUserId,
+        message: input.message,
+      },
+      select: {
+        id: true,
+        bandId: true,
+        inviteeUserId: true,
+        status: true,
+        createdAt: true,
+        inviterBandMember: {
+          select: {
+            userId: true,
+          },
+        },
+      },
+    });
+
+    return {
+      invitationId: invitation.id,
+      bandId: invitation.bandId,
+      inviterUserId: invitation.inviterBandMember.userId,
+      inviteeUserId: invitation.inviteeUserId,
+      invitationStatus: invitation.status,
+      createdAt: invitation.createdAt.toISOString(),
     };
   }
 
@@ -465,6 +507,7 @@ export class BandsPrismaRepository implements BandsRepository {
   ): Promise<{
     id: string;
     userId: string;
+    role: BandMemberRole;
   } | null> {
     const client = tx ?? this.prisma;
 
@@ -476,6 +519,65 @@ export class BandsPrismaRepository implements BandsRepository {
       select: {
         id: true,
         userId: true,
+        role: true,
+      },
+    });
+  }
+
+  /**
+   * 같은 밴드와 초대 대상 기준으로 기존 초대가 있는지 확인한다.
+   *
+   * @param {string} bandId - 대상 밴드 ID
+   * @param {string} inviteeUserId - 초대 대상 사용자 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string; status: BandInvitationStatus } | null>} 기존 초대 정보
+   */
+  async findBandInvitationByBandIdAndInviteeUserId(
+    bandId: string,
+    inviteeUserId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    status: BandInvitationStatus;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    return client.bandInvitation.findFirst({
+      where: {
+        bandId,
+        inviteeUserId,
+      },
+      select: {
+        id: true,
+        status: true,
+      },
+    });
+  }
+
+  /**
+   * 밴드가 차단한 사용자인지 확인한다.
+   *
+   * @param {string} bandId - 대상 밴드 ID
+   * @param {string} userId - 확인할 사용자 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string } | null>} 차단 정보
+   */
+  async findBandBlacklistByBandIdAndUserId(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    return client.bandBlacklist.findFirst({
+      where: {
+        bandId,
+        userId,
+      },
+      select: {
+        id: true,
       },
     });
   }

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -12,6 +12,7 @@ import type { BandMemberListItem, GetBandMembersResult } from '../types/band-mem
 import type { BandSearchListItem, SearchBandsResult } from '../types/band-search-result.type';
 import type { CreateBandInvitationResult } from '../types/create-band-invitation-result.type';
 import type { BandGenreItem, CreateBandInvitationSuccessItem } from '../types/create-band-result.type';
+import type { DeclineBandInvitationResult } from '../types/decline-band-invitation-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult, MyBandListItem } from '../types/my-band-list.type';
@@ -76,6 +77,43 @@ export class BandsPrismaRepository implements BandsRepository {
       userId: invitation.inviteeUserId,
       invitationStatus: invitation.status,
       joinedAt: member.joinedAt.toISOString(),
+    };
+  }
+
+  /**
+   * 초대 상태를 거절로 바꾸고 응답 시각을 기록한다.
+   *
+   * @param {string} invitationId - 거절할 초대 ID
+   * @param {Date} respondedAt - 초대 응답 시각
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<DeclineBandInvitationResult>} 거절 처리 결과
+   */
+  async declineBandInvitation(invitationId: string, respondedAt: Date, tx?: Prisma.TransactionClient): Promise<DeclineBandInvitationResult> {
+    const client = tx ?? this.prisma;
+
+    const invitation = await client.bandInvitation.update({
+      where: {
+        id: invitationId,
+      },
+      data: {
+        status: 'DECLINED',
+        respondedAt,
+      },
+      select: {
+        id: true,
+        bandId: true,
+        inviteeUserId: true,
+        status: true,
+        respondedAt: true,
+      },
+    });
+
+    return {
+      invitationId: invitation.id,
+      bandId: invitation.bandId,
+      userId: invitation.inviteeUserId,
+      invitationStatus: invitation.status,
+      respondedAt: (invitation.respondedAt ?? respondedAt).toISOString(),
     };
   }
 
@@ -611,13 +649,13 @@ export class BandsPrismaRepository implements BandsRepository {
   }
 
   /**
-   * 수락 가능 여부 판단에 필요한 초대와 삭제되지 않은 밴드 정보를 조회한다.
+   * 초대 응답 가능 여부 판단에 필요한 초대와 삭제되지 않은 밴드 정보를 조회한다.
    *
    * @param {string} invitationId - 수락할 초대 ID
    * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
    * @returns {Promise<{ id: string; bandId: string; inviteeUserId: string; status: BandInvitationStatus } | null>} 초대 정보
    */
-  async findBandInvitationForAccept(
+  async findBandInvitationForResponse(
     invitationId: string,
     tx?: Prisma.TransactionClient,
   ): Promise<{

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -44,12 +44,12 @@ export class BandsPrismaRepository implements BandsRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   /**
-   * 초대 상태를 수락으로 바꾸고 기본 멤버로 가입시킨다.
+   * 초대는 가입 전 임시 관계이므로 수락 후 멤버를 생성하고 초대 row를 삭제한다.
    *
    * @param {string} invitationId - 수락할 초대 ID
    * @param {string} bandId - 가입할 밴드 ID
    * @param {string} userId - 가입할 사용자 ID
-   * @param {Date} respondedAt - 초대 응답 시각
+   * @param {Date} _respondedAt - 기존 인터페이스 호환을 위해 받지만 초대 삭제 정책에서는 저장하지 않는 응답 시각
    * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
    * @returns {Promise<AcceptBandInvitationResult>} 수락 처리 결과
    */
@@ -57,26 +57,10 @@ export class BandsPrismaRepository implements BandsRepository {
     invitationId: string,
     bandId: string,
     userId: string,
-    respondedAt: Date,
+    _respondedAt: Date,
     tx?: Prisma.TransactionClient,
   ): Promise<AcceptBandInvitationResult> {
     const client = tx ?? this.prisma;
-
-    const invitation = await client.bandInvitation.update({
-      where: {
-        id: invitationId,
-      },
-      data: {
-        status: 'ACCEPTED',
-        respondedAt,
-      },
-      select: {
-        id: true,
-        bandId: true,
-        inviteeUserId: true,
-        status: true,
-      },
-    });
 
     const member = await client.bandMember.create({
       data: {
@@ -89,11 +73,17 @@ export class BandsPrismaRepository implements BandsRepository {
       },
     });
 
+    await client.bandInvitation.delete({
+      where: {
+        id: invitationId,
+      },
+    });
+
     return {
-      invitationId: invitation.id,
-      bandId: invitation.bandId,
-      userId: invitation.inviteeUserId,
-      invitationStatus: invitation.status,
+      invitationId,
+      bandId,
+      userId,
+      invitationStatus: 'ACCEPTED',
       joinedAt: member.joinedAt.toISOString(),
     };
   }
@@ -1063,6 +1053,34 @@ export class BandsPrismaRepository implements BandsRepository {
   }
 
   /**
+   * 가입 요청 알림을 받을 수 있는 밴드 운영자 사용자 ID를 조회한다.
+   *
+   * @param {string} bandId - 대상 밴드 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<string[]>} 밴드장과 관리자 사용자 ID 목록
+   */
+  async findBandManagerUserIdsByBandId(bandId: string, tx?: Prisma.TransactionClient): Promise<string[]> {
+    const client = tx ?? this.prisma;
+
+    const members = await client.bandMember.findMany({
+      where: {
+        bandId,
+        role: {
+          in: ['BM', 'ADMIN'],
+        },
+        user: {
+          deletedAt: null,
+        },
+      },
+      select: {
+        userId: true,
+      },
+    });
+
+    return members.map(member => member.userId);
+  }
+
+  /**
    * 같은 밴드와 초대 대상 기준으로 기존 초대가 있는지 확인한다.
    *
    * @param {string} bandId - 대상 밴드 ID
@@ -1210,7 +1228,7 @@ export class BandsPrismaRepository implements BandsRepository {
    *
    * @param {string} invitationId - 수락할 초대 ID
    * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
-   * @returns {Promise<{ id: string; bandId: string; inviteeUserId: string; status: BandInvitationStatus } | null>} 초대 정보
+   * @returns {Promise<{ id: string; bandId: string; inviterUserId: string; inviteeUserId: string; status: BandInvitationStatus } | null>} 초대 정보
    */
   async findBandInvitationForResponse(
     invitationId: string,
@@ -1218,12 +1236,13 @@ export class BandsPrismaRepository implements BandsRepository {
   ): Promise<{
     id: string;
     bandId: string;
+    inviterUserId: string;
     inviteeUserId: string;
     status: BandInvitationStatus;
   } | null> {
     const client = tx ?? this.prisma;
 
-    return client.bandInvitation.findFirst({
+    const invitation = await client.bandInvitation.findFirst({
       where: {
         id: invitationId,
         band: {
@@ -1235,8 +1254,25 @@ export class BandsPrismaRepository implements BandsRepository {
         bandId: true,
         inviteeUserId: true,
         status: true,
+        inviterBandMember: {
+          select: {
+            userId: true,
+          },
+        },
       },
     });
+
+    if (invitation === null) {
+      return null;
+    }
+
+    return {
+      id: invitation.id,
+      bandId: invitation.bandId,
+      inviterUserId: invitation.inviterBandMember.userId,
+      inviteeUserId: invitation.inviteeUserId,
+      status: invitation.status,
+    };
   }
 
   /**

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -5,6 +5,7 @@ import type { BandInvitationStatus, BandMemberRole, Prisma } from '../../../gene
 import type { BandMemberOrderDirection, GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { GetReceivedBandInvitationsQuery } from '../dto/get-received-band-invitations-query.dto';
+import type { GetSentBandInvitationsQuery } from '../dto/get-sent-band-invitations-query.dto';
 import type { BandSearchOrderDirection, SearchBandsQuery } from '../dto/search-bands-query.dto';
 import type { UpdateBandInput } from '../dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
@@ -19,6 +20,7 @@ import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult, MyBandListItem } from '../types/my-band-list.type';
 import type { GetReceivedBandInvitationsResult, ReceivedBandInvitationListItem } from '../types/received-band-invitation-list.type';
+import type { GetSentBandInvitationsResult, SentBandInvitationListItem } from '../types/sent-band-invitation-list.type';
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
 import type { UpdateBandResult } from '../types/update-band-result.type';
 
@@ -684,6 +686,78 @@ export class BandsPrismaRepository implements BandsRepository {
   }
 
   /**
+   * 인증 사용자가 직접 보낸 초대를 상태와 커서 기준으로 조회한다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {GetSentBandInvitationsQuery} query - 상태 필터와 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetSentBandInvitationsResult>} 보낸 초대 목록
+   */
+  async findSentBandInvitations(
+    userId: string,
+    query: GetSentBandInvitationsQuery,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetSentBandInvitationsResult> {
+    const client = tx ?? this.prisma;
+
+    const invitations = await client.bandInvitation.findMany({
+      where: {
+        status: query.where__invitation_status,
+        band: {
+          deletedAt: null,
+        },
+        inviterBandMember: {
+          userId,
+        },
+        inviteeUser: {
+          deletedAt: null,
+        },
+      },
+      include: {
+        band: {
+          include: {
+            _count: {
+              select: {
+                members: true,
+              },
+            },
+          },
+        },
+        inviteeUser: {
+          include: {
+            profile: {
+              select: {
+                nickname: true,
+                avatarUrl: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: [{ createdAt: query.order__created_at }, { id: query.order__id }],
+      take: query.take + 1,
+      ...(query.cursor__id !== undefined ? { cursor: { id: query.cursor__id }, skip: 1 } : {}),
+    });
+
+    const hasNext = invitations.length > query.take;
+    const rows = hasNext ? invitations.slice(0, query.take) : invitations;
+    const items = rows.map(invitation => this.mapSentBandInvitationListItem(invitation));
+    const count = items.length;
+    const cursor = count > 0 ? { id: items[0].invitationId } : null;
+    const next = hasNext && count > 0 ? { id: items[count - 1].invitationId } : null;
+
+    return {
+      items,
+      meta: {
+        count,
+        take: query.take,
+        cursor,
+        next,
+      },
+    };
+  }
+
+  /**
    * 밴드와 사용자 기준으로 밴드 멤버를 조회한다.
    *
    * @param {string} bandId - 대상 밴드 ID
@@ -1224,6 +1298,51 @@ export class BandsPrismaRepository implements BandsRepository {
       message: invitation.message,
       invitationStatus: invitation.status,
       createdAt: invitation.createdAt.toISOString(),
+    };
+  }
+
+  private mapSentBandInvitationListItem(
+    invitation: Prisma.BandInvitationGetPayload<{
+      include: {
+        band: {
+          include: {
+            _count: {
+              select: {
+                members: true;
+              };
+            };
+          };
+        };
+        inviteeUser: {
+          include: {
+            profile: {
+              select: {
+                nickname: true;
+                avatarUrl: true;
+              };
+            };
+          };
+        };
+      };
+    }>,
+  ): SentBandInvitationListItem {
+    return {
+      invitationId: invitation.id,
+      band: {
+        bandId: invitation.band.id,
+        name: invitation.band.name ?? '',
+        description: invitation.band.description,
+        memberCount: invitation.band._count.members,
+      },
+      invitee: {
+        userId: invitation.inviteeUserId,
+        nickname: invitation.inviteeUser.profile?.nickname ?? '',
+        avatarUrl: invitation.inviteeUser.profile?.avatarUrl ?? null,
+      },
+      invitationStatus: invitation.status,
+      message: invitation.message,
+      createdAt: invitation.createdAt.toISOString(),
+      respondedAt: invitation.respondedAt?.toISOString() ?? null,
     };
   }
 

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -7,6 +7,7 @@ import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { BandSearchOrderDirection, SearchBandsQuery } from '../dto/search-bands-query.dto';
 import type { UpdateBandInput } from '../dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
+import type { AcceptBandInvitationResult } from '../types/accept-band-invitation-result.type';
 import type { BandMemberListItem, GetBandMembersResult } from '../types/band-member-list.type';
 import type { BandSearchListItem, SearchBandsResult } from '../types/band-search-result.type';
 import type { CreateBandInvitationResult } from '../types/create-band-invitation-result.type';
@@ -22,6 +23,61 @@ import type { BandsRepository, CreateBandInvitationRepositoryInput, CreateBandRe
 @Injectable()
 export class BandsPrismaRepository implements BandsRepository {
   constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 초대 상태를 수락으로 바꾸고 기본 멤버로 가입시킨다.
+   *
+   * @param {string} invitationId - 수락할 초대 ID
+   * @param {string} bandId - 가입할 밴드 ID
+   * @param {string} userId - 가입할 사용자 ID
+   * @param {Date} respondedAt - 초대 응답 시각
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<AcceptBandInvitationResult>} 수락 처리 결과
+   */
+  async acceptBandInvitation(
+    invitationId: string,
+    bandId: string,
+    userId: string,
+    respondedAt: Date,
+    tx?: Prisma.TransactionClient,
+  ): Promise<AcceptBandInvitationResult> {
+    const client = tx ?? this.prisma;
+
+    const invitation = await client.bandInvitation.update({
+      where: {
+        id: invitationId,
+      },
+      data: {
+        status: 'ACCEPTED',
+        respondedAt,
+      },
+      select: {
+        id: true,
+        bandId: true,
+        inviteeUserId: true,
+        status: true,
+      },
+    });
+
+    const member = await client.bandMember.create({
+      data: {
+        bandId,
+        userId,
+        role: 'MEMBER',
+      },
+      select: {
+        joinedAt: true,
+      },
+    });
+
+    return {
+      invitationId: invitation.id,
+      bandId: invitation.bandId,
+      userId: invitation.inviteeUserId,
+      invitationStatus: invitation.status,
+      joinedAt: member.joinedAt.toISOString(),
+    };
+  }
 
   /**
    * 상위 Service가 넘긴 트랜잭션이 있으면 같은 작업 단위 안에서 밴드를 생성한다.
@@ -549,6 +605,40 @@ export class BandsPrismaRepository implements BandsRepository {
       },
       select: {
         id: true,
+        status: true,
+      },
+    });
+  }
+
+  /**
+   * 수락 가능 여부 판단에 필요한 초대와 삭제되지 않은 밴드 정보를 조회한다.
+   *
+   * @param {string} invitationId - 수락할 초대 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string; bandId: string; inviteeUserId: string; status: BandInvitationStatus } | null>} 초대 정보
+   */
+  async findBandInvitationForAccept(
+    invitationId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    bandId: string;
+    inviteeUserId: string;
+    status: BandInvitationStatus;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    return client.bandInvitation.findFirst({
+      where: {
+        id: invitationId,
+        band: {
+          deletedAt: null,
+        },
+      },
+      select: {
+        id: true,
+        bandId: true,
+        inviteeUserId: true,
         status: true,
       },
     });

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -6,6 +6,7 @@ import type { BandMemberOrderDirection, GetBandMembersQuery } from '../dto/get-b
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { GetReceivedBandInvitationsQuery } from '../dto/get-received-band-invitations-query.dto';
 import type { GetSentBandInvitationsQuery } from '../dto/get-sent-band-invitations-query.dto';
+import type { GetSentBandJoinRequestsQuery } from '../dto/get-sent-band-join-requests-query.dto';
 import type { BandSearchOrderDirection, SearchBandsQuery } from '../dto/search-bands-query.dto';
 import type { UpdateBandInput } from '../dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
@@ -22,6 +23,7 @@ import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult, MyBandListItem } from '../types/my-band-list.type';
 import type { GetReceivedBandInvitationsResult, ReceivedBandInvitationListItem } from '../types/received-band-invitation-list.type';
 import type { GetSentBandInvitationsResult, SentBandInvitationListItem } from '../types/sent-band-invitation-list.type';
+import type { GetSentBandJoinRequestsResult, SentBandJoinRequestListItem } from '../types/sent-band-join-request-list.type';
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
 import type { UpdateBandResult } from '../types/update-band-result.type';
 
@@ -827,6 +829,62 @@ export class BandsPrismaRepository implements BandsRepository {
   }
 
   /**
+   * 인증 사용자가 직접 보낸 가입 요청을 상태와 커서 기준으로 조회한다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {GetSentBandJoinRequestsQuery} query - 상태 필터와 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetSentBandJoinRequestsResult>} 보낸 가입 요청 목록
+   */
+  async findSentBandJoinRequests(
+    userId: string,
+    query: GetSentBandJoinRequestsQuery,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetSentBandJoinRequestsResult> {
+    const client = tx ?? this.prisma;
+
+    const joinRequests = await client.bandJoinRequest.findMany({
+      where: {
+        userId,
+        status: query.where__join_request_status,
+        band: {
+          deletedAt: null,
+        },
+      },
+      include: {
+        band: {
+          select: {
+            id: true,
+            name: true,
+            description: true,
+            visibility: true,
+          },
+        },
+      },
+      orderBy: [{ createdAt: query.order__created_at }, { id: query.order__id }],
+      take: query.take + 1,
+      ...(query.cursor__id !== undefined ? { cursor: { id: query.cursor__id }, skip: 1 } : {}),
+    });
+
+    const hasNext = joinRequests.length > query.take;
+    const rows = hasNext ? joinRequests.slice(0, query.take) : joinRequests;
+    const items = rows.map(joinRequest => this.mapSentBandJoinRequestListItem(joinRequest));
+    const count = items.length;
+    const cursor = count > 0 ? { id: items[0].joinRequestId } : null;
+    const next = hasNext && count > 0 ? { id: items[count - 1].joinRequestId } : null;
+
+    return {
+      items,
+      meta: {
+        count,
+        take: query.take,
+        cursor,
+        next,
+      },
+    };
+  }
+
+  /**
    * 밴드와 사용자 기준으로 밴드 멤버를 조회한다.
    *
    * @param {string} bandId - 대상 밴드 ID
@@ -1442,6 +1500,34 @@ export class BandsPrismaRepository implements BandsRepository {
       message: invitation.message,
       createdAt: invitation.createdAt.toISOString(),
       respondedAt: invitation.respondedAt?.toISOString() ?? null,
+    };
+  }
+
+  private mapSentBandJoinRequestListItem(
+    joinRequest: Prisma.BandJoinRequestGetPayload<{
+      include: {
+        band: {
+          select: {
+            id: true;
+            name: true;
+            description: true;
+            visibility: true;
+          };
+        };
+      };
+    }>,
+  ): SentBandJoinRequestListItem {
+    return {
+      joinRequestId: joinRequest.id,
+      band: {
+        bandId: joinRequest.band.id,
+        name: joinRequest.band.name ?? '',
+        description: joinRequest.band.description,
+        visibility: joinRequest.band.visibility ?? true,
+      },
+      message: joinRequest.message,
+      joinRequestStatus: joinRequest.status,
+      createdAt: joinRequest.createdAt.toISOString(),
     };
   }
 

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -13,6 +13,7 @@ import type { BandSearchListItem, SearchBandsResult } from '../types/band-search
 import type { CreateBandInvitationResult } from '../types/create-band-invitation-result.type';
 import type { BandGenreItem, CreateBandInvitationSuccessItem } from '../types/create-band-result.type';
 import type { DeclineBandInvitationResult } from '../types/decline-band-invitation-result.type';
+import type { DeleteBandInvitationResult } from '../types/delete-band-invitation-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult, MyBandListItem } from '../types/my-band-list.type';
@@ -114,6 +115,27 @@ export class BandsPrismaRepository implements BandsRepository {
       userId: invitation.inviteeUserId,
       invitationStatus: invitation.status,
       respondedAt: (invitation.respondedAt ?? respondedAt).toISOString(),
+    };
+  }
+
+  /**
+   * 초대 취소는 별도 상태 컬럼이 없으므로 초대 row를 삭제한다.
+   *
+   * @param {string} invitationId - 삭제할 초대 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<DeleteBandInvitationResult>} 삭제한 초대 ID
+   */
+  async deleteBandInvitation(invitationId: string, tx?: Prisma.TransactionClient): Promise<DeleteBandInvitationResult> {
+    const client = tx ?? this.prisma;
+
+    await client.bandInvitation.delete({
+      where: {
+        id: invitationId,
+      },
+    });
+
+    return {
+      invitationId,
     };
   }
 
@@ -646,6 +668,52 @@ export class BandsPrismaRepository implements BandsRepository {
         status: true,
       },
     });
+  }
+
+  /**
+   * 초대 취소 권한 판단에 필요한 초대자와 삭제되지 않은 밴드 정보를 조회한다.
+   *
+   * @param {string} invitationId - 취소할 초대 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string; status: BandInvitationStatus; inviterUserId: string } | null>} 초대 취소 판단 정보
+   */
+  async findBandInvitationForDelete(
+    invitationId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    status: BandInvitationStatus;
+    inviterUserId: string;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    const invitation = await client.bandInvitation.findFirst({
+      where: {
+        id: invitationId,
+        band: {
+          deletedAt: null,
+        },
+      },
+      select: {
+        id: true,
+        status: true,
+        inviterBandMember: {
+          select: {
+            userId: true,
+          },
+        },
+      },
+    });
+
+    if (invitation === null) {
+      return null;
+    }
+
+    return {
+      id: invitation.id,
+      status: invitation.status,
+      inviterUserId: invitation.inviterBandMember.userId,
+    };
   }
 
   /**

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from '../../../database/prisma';
 import type { BandInvitationStatus, BandMemberRole, JoinRequestStatus, Prisma } from '../../../generated/prisma';
+import type { GetBandJoinRequestsQuery } from '../dto/get-band-join-requests-query.dto';
 import type { BandMemberOrderDirection, GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { GetReceivedBandInvitationsQuery } from '../dto/get-received-band-invitations-query.dto';
@@ -11,6 +12,8 @@ import type { BandSearchOrderDirection, SearchBandsQuery } from '../dto/search-b
 import type { UpdateBandInput } from '../dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
 import type { AcceptBandInvitationResult } from '../types/accept-band-invitation-result.type';
+import type { ApproveBandJoinRequestResult } from '../types/approve-band-join-request-result.type';
+import type { BandJoinRequestListItem, GetBandJoinRequestsResult } from '../types/band-join-request-list.type';
 import type { BandMemberListItem, GetBandMembersResult } from '../types/band-member-list.type';
 import type { BandSearchListItem, SearchBandsResult } from '../types/band-search-result.type';
 import type { CreateBandInvitationResult } from '../types/create-band-invitation-result.type';
@@ -22,6 +25,7 @@ import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult, MyBandListItem } from '../types/my-band-list.type';
 import type { GetReceivedBandInvitationsResult, ReceivedBandInvitationListItem } from '../types/received-band-invitation-list.type';
+import type { RejectBandJoinRequestResult } from '../types/reject-band-join-request-result.type';
 import type { GetSentBandInvitationsResult, SentBandInvitationListItem } from '../types/sent-band-invitation-list.type';
 import type { GetSentBandJoinRequestsResult, SentBandJoinRequestListItem } from '../types/sent-band-join-request-list.type';
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
@@ -95,6 +99,58 @@ export class BandsPrismaRepository implements BandsRepository {
   }
 
   /**
+   * 가입 요청 상태를 승인으로 바꾸고 기본 멤버로 가입시킨다.
+   *
+   * @param {string} joinRequestId - 승인할 가입 요청 ID
+   * @param {string} bandId - 가입할 밴드 ID
+   * @param {string} userId - 가입할 사용자 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<ApproveBandJoinRequestResult>} 승인 처리 결과
+   */
+  async approveBandJoinRequest(
+    joinRequestId: string,
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<ApproveBandJoinRequestResult> {
+    const client = tx ?? this.prisma;
+
+    const joinRequest = await client.bandJoinRequest.update({
+      where: {
+        id: joinRequestId,
+      },
+      data: {
+        status: 'APPROVED',
+      },
+      select: {
+        id: true,
+        bandId: true,
+        userId: true,
+        status: true,
+      },
+    });
+
+    const member = await client.bandMember.create({
+      data: {
+        bandId,
+        userId,
+        role: 'MEMBER',
+      },
+      select: {
+        joinedAt: true,
+      },
+    });
+
+    return {
+      joinRequestId: joinRequest.id,
+      bandId: joinRequest.bandId,
+      userId: joinRequest.userId,
+      joinRequestStatus: joinRequest.status,
+      joinedAt: member.joinedAt.toISOString(),
+    };
+  }
+
+  /**
    * 초대 상태를 거절로 바꾸고 응답 시각을 기록한다.
    *
    * @param {string} invitationId - 거절할 초대 ID
@@ -128,6 +184,39 @@ export class BandsPrismaRepository implements BandsRepository {
       userId: invitation.inviteeUserId,
       invitationStatus: invitation.status,
       respondedAt: (invitation.respondedAt ?? respondedAt).toISOString(),
+    };
+  }
+
+  /**
+   * 가입 요청 상태를 거절로 바꾼다.
+   *
+   * @param {string} joinRequestId - 거절할 가입 요청 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<RejectBandJoinRequestResult>} 거절 처리 결과
+   */
+  async rejectBandJoinRequest(joinRequestId: string, tx?: Prisma.TransactionClient): Promise<RejectBandJoinRequestResult> {
+    const client = tx ?? this.prisma;
+
+    const joinRequest = await client.bandJoinRequest.update({
+      where: {
+        id: joinRequestId,
+      },
+      data: {
+        status: 'REJECTED',
+      },
+      select: {
+        id: true,
+        bandId: true,
+        userId: true,
+        status: true,
+      },
+    });
+
+    return {
+      joinRequestId: joinRequest.id,
+      bandId: joinRequest.bandId,
+      userId: joinRequest.userId,
+      joinRequestStatus: joinRequest.status,
     };
   }
 
@@ -885,6 +974,63 @@ export class BandsPrismaRepository implements BandsRepository {
   }
 
   /**
+   * 특정 밴드로 들어온 가입 요청을 상태와 커서 기준으로 조회한다.
+   *
+   * @param {string} bandId - 대상 밴드 ID
+   * @param {GetBandJoinRequestsQuery} query - 상태 필터와 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetBandJoinRequestsResult>} 밴드 가입 요청 목록
+   */
+  async findBandJoinRequests(bandId: string, query: GetBandJoinRequestsQuery, tx?: Prisma.TransactionClient): Promise<GetBandJoinRequestsResult> {
+    const client = tx ?? this.prisma;
+
+    const joinRequests = await client.bandJoinRequest.findMany({
+      where: {
+        bandId,
+        status: query.where__join_request_status,
+        band: {
+          deletedAt: null,
+        },
+        user: {
+          deletedAt: null,
+        },
+      },
+      include: {
+        user: {
+          include: {
+            profile: {
+              select: {
+                nickname: true,
+                avatarUrl: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: [{ createdAt: query.order__created_at }, { id: query.order__id }],
+      take: query.take + 1,
+      ...(query.cursor__id !== undefined ? { cursor: { id: query.cursor__id }, skip: 1 } : {}),
+    });
+
+    const hasNext = joinRequests.length > query.take;
+    const rows = hasNext ? joinRequests.slice(0, query.take) : joinRequests;
+    const items = rows.map(joinRequest => this.mapBandJoinRequestListItem(joinRequest));
+    const count = items.length;
+    const cursor = count > 0 ? { id: items[0].joinRequestId } : null;
+    const next = hasNext && count > 0 ? { id: items[count - 1].joinRequestId } : null;
+
+    return {
+      items,
+      meta: {
+        count,
+        take: query.take,
+        cursor,
+        next,
+      },
+    };
+  }
+
+  /**
    * 밴드와 사용자 기준으로 밴드 멤버를 조회한다.
    *
    * @param {string} bandId - 대상 밴드 ID
@@ -971,6 +1117,43 @@ export class BandsPrismaRepository implements BandsRepository {
       },
       select: {
         id: true,
+        status: true,
+      },
+    });
+  }
+
+  /**
+   * 가입 요청 응답 가능 여부 판단에 필요한 가입 요청과 삭제되지 않은 밴드 정보를 조회한다.
+   *
+   * @param {string} joinRequestId - 응답할 가입 요청 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string; bandId: string; userId: string; status: JoinRequestStatus } | null>} 가입 요청 정보
+   */
+  async findBandJoinRequestForResponse(
+    joinRequestId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    bandId: string;
+    userId: string;
+    status: JoinRequestStatus;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    return client.bandJoinRequest.findFirst({
+      where: {
+        id: joinRequestId,
+        band: {
+          deletedAt: null,
+        },
+        user: {
+          deletedAt: null,
+        },
+      },
+      select: {
+        id: true,
+        bandId: true,
+        userId: true,
         status: true,
       },
     });
@@ -1524,6 +1707,35 @@ export class BandsPrismaRepository implements BandsRepository {
         name: joinRequest.band.name ?? '',
         description: joinRequest.band.description,
         visibility: joinRequest.band.visibility ?? true,
+      },
+      message: joinRequest.message,
+      joinRequestStatus: joinRequest.status,
+      createdAt: joinRequest.createdAt.toISOString(),
+    };
+  }
+
+  private mapBandJoinRequestListItem(
+    joinRequest: Prisma.BandJoinRequestGetPayload<{
+      include: {
+        user: {
+          include: {
+            profile: {
+              select: {
+                nickname: true;
+                avatarUrl: true;
+              };
+            };
+          };
+        };
+      };
+    }>,
+  ): BandJoinRequestListItem {
+    return {
+      joinRequestId: joinRequest.id,
+      requester: {
+        userId: joinRequest.userId,
+        nickname: joinRequest.user.profile?.nickname ?? '',
+        avatarUrl: joinRequest.user.profile?.avatarUrl ?? null,
       },
       message: joinRequest.message,
       joinRequestStatus: joinRequest.status,

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '../../../database/prisma';
 import type { BandInvitationStatus, BandMemberRole, Prisma } from '../../../generated/prisma';
 import type { BandMemberOrderDirection, GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
+import type { GetReceivedBandInvitationsQuery } from '../dto/get-received-band-invitations-query.dto';
 import type { BandSearchOrderDirection, SearchBandsQuery } from '../dto/search-bands-query.dto';
 import type { UpdateBandInput } from '../dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
@@ -17,6 +18,7 @@ import type { DeleteBandInvitationResult } from '../types/delete-band-invitation
 import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult, MyBandListItem } from '../types/my-band-list.type';
+import type { GetReceivedBandInvitationsResult, ReceivedBandInvitationListItem } from '../types/received-band-invitation-list.type';
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
 import type { UpdateBandResult } from '../types/update-band-result.type';
 
@@ -609,6 +611,79 @@ export class BandsPrismaRepository implements BandsRepository {
   }
 
   /**
+   * 인증 사용자가 받은 초대를 상태와 커서 기준으로 조회한다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {GetReceivedBandInvitationsQuery} query - 상태 필터와 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetReceivedBandInvitationsResult>} 받은 초대 목록
+   */
+  async findReceivedBandInvitations(
+    userId: string,
+    query: GetReceivedBandInvitationsQuery,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetReceivedBandInvitationsResult> {
+    const client = tx ?? this.prisma;
+
+    const invitations = await client.bandInvitation.findMany({
+      where: {
+        inviteeUserId: userId,
+        status: query.where__invitation_status,
+        band: {
+          deletedAt: null,
+        },
+        inviterBandMember: {
+          user: {
+            deletedAt: null,
+          },
+        },
+      },
+      include: {
+        band: {
+          select: {
+            id: true,
+            name: true,
+            description: true,
+          },
+        },
+        inviterBandMember: {
+          include: {
+            user: {
+              include: {
+                profile: {
+                  select: {
+                    nickname: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      orderBy: [{ createdAt: query.order__created_at }, { id: query.order__id }],
+      take: query.take + 1,
+      ...(query.cursor__id !== undefined ? { cursor: { id: query.cursor__id }, skip: 1 } : {}),
+    });
+
+    const hasNext = invitations.length > query.take;
+    const rows = hasNext ? invitations.slice(0, query.take) : invitations;
+    const items = rows.map(invitation => this.mapReceivedBandInvitationListItem(invitation));
+    const count = items.length;
+    const cursor = count > 0 ? { id: items[0].invitationId } : null;
+    const next = hasNext && count > 0 ? { id: items[count - 1].invitationId } : null;
+
+    return {
+      items,
+      meta: {
+        count,
+        take: query.take,
+        cursor,
+        next,
+      },
+    };
+  }
+
+  /**
    * 밴드와 사용자 기준으로 밴드 멤버를 조회한다.
    *
    * @param {string} bandId - 대상 밴드 ID
@@ -1107,6 +1182,49 @@ export class BandsPrismaRepository implements BandsRepository {
         memberCount: band._count.members,
       },
     ];
+  }
+
+  private mapReceivedBandInvitationListItem(
+    invitation: Prisma.BandInvitationGetPayload<{
+      include: {
+        band: {
+          select: {
+            id: true;
+            name: true;
+            description: true;
+          };
+        };
+        inviterBandMember: {
+          include: {
+            user: {
+              include: {
+                profile: {
+                  select: {
+                    nickname: true;
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    }>,
+  ): ReceivedBandInvitationListItem {
+    return {
+      invitationId: invitation.id,
+      band: {
+        bandId: invitation.band.id,
+        name: invitation.band.name ?? '',
+        description: invitation.band.description,
+      },
+      inviter: {
+        userId: invitation.inviterBandMember.userId,
+        nickname: invitation.inviterBandMember.user.profile?.nickname ?? '',
+      },
+      message: invitation.message,
+      invitationStatus: invitation.status,
+      createdAt: invitation.createdAt.toISOString(),
+    };
   }
 
   private mapGenres(

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from '../../../database/prisma';
-import type { BandInvitationStatus, BandMemberRole, Prisma } from '../../../generated/prisma';
+import type { BandInvitationStatus, BandMemberRole, JoinRequestStatus, Prisma } from '../../../generated/prisma';
 import type { BandMemberOrderDirection, GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { GetReceivedBandInvitationsQuery } from '../dto/get-received-band-invitations-query.dto';
@@ -13,6 +13,7 @@ import type { AcceptBandInvitationResult } from '../types/accept-band-invitation
 import type { BandMemberListItem, GetBandMembersResult } from '../types/band-member-list.type';
 import type { BandSearchListItem, SearchBandsResult } from '../types/band-search-result.type';
 import type { CreateBandInvitationResult } from '../types/create-band-invitation-result.type';
+import type { CreateBandJoinRequestResult } from '../types/create-band-join-request-result.type';
 import type { BandGenreItem, CreateBandInvitationSuccessItem } from '../types/create-band-result.type';
 import type { DeclineBandInvitationResult } from '../types/decline-band-invitation-result.type';
 import type { DeleteBandInvitationResult } from '../types/delete-band-invitation-result.type';
@@ -24,7 +25,13 @@ import type { GetSentBandInvitationsResult, SentBandInvitationListItem } from '.
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
 import type { UpdateBandResult } from '../types/update-band-result.type';
 
-import type { BandsRepository, CreateBandInvitationRepositoryInput, CreateBandRepositoryInput, CreateBandRepositoryResult } from './bands.repository';
+import type {
+  BandsRepository,
+  CreateBandInvitationRepositoryInput,
+  CreateBandJoinRequestRepositoryInput,
+  CreateBandRepositoryInput,
+  CreateBandRepositoryResult,
+} from './bands.repository';
 
 @Injectable()
 export class BandsPrismaRepository implements BandsRepository {
@@ -264,6 +271,40 @@ export class BandsPrismaRepository implements BandsRepository {
       inviteeUserId: invitation.inviteeUserId,
       invitationStatus: invitation.status,
       createdAt: invitation.createdAt.toISOString(),
+    };
+  }
+
+  /**
+   * 인증 사용자의 밴드 가입 요청을 생성한다.
+   *
+   * @param {CreateBandJoinRequestRepositoryInput} input - Service 정책 검증이 끝난 가입 요청 입력값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<CreateBandJoinRequestResult>} 생성된 가입 요청 정보
+   */
+  async createBandJoinRequest(input: CreateBandJoinRequestRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandJoinRequestResult> {
+    const client = tx ?? this.prisma;
+
+    const joinRequest = await client.bandJoinRequest.create({
+      data: {
+        bandId: input.bandId,
+        userId: input.userId,
+        message: input.message,
+      },
+      select: {
+        id: true,
+        bandId: true,
+        userId: true,
+        status: true,
+        createdAt: true,
+      },
+    });
+
+    return {
+      joinRequestId: joinRequest.id,
+      bandId: joinRequest.bandId,
+      userId: joinRequest.userId,
+      joinRequestStatus: joinRequest.status,
+      createdAt: joinRequest.createdAt.toISOString(),
     };
   }
 
@@ -514,6 +555,34 @@ export class BandsPrismaRepository implements BandsRepository {
       select: {
         id: true,
         bandMasterUserId: true,
+      },
+    });
+  }
+
+  /**
+   * 가입 요청 가능 여부 판단에 필요한 삭제되지 않은 밴드 공개 상태를 조회한다.
+   *
+   * @param {string} bandId - 대상 밴드 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string; visibility: boolean } | null>} 삭제되지 않은 밴드 정보
+   */
+  async findBandForJoinRequest(
+    bandId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    visibility: boolean;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    return client.band.findFirst({
+      where: {
+        id: bandId,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        visibility: true,
       },
     });
   }
@@ -811,6 +880,36 @@ export class BandsPrismaRepository implements BandsRepository {
       where: {
         bandId,
         inviteeUserId,
+      },
+      select: {
+        id: true,
+        status: true,
+      },
+    });
+  }
+
+  /**
+   * 같은 밴드와 사용자 기준으로 기존 가입 요청이 있는지 확인한다.
+   *
+   * @param {string} bandId - 대상 밴드 ID
+   * @param {string} userId - 가입 요청 사용자 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string; status: JoinRequestStatus } | null>} 기존 가입 요청 정보
+   */
+  async findBandJoinRequestByBandIdAndUserId(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    status: JoinRequestStatus;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    return client.bandJoinRequest.findFirst({
+      where: {
+        bandId,
+        userId,
       },
       select: {
         id: true,

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -1,6 +1,7 @@
-import type { BandInvitationStatus, BandMemberRole, Prisma } from '../../../generated/prisma';
+import type { BandInvitationStatus, BandMemberRole, JoinRequestStatus, Prisma } from '../../../generated/prisma';
 import type { CreateBandInput } from '../dto/create-band.dto';
 import type { CreateBandInvitationInput } from '../dto/create-band-invitation.dto';
+import type { CreateBandJoinRequestInput } from '../dto/create-band-join-request.dto';
 import type { GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { GetReceivedBandInvitationsQuery } from '../dto/get-received-band-invitations-query.dto';
@@ -12,6 +13,7 @@ import type { AcceptBandInvitationResult } from '../types/accept-band-invitation
 import type { GetBandMembersResult } from '../types/band-member-list.type';
 import type { SearchBandsResult } from '../types/band-search-result.type';
 import type { CreateBandInvitationResult } from '../types/create-band-invitation-result.type';
+import type { CreateBandJoinRequestResult } from '../types/create-band-join-request-result.type';
 import type { CreateBandInvitationSuccessItem, CreateBandResult } from '../types/create-band-result.type';
 import type { DeclineBandInvitationResult } from '../types/decline-band-invitation-result.type';
 import type { DeleteBandInvitationResult } from '../types/delete-band-invitation-result.type';
@@ -45,6 +47,11 @@ export interface CreateBandInvitationRepositoryInput extends CreateBandInvitatio
   inviterBandMemberId: string;
 }
 
+export interface CreateBandJoinRequestRepositoryInput extends CreateBandJoinRequestInput {
+  bandId: string;
+  userId: string;
+}
+
 export interface BandsRepository {
   acceptBandInvitation(
     invitationId: string,
@@ -55,6 +62,7 @@ export interface BandsRepository {
   ): Promise<AcceptBandInvitationResult>;
   createBand(input: CreateBandRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandRepositoryResult>;
   createBandInvitation(input: CreateBandInvitationRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandInvitationResult>;
+  createBandJoinRequest(input: CreateBandJoinRequestRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandJoinRequestResult>;
   deleteBand(bandId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteBandResult>;
   deleteBandInvitation(invitationId: string, tx?: Prisma.TransactionClient): Promise<DeleteBandInvitationResult>;
   findBandForLeave(
@@ -84,6 +92,21 @@ export interface BandsRepository {
   ): Promise<{
     id: string;
     bandMasterUserId: string;
+  } | null>;
+  findBandForJoinRequest(
+    bandId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    visibility: boolean;
+  } | null>;
+  findBandJoinRequestByBandIdAndUserId(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    status: JoinRequestStatus;
   } | null>;
   updateBand(bandId: string, input: UpdateBandInput, tx?: Prisma.TransactionClient): Promise<UpdateBandResult>;
   findBandMemberByBandIdAndUserId(

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -12,6 +12,7 @@ import type { SearchBandsResult } from '../types/band-search-result.type';
 import type { CreateBandInvitationResult } from '../types/create-band-invitation-result.type';
 import type { CreateBandInvitationSuccessItem, CreateBandResult } from '../types/create-band-result.type';
 import type { DeclineBandInvitationResult } from '../types/decline-band-invitation-result.type';
+import type { DeleteBandInvitationResult } from '../types/delete-band-invitation-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult } from '../types/my-band-list.type';
@@ -51,6 +52,7 @@ export interface BandsRepository {
   createBand(input: CreateBandRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandRepositoryResult>;
   createBandInvitation(input: CreateBandInvitationRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandInvitationResult>;
   deleteBand(bandId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteBandResult>;
+  deleteBandInvitation(invitationId: string, tx?: Prisma.TransactionClient): Promise<DeleteBandInvitationResult>;
   findBandForLeave(
     bandId: string,
     userId: string,
@@ -90,6 +92,14 @@ export interface BandsRepository {
   ): Promise<{
     id: string;
     status: BandInvitationStatus;
+  } | null>;
+  findBandInvitationForDelete(
+    invitationId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    status: BandInvitationStatus;
+    inviterUserId: string;
   } | null>;
   declineBandInvitation(invitationId: string, respondedAt: Date, tx?: Prisma.TransactionClient): Promise<DeclineBandInvitationResult>;
   findBandInvitationForResponse(

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -2,6 +2,7 @@ import type { BandInvitationStatus, BandMemberRole, JoinRequestStatus, Prisma } 
 import type { CreateBandInput } from '../dto/create-band.dto';
 import type { CreateBandInvitationInput } from '../dto/create-band-invitation.dto';
 import type { CreateBandJoinRequestInput } from '../dto/create-band-join-request.dto';
+import type { GetBandJoinRequestsQuery } from '../dto/get-band-join-requests-query.dto';
 import type { GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { GetReceivedBandInvitationsQuery } from '../dto/get-received-band-invitations-query.dto';
@@ -11,6 +12,8 @@ import type { SearchBandsQuery } from '../dto/search-bands-query.dto';
 import type { UpdateBandInput } from '../dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
 import type { AcceptBandInvitationResult } from '../types/accept-band-invitation-result.type';
+import type { ApproveBandJoinRequestResult } from '../types/approve-band-join-request-result.type';
+import type { GetBandJoinRequestsResult } from '../types/band-join-request-list.type';
 import type { GetBandMembersResult } from '../types/band-member-list.type';
 import type { SearchBandsResult } from '../types/band-search-result.type';
 import type { CreateBandInvitationResult } from '../types/create-band-invitation-result.type';
@@ -22,6 +25,7 @@ import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult } from '../types/my-band-list.type';
 import type { GetReceivedBandInvitationsResult } from '../types/received-band-invitation-list.type';
+import type { RejectBandJoinRequestResult } from '../types/reject-band-join-request-result.type';
 import type { GetSentBandInvitationsResult } from '../types/sent-band-invitation-list.type';
 import type { GetSentBandJoinRequestsResult } from '../types/sent-band-join-request-list.type';
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
@@ -65,6 +69,8 @@ export interface BandsRepository {
   createBand(input: CreateBandRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandRepositoryResult>;
   createBandInvitation(input: CreateBandInvitationRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandInvitationResult>;
   createBandJoinRequest(input: CreateBandJoinRequestRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandJoinRequestResult>;
+  approveBandJoinRequest(joinRequestId: string, bandId: string, userId: string, tx?: Prisma.TransactionClient): Promise<ApproveBandJoinRequestResult>;
+  rejectBandJoinRequest(joinRequestId: string, tx?: Prisma.TransactionClient): Promise<RejectBandJoinRequestResult>;
   deleteBand(bandId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteBandResult>;
   deleteBandInvitation(invitationId: string, tx?: Prisma.TransactionClient): Promise<DeleteBandInvitationResult>;
   findBandForLeave(
@@ -92,6 +98,7 @@ export interface BandsRepository {
     query: GetSentBandJoinRequestsQuery,
     tx?: Prisma.TransactionClient,
   ): Promise<GetSentBandJoinRequestsResult>;
+  findBandJoinRequests(bandId: string, query: GetBandJoinRequestsQuery, tx?: Prisma.TransactionClient): Promise<GetBandJoinRequestsResult>;
   searchBands(query: SearchBandsQuery, tx?: Prisma.TransactionClient): Promise<SearchBandsResult>;
   findActiveBandById(
     bandId: string,
@@ -113,6 +120,15 @@ export interface BandsRepository {
     tx?: Prisma.TransactionClient,
   ): Promise<{
     id: string;
+    status: JoinRequestStatus;
+  } | null>;
+  findBandJoinRequestForResponse(
+    joinRequestId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    bandId: string;
+    userId: string;
     status: JoinRequestStatus;
   } | null>;
   updateBand(bandId: string, input: UpdateBandInput, tx?: Prisma.TransactionClient): Promise<UpdateBandResult>;

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -3,6 +3,7 @@ import type { CreateBandInput } from '../dto/create-band.dto';
 import type { CreateBandInvitationInput } from '../dto/create-band-invitation.dto';
 import type { GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
+import type { GetReceivedBandInvitationsQuery } from '../dto/get-received-band-invitations-query.dto';
 import type { SearchBandsQuery } from '../dto/search-bands-query.dto';
 import type { UpdateBandInput } from '../dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
@@ -16,6 +17,7 @@ import type { DeleteBandInvitationResult } from '../types/delete-band-invitation
 import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult } from '../types/my-band-list.type';
+import type { GetReceivedBandInvitationsResult } from '../types/received-band-invitation-list.type';
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
 import type { UpdateBandResult } from '../types/update-band-result.type';
 
@@ -67,6 +69,11 @@ export interface BandsRepository {
   leaveBand(bandMemberId: string, tx?: Prisma.TransactionClient): Promise<LeaveBandResult>;
   findBandMembers(bandId: string, query: GetBandMembersQuery, tx?: Prisma.TransactionClient): Promise<GetBandMembersResult>;
   findMyBands(userId: string, query: GetMyBandsQuery, tx?: Prisma.TransactionClient): Promise<GetMyBandsResult>;
+  findReceivedBandInvitations(
+    userId: string,
+    query: GetReceivedBandInvitationsQuery,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetReceivedBandInvitationsResult>;
   searchBands(query: SearchBandsQuery, tx?: Prisma.TransactionClient): Promise<SearchBandsResult>;
   findActiveBandById(
     bandId: string,

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -11,6 +11,7 @@ import type { GetBandMembersResult } from '../types/band-member-list.type';
 import type { SearchBandsResult } from '../types/band-search-result.type';
 import type { CreateBandInvitationResult } from '../types/create-band-invitation-result.type';
 import type { CreateBandInvitationSuccessItem, CreateBandResult } from '../types/create-band-result.type';
+import type { DeclineBandInvitationResult } from '../types/decline-band-invitation-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult } from '../types/my-band-list.type';
@@ -90,7 +91,8 @@ export interface BandsRepository {
     id: string;
     status: BandInvitationStatus;
   } | null>;
-  findBandInvitationForAccept(
+  declineBandInvitation(invitationId: string, respondedAt: Date, tx?: Prisma.TransactionClient): Promise<DeclineBandInvitationResult>;
+  findBandInvitationForResponse(
     invitationId: string,
     tx?: Prisma.TransactionClient,
   ): Promise<{

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -4,6 +4,7 @@ import type { CreateBandInvitationInput } from '../dto/create-band-invitation.dt
 import type { GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { GetReceivedBandInvitationsQuery } from '../dto/get-received-band-invitations-query.dto';
+import type { GetSentBandInvitationsQuery } from '../dto/get-sent-band-invitations-query.dto';
 import type { SearchBandsQuery } from '../dto/search-bands-query.dto';
 import type { UpdateBandInput } from '../dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
@@ -18,6 +19,7 @@ import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult } from '../types/my-band-list.type';
 import type { GetReceivedBandInvitationsResult } from '../types/received-band-invitation-list.type';
+import type { GetSentBandInvitationsResult } from '../types/sent-band-invitation-list.type';
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
 import type { UpdateBandResult } from '../types/update-band-result.type';
 
@@ -74,6 +76,7 @@ export interface BandsRepository {
     query: GetReceivedBandInvitationsQuery,
     tx?: Prisma.TransactionClient,
   ): Promise<GetReceivedBandInvitationsResult>;
+  findSentBandInvitations(userId: string, query: GetSentBandInvitationsQuery, tx?: Prisma.TransactionClient): Promise<GetSentBandInvitationsResult>;
   searchBands(query: SearchBandsQuery, tx?: Prisma.TransactionClient): Promise<SearchBandsResult>;
   findActiveBandById(
     bandId: string,

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -6,6 +6,7 @@ import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { SearchBandsQuery } from '../dto/search-bands-query.dto';
 import type { UpdateBandInput } from '../dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
+import type { AcceptBandInvitationResult } from '../types/accept-band-invitation-result.type';
 import type { GetBandMembersResult } from '../types/band-member-list.type';
 import type { SearchBandsResult } from '../types/band-search-result.type';
 import type { CreateBandInvitationResult } from '../types/create-band-invitation-result.type';
@@ -39,6 +40,13 @@ export interface CreateBandInvitationRepositoryInput extends CreateBandInvitatio
 }
 
 export interface BandsRepository {
+  acceptBandInvitation(
+    invitationId: string,
+    bandId: string,
+    userId: string,
+    respondedAt: Date,
+    tx?: Prisma.TransactionClient,
+  ): Promise<AcceptBandInvitationResult>;
   createBand(input: CreateBandRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandRepositoryResult>;
   createBandInvitation(input: CreateBandInvitationRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandInvitationResult>;
   deleteBand(bandId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteBandResult>;
@@ -80,6 +88,15 @@ export interface BandsRepository {
     tx?: Prisma.TransactionClient,
   ): Promise<{
     id: string;
+    status: BandInvitationStatus;
+  } | null>;
+  findBandInvitationForAccept(
+    invitationId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    bandId: string;
+    inviteeUserId: string;
     status: BandInvitationStatus;
   } | null>;
   findBandBlacklistByBandIdAndUserId(

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -1,5 +1,6 @@
-import type { BandMemberRole, Prisma } from '../../../generated/prisma';
+import type { BandInvitationStatus, BandMemberRole, Prisma } from '../../../generated/prisma';
 import type { CreateBandInput } from '../dto/create-band.dto';
+import type { CreateBandInvitationInput } from '../dto/create-band-invitation.dto';
 import type { GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { SearchBandsQuery } from '../dto/search-bands-query.dto';
@@ -7,6 +8,7 @@ import type { UpdateBandInput } from '../dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
 import type { GetBandMembersResult } from '../types/band-member-list.type';
 import type { SearchBandsResult } from '../types/band-search-result.type';
+import type { CreateBandInvitationResult } from '../types/create-band-invitation-result.type';
 import type { CreateBandInvitationSuccessItem, CreateBandResult } from '../types/create-band-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { LeaveBandResult } from '../types/leave-band-result.type';
@@ -31,8 +33,14 @@ export interface CreateBandRepositoryResult extends CreateBandResult {
   };
 }
 
+export interface CreateBandInvitationRepositoryInput extends CreateBandInvitationInput {
+  bandId: string;
+  inviterBandMemberId: string;
+}
+
 export interface BandsRepository {
   createBand(input: CreateBandRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandRepositoryResult>;
+  createBandInvitation(input: CreateBandInvitationRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateBandInvitationResult>;
   deleteBand(bandId: string, deletedAt: Date, tx?: Prisma.TransactionClient): Promise<DeleteBandResult>;
   findBandForLeave(
     bandId: string,
@@ -64,6 +72,22 @@ export interface BandsRepository {
   ): Promise<{
     id: string;
     userId: string;
+    role: BandMemberRole;
+  } | null>;
+  findBandInvitationByBandIdAndInviteeUserId(
+    bandId: string,
+    inviteeUserId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    status: BandInvitationStatus;
+  } | null>;
+  findBandBlacklistByBandIdAndUserId(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
   } | null>;
   findExistingGenreIds(genreIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;
   findExistingUserIds(userIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -6,6 +6,7 @@ import type { GetBandMembersQuery } from '../dto/get-band-members-query.dto';
 import type { GetMyBandsQuery } from '../dto/get-my-bands-query.dto';
 import type { GetReceivedBandInvitationsQuery } from '../dto/get-received-band-invitations-query.dto';
 import type { GetSentBandInvitationsQuery } from '../dto/get-sent-band-invitations-query.dto';
+import type { GetSentBandJoinRequestsQuery } from '../dto/get-sent-band-join-requests-query.dto';
 import type { SearchBandsQuery } from '../dto/search-bands-query.dto';
 import type { UpdateBandInput } from '../dto/update-band.dto';
 import type { UpdateBandMemberRoleInput } from '../dto/update-band-member-role.dto';
@@ -22,6 +23,7 @@ import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult } from '../types/my-band-list.type';
 import type { GetReceivedBandInvitationsResult } from '../types/received-band-invitation-list.type';
 import type { GetSentBandInvitationsResult } from '../types/sent-band-invitation-list.type';
+import type { GetSentBandJoinRequestsResult } from '../types/sent-band-join-request-list.type';
 import type { UpdateBandMemberRoleResult } from '../types/update-band-member-role-result.type';
 import type { UpdateBandResult } from '../types/update-band-result.type';
 
@@ -85,6 +87,11 @@ export interface BandsRepository {
     tx?: Prisma.TransactionClient,
   ): Promise<GetReceivedBandInvitationsResult>;
   findSentBandInvitations(userId: string, query: GetSentBandInvitationsQuery, tx?: Prisma.TransactionClient): Promise<GetSentBandInvitationsResult>;
+  findSentBandJoinRequests(
+    userId: string,
+    query: GetSentBandJoinRequestsQuery,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetSentBandJoinRequestsResult>;
   searchBands(query: SearchBandsQuery, tx?: Prisma.TransactionClient): Promise<SearchBandsResult>;
   findActiveBandById(
     bandId: string,

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -131,6 +131,7 @@ export interface BandsRepository {
     userId: string;
     status: JoinRequestStatus;
   } | null>;
+  findBandManagerUserIdsByBandId(bandId: string, tx?: Prisma.TransactionClient): Promise<string[]>;
   updateBand(bandId: string, input: UpdateBandInput, tx?: Prisma.TransactionClient): Promise<UpdateBandResult>;
   findBandMemberByBandIdAndUserId(
     bandId: string,
@@ -164,6 +165,7 @@ export interface BandsRepository {
   ): Promise<{
     id: string;
     bandId: string;
+    inviterUserId: string;
     inviteeUserId: string;
     status: BandInvitationStatus;
   } | null>;

--- a/backend/src/modules/bands/types/accept-band-invitation-result.type.ts
+++ b/backend/src/modules/bands/types/accept-band-invitation-result.type.ts
@@ -1,0 +1,9 @@
+import type { BandInvitationStatus } from '../../../generated/prisma';
+
+export interface AcceptBandInvitationResult {
+  invitationId: string;
+  bandId: string;
+  userId: string;
+  invitationStatus: BandInvitationStatus;
+  joinedAt: string;
+}

--- a/backend/src/modules/bands/types/approve-band-join-request-result.type.ts
+++ b/backend/src/modules/bands/types/approve-band-join-request-result.type.ts
@@ -1,0 +1,9 @@
+import type { JoinRequestStatus } from '../../../generated/prisma';
+
+export interface ApproveBandJoinRequestResult {
+  joinRequestId: string;
+  bandId: string;
+  userId: string;
+  joinRequestStatus: JoinRequestStatus;
+  joinedAt: string;
+}

--- a/backend/src/modules/bands/types/band-join-request-list.type.ts
+++ b/backend/src/modules/bands/types/band-join-request-list.type.ts
@@ -1,0 +1,27 @@
+import type { JoinRequestStatus } from '../../../generated/prisma';
+
+export interface BandJoinRequestListItem {
+  joinRequestId: string;
+  requester: {
+    userId: string;
+    nickname: string;
+    avatarUrl: string | null;
+  };
+  message: string | null;
+  joinRequestStatus: JoinRequestStatus;
+  createdAt: string;
+}
+
+export interface BandJoinRequestCursor {
+  id: string;
+}
+
+export interface GetBandJoinRequestsResult {
+  items: BandJoinRequestListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: BandJoinRequestCursor | null;
+    next: BandJoinRequestCursor | null;
+  };
+}

--- a/backend/src/modules/bands/types/create-band-invitation-result.type.ts
+++ b/backend/src/modules/bands/types/create-band-invitation-result.type.ts
@@ -1,0 +1,10 @@
+import type { BandInvitationStatus } from '../../../generated/prisma';
+
+export interface CreateBandInvitationResult {
+  invitationId: string;
+  bandId: string;
+  inviterUserId: string;
+  inviteeUserId: string;
+  invitationStatus: BandInvitationStatus;
+  createdAt: string;
+}

--- a/backend/src/modules/bands/types/create-band-join-request-result.type.ts
+++ b/backend/src/modules/bands/types/create-band-join-request-result.type.ts
@@ -1,0 +1,9 @@
+import type { JoinRequestStatus } from '../../../generated/prisma';
+
+export interface CreateBandJoinRequestResult {
+  joinRequestId: string;
+  bandId: string;
+  userId: string;
+  joinRequestStatus: JoinRequestStatus;
+  createdAt: string;
+}

--- a/backend/src/modules/bands/types/decline-band-invitation-result.type.ts
+++ b/backend/src/modules/bands/types/decline-band-invitation-result.type.ts
@@ -1,0 +1,9 @@
+import type { BandInvitationStatus } from '../../../generated/prisma';
+
+export interface DeclineBandInvitationResult {
+  invitationId: string;
+  bandId: string;
+  userId: string;
+  invitationStatus: BandInvitationStatus;
+  respondedAt: string;
+}

--- a/backend/src/modules/bands/types/delete-band-invitation-result.type.ts
+++ b/backend/src/modules/bands/types/delete-band-invitation-result.type.ts
@@ -1,0 +1,3 @@
+export interface DeleteBandInvitationResult {
+  invitationId: string;
+}

--- a/backend/src/modules/bands/types/received-band-invitation-list.type.ts
+++ b/backend/src/modules/bands/types/received-band-invitation-list.type.ts
@@ -1,0 +1,31 @@
+import type { BandInvitationStatus } from '../../../generated/prisma';
+
+export interface ReceivedBandInvitationListItem {
+  invitationId: string;
+  band: {
+    bandId: string;
+    name: string;
+    description: string | null;
+  };
+  inviter: {
+    userId: string;
+    nickname: string;
+  };
+  message: string | null;
+  invitationStatus: BandInvitationStatus;
+  createdAt: string;
+}
+
+export interface ReceivedBandInvitationCursor {
+  id: string;
+}
+
+export interface GetReceivedBandInvitationsResult {
+  items: ReceivedBandInvitationListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: ReceivedBandInvitationCursor | null;
+    next: ReceivedBandInvitationCursor | null;
+  };
+}

--- a/backend/src/modules/bands/types/reject-band-join-request-result.type.ts
+++ b/backend/src/modules/bands/types/reject-band-join-request-result.type.ts
@@ -1,0 +1,8 @@
+import type { JoinRequestStatus } from '../../../generated/prisma';
+
+export interface RejectBandJoinRequestResult {
+  joinRequestId: string;
+  bandId: string;
+  userId: string;
+  joinRequestStatus: JoinRequestStatus;
+}

--- a/backend/src/modules/bands/types/sent-band-invitation-list.type.ts
+++ b/backend/src/modules/bands/types/sent-band-invitation-list.type.ts
@@ -1,0 +1,34 @@
+import type { BandInvitationStatus } from '../../../generated/prisma';
+
+export interface SentBandInvitationListItem {
+  invitationId: string;
+  band: {
+    bandId: string;
+    name: string;
+    description: string | null;
+    memberCount: number;
+  };
+  invitee: {
+    userId: string;
+    nickname: string;
+    avatarUrl: string | null;
+  };
+  invitationStatus: BandInvitationStatus;
+  message: string | null;
+  createdAt: string;
+  respondedAt: string | null;
+}
+
+export interface SentBandInvitationCursor {
+  id: string;
+}
+
+export interface GetSentBandInvitationsResult {
+  items: SentBandInvitationListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: SentBandInvitationCursor | null;
+    next: SentBandInvitationCursor | null;
+  };
+}

--- a/backend/src/modules/bands/types/sent-band-join-request-list.type.ts
+++ b/backend/src/modules/bands/types/sent-band-join-request-list.type.ts
@@ -1,0 +1,28 @@
+import type { JoinRequestStatus } from '../../../generated/prisma';
+
+export interface SentBandJoinRequestListItem {
+  joinRequestId: string;
+  band: {
+    bandId: string;
+    name: string;
+    description: string | null;
+    visibility: boolean;
+  };
+  message: string | null;
+  joinRequestStatus: JoinRequestStatus;
+  createdAt: string;
+}
+
+export interface SentBandJoinRequestCursor {
+  id: string;
+}
+
+export interface GetSentBandJoinRequestsResult {
+  items: SentBandJoinRequestListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: SentBandJoinRequestCursor | null;
+    next: SentBandJoinRequestCursor | null;
+  };
+}

--- a/backend/src/modules/notifications/notifications.module.ts
+++ b/backend/src/modules/notifications/notifications.module.ts
@@ -21,5 +21,6 @@ import { NotificationsService } from './notifications.service';
       useExisting: NotificationsPrismaRepository,
     },
   ],
+  exports: [NotificationsService],
 })
 export class NotificationsModule {}

--- a/backend/src/modules/notifications/notifications.service.spec.ts
+++ b/backend/src/modules/notifications/notifications.service.spec.ts
@@ -43,6 +43,12 @@ const mockDeleteResult: DeleteNotificationResult = { notificationId: 'noti-001' 
 const mockDeleteManyResult: DeleteManyNotificationsResult = { deletedCount: 2, notificationIds: ['noti-001', 'noti-002'] };
 
 const repositoryStub: NotificationsRepository = {
+  async createNotification() {
+    return undefined;
+  },
+  async createManyNotifications() {
+    return undefined;
+  },
   async findNotifications() {
     return mockListResult;
   },

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -3,7 +3,11 @@ import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import type { Prisma } from '../../generated/prisma';
 
 import type { GetNotificationsQuery } from './dto/get-notifications-query.dto';
-import { NOTIFICATIONS_REPOSITORY, type NotificationsRepository } from './repositories/notifications.repository';
+import {
+  type CreateNotificationRepositoryInput,
+  NOTIFICATIONS_REPOSITORY,
+  type NotificationsRepository,
+} from './repositories/notifications.repository';
 
 @Injectable()
 export class NotificationsService {
@@ -11,6 +15,14 @@ export class NotificationsService {
     @Inject(NOTIFICATIONS_REPOSITORY)
     private readonly notificationsRepository: NotificationsRepository,
   ) {}
+
+  async createNotification(input: CreateNotificationRepositoryInput, tx?: Prisma.TransactionClient) {
+    return this.notificationsRepository.createNotification(input, tx);
+  }
+
+  async createManyNotifications(inputs: CreateNotificationRepositoryInput[], tx?: Prisma.TransactionClient) {
+    return this.notificationsRepository.createManyNotifications(inputs, tx);
+  }
 
   async getNotifications(userId: string, query: GetNotificationsQuery, tx?: Prisma.TransactionClient) {
     return this.notificationsRepository.findNotifications(userId, query, tx);

--- a/backend/src/modules/notifications/repositories/notifications.prisma-repository.spec.ts
+++ b/backend/src/modules/notifications/repositories/notifications.prisma-repository.spec.ts
@@ -15,6 +15,8 @@ const mockNotification = {
 
 const mockPrisma = {
   notification: {
+    create: jest.fn(),
+    createMany: jest.fn(),
     findMany: jest.fn(),
     findFirst: jest.fn(),
     update: jest.fn(),

--- a/backend/src/modules/notifications/repositories/notifications.prisma-repository.ts
+++ b/backend/src/modules/notifications/repositories/notifications.prisma-repository.ts
@@ -10,7 +10,7 @@ import type { MarkManyReadResult } from '../types/mark-many-read-result.type';
 import type { MarkNotificationReadResult } from '../types/mark-notification-read-result.type';
 import type { GetNotificationsResult, NotificationListItem } from '../types/notification-list-item.type';
 
-import type { NotificationsRepository } from './notifications.repository';
+import type { CreateNotificationRepositoryInput, NotificationsRepository } from './notifications.repository';
 
 type NotificationRow = {
   id: string;
@@ -25,6 +25,40 @@ type NotificationRow = {
 @Injectable()
 export class NotificationsPrismaRepository implements NotificationsRepository {
   constructor(private readonly prisma: PrismaService) {}
+
+  async createNotification(input: CreateNotificationRepositoryInput, tx?: Prisma.TransactionClient): Promise<void> {
+    const client = this.getClient(tx);
+
+    await client.notification.create({
+      data: {
+        userId: input.userId,
+        type: input.type,
+        title: input.title,
+        description: input.description,
+        targetPath: input.targetPath,
+        remindsAt: input.remindsAt,
+      },
+    });
+  }
+
+  async createManyNotifications(inputs: CreateNotificationRepositoryInput[], tx?: Prisma.TransactionClient): Promise<void> {
+    if (inputs.length === 0) {
+      return;
+    }
+
+    const client = this.getClient(tx);
+
+    await client.notification.createMany({
+      data: inputs.map(input => ({
+        userId: input.userId,
+        type: input.type,
+        title: input.title,
+        description: input.description,
+        targetPath: input.targetPath,
+        remindsAt: input.remindsAt,
+      })),
+    });
+  }
 
   async findNotifications(userId: string, query: GetNotificationsQuery, tx?: Prisma.TransactionClient): Promise<GetNotificationsResult> {
     const client = this.getClient(tx);

--- a/backend/src/modules/notifications/repositories/notifications.repository.ts
+++ b/backend/src/modules/notifications/repositories/notifications.repository.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from '../../../generated/prisma';
+import type { NotificationType, Prisma } from '../../../generated/prisma';
 import type { GetNotificationsQuery } from '../dto/get-notifications-query.dto';
 import type { DeleteManyNotificationsResult } from '../types/delete-many-notifications-result.type';
 import type { DeleteNotificationResult } from '../types/delete-notification-result.type';
@@ -9,7 +9,18 @@ import type { GetNotificationsResult } from '../types/notification-list-item.typ
 
 export const NOTIFICATIONS_REPOSITORY = Symbol('NOTIFICATIONS_REPOSITORY');
 
+export interface CreateNotificationRepositoryInput {
+  userId: string;
+  type: NotificationType;
+  title: string;
+  description?: string | null;
+  targetPath?: string | null;
+  remindsAt?: Date | null;
+}
+
 export interface NotificationsRepository {
+  createNotification(input: CreateNotificationRepositoryInput, tx?: Prisma.TransactionClient): Promise<void>;
+  createManyNotifications(inputs: CreateNotificationRepositoryInput[], tx?: Prisma.TransactionClient): Promise<void>;
   findNotifications(userId: string, query: GetNotificationsQuery, tx?: Prisma.TransactionClient): Promise<GetNotificationsResult>;
   markAllNotificationsAsRead(userId: string, tx?: Prisma.TransactionClient): Promise<MarkAllReadResult>;
   markManyNotificationsAsRead(userId: string, notificationIds: string[], tx?: Prisma.TransactionClient): Promise<MarkManyReadResult>;


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 40분

<br/>

## 📌 작업 요약

- 밴드 초대 API 개발
- 밴드 가입 요청 API 개발
- 초대/가입 요청 생성, 목록 조회, 수락/승인/거절/취소 흐름 구현

<br/>

## 📝 작업 내용

1. 밴드 초대 생성
   - `POST /bands/:bandId/invitations`
   - 인증 필요
   - `BM`, `ADMIN`만 초대 가능
   - 자기 자신 초대 불가
   - 존재하지 않거나 비활성화된 사용자 초대 불가
   - 이미 멤버인 사용자 초대 불가
   - 블랙리스트 사용자 초대 불가
   - 기존 초대가 있으면 중복 생성 불가

2. 받은/보낸 초대 목록 조회
   - `GET /invitations/received`
   - `GET /invitations/sent`
   - 인증 필요
   - 기본 상태 필터는 `PENDING`
   - cursor는 `cursor__id`만 사용
   - 삭제된 밴드, 삭제된 사용자와 연결된 초대는 제외

3. 초대 수락/거절/취소
   - `POST /invitations/:invitationId/accept`
   - `POST /invitations/:invitationId/decline`
   - `DELETE /invitations/:invitationId`
   - 수락/거절은 초대받은 사용자만 가능
   - 취소는 초대를 보낸 사용자만 가능
   - `PENDING` 상태만 수락/거절/취소 가능
   - 수락 시 `BandInvitation.status = ACCEPTED` 후 `BandMember` 생성
   - 취소는 DB에 `CANCELED` 상태가 없어 hard delete

4. 밴드 가입 요청 생성
   - `POST /bands/:bandId/join-requests`
   - 인증 필요
   - 공개 밴드만 가입 요청 가능
   - 이미 멤버인 사용자 요청 불가
   - 블랙리스트 사용자 요청 불가
   - 기존 초대 또는 기존 가입 요청이 있으면 중복 요청 불가

5. 가입 요청 목록 조회
   - `GET /join-requests/sent`
   - `GET /bands/:bandId/join-requests`
   - 인증 필요
   - 내가 보낸 가입 요청과 밴드로 들어온 가입 요청을 분리
   - 밴드로 들어온 가입 요청 조회는 `BM`, `ADMIN`만 가능
   - 기본 상태 필터는 `PENDING`

6. 가입 요청 승인/거절
   - `POST /join-requests/:joinRequestId/approve`
   - `POST /join-requests/:joinRequestId/reject`
   - `BM`, `ADMIN`만 처리 가능
   - `PENDING` 상태만 승인/거절 가능
   - 승인 시 `BandJoinRequest.status = APPROVED` 후 `BandMember` 생성
   - 거절 시 `BandJoinRequest.status = REJECTED`

<br/>

## 🚨 주요 고민 및 결정

### 권한 정책

- 초대 생성은 `BM`, `ADMIN`만 가능
- 가입 요청 생성은 일반 인증 사용자가 공개 밴드에만 가능
- 밴드로 들어온 가입 요청 조회/승인/거절은 `BM`, `ADMIN`만 가능
- 초대 수락/거절은 초대받은 사용자 기준
- 초대 취소는 초대를 보낸 사용자 기준

### 초대와 가입 요청의 중복 관계

- 같은 밴드/사용자 관계에서 초대와 가입 요청이 동시에 존재하면 상태 관리가 애매해짐
- 가입 요청 생성 시 기존 초대가 있으면 막도록 구현
- 가입 요청은 schema의 `@@unique([bandId, userId])` 기준으로 기존 요청이 있으면 재요청 불가
- `REJECTED` 이후 재요청 허용이 필요하면 schema 또는 update 정책 변경이 먼저 필요함

### 응답 조회 메서드 재사용

- 구현을 하다보니 초대 수락/거절에서 조회 목적이 같아 `findBandInvitationForAccept`처럼 특정 액션에 묶인 이름 대신 `findBandInvitationForResponse`로 일반화
- 가입 요청도 승인/거절 공통 조회용으로 `findBandJoinRequestForResponse`를 추가

<br/>


## 💬 리뷰 요구사항

- 가입 요청 조회/승인/거절 권한을 `BM`, `ADMIN`으로 제한한 정책이 적절한지
- `REJECTED` 가입 요청의 재요청을 막는 현재 정책이 괜찮은지

| 상황                | API                                          | 알림 수신자                 | type     | title                              | description                             | targetPath                     | 비고                                                                         |
| ------------------- | -------------------------------------------- | --------------------------- | -------- | ---------------------------------- | --------------------------------------- | ------------------------------ | ---------------------------------------------------------------------------- |
| 밴드 초대 생성      | `POST /bands/:bandId/invitations`            | 초대받은 사용자             | `INVITE` | `밴드 초대가 도착했습니다.`        | `새 밴드 초대가 도착했습니다.`          | `/invitations/received`        | 초대 생성과 같은 transaction에서 생성                                        |
| 밴드 초대 수락      | `POST /invitations/:invitationId/accept`     | 초대를 보낸 사용자          | `INVITE` | `밴드 초대를 수락했습니다.`        | `보낸 밴드 초대가 수락되었습니다.`      | `/bands/:bandId/members`       | 초대 row 삭제와 멤버 생성 이후 생성                                          |
| 밴드 초대 거절      | `POST /invitations/:invitationId/decline`    | 초대를 보낸 사용자          | `INVITE` | `밴드 초대를 거절했습니다.`        | `보낸 밴드 초대가 거절되었습니다.`      | `/invitations/sent`            | 초대 상태를 `DECLINED`로 변경한 이후 생성                                    |
| 밴드 초대 취소      | `DELETE /invitations/:invitationId`          | 없음                        | -        | -                                  | -                                       | -                              | 취소는 보낸 사용자의 직접 작업이고 `CANCELED` 상태가 없어 hard delete만 처리 |
| 밴드 가입 요청 생성 | `POST /bands/:bandId/join-requests`          | 밴드의 `BM`, `ADMIN` 사용자 | `INVITE` | `밴드 가입 요청이 도착했습니다.`   | `새 밴드 가입 요청이 도착했습니다.`     | `/bands/:bandId/join-requests` | 요청자 자신은 수신자에서 제외                                                |
| 밴드 가입 요청 승인 | `POST /join-requests/:joinRequestId/approve` | 가입 요청을 보낸 사용자     | `INVITE` | `밴드 가입 요청이 승인되었습니다.` | `보낸 밴드 가입 요청이 승인되었습니다.` | `/bands/:bandId`               | 가입 요청 승인과 멤버 생성 이후 생성                                         |
| 밴드 가입 요청 거절 | `POST /join-requests/:joinRequestId/reject`  | 가입 요청을 보낸 사용자     | `INVITE` | `밴드 가입 요청이 거절되었습니다.` | `보낸 밴드 가입 요청이 거절되었습니다.` | `/join-requests/sent`          | 가입 요청 상태를 `REJECTED`로 변경한 이후 생성  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 밴드 초대 기능 추가(생성·수신/발신 조회·수락·거절·취소)
  * 밴드 가입 요청 기능 추가(생성·발신/밴드별 조회·승인·거절)
  * 초대·가입 요청에 메시지 입력 가능
  * 알림 생성 기능 추가(단건/다건 생성 지원) — 관련 알림 발송 흐름 확장

* **Tests**
  * 초대·가입 요청 서비스 및 리포지토리 테스트 대폭 확장 (권한·상태·트랜잭션 포함)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BandCo-House/BandCo/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->