### PR TITLE
primary color 이름 변경

### DIFF
--- a/frontend/tokens/tokens.json
+++ b/frontend/tokens/tokens.json
@@ -13,7 +13,7 @@
         }
       }
     },
-    "main": {
+    "primary": {
       "main": {
         "value": "#ecfcab",
         "type": "color",
@@ -319,41 +319,41 @@
     },
     "fontSize": {
       "0": {
-        "value": 12,
+        "value": "12",
         "type": "fontSizes"
       },
       "1": {
-        "value": 14,
+        "value": "14",
         "type": "fontSizes"
       },
       "2": {
-        "value": 16,
+        "value": "16",
         "type": "fontSizes"
       },
       "3": {
-        "value": 18,
+        "value": "18",
         "type": "fontSizes"
       },
       "4": {
-        "value": 20,
+        "value": "20",
         "type": "fontSizes"
       },
       "5": {
-        "value": 24,
+        "value": "24",
         "type": "fontSizes"
       },
       "6": {
-        "value": 28,
+        "value": "28",
         "type": "fontSizes"
       },
       "7": {
-        "value": 32,
+        "value": "32",
         "type": "fontSizes"
       }
     },
     "letterSpacing": {
       "0": {
-        "value": 0,
+        "value": "0",
         "type": "letterSpacing"
       },
       "1": {
@@ -363,11 +363,11 @@
     },
     "paragraphSpacing": {
       "0": {
-        "value": 0,
+        "value": "0",
         "type": "paragraphSpacing"
       },
       "1": {
-        "value": 25.706586837768555,
+        "value": "25.706586837768555",
         "type": "paragraphSpacing"
       }
     },


### PR DESCRIPTION
main(변경 전) -> primary(변경 후)
다크모드에서 ECFCAB_main, 9CA578_light, 272B22(80%)_surface 세 가지 색상 그룹 이름 변경




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 다크 테마의 색상 시스템 구조를 개선했습니다.
  * 타이포그래피 및 간격 설정값을 일관되게 표준화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BandCo-House/BandCo/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->