### PR TITLE
[Kan-46] 네비게이션

### DIFF
--- a/frontend/src/app/layouts/RootLayout.tsx
+++ b/frontend/src/app/layouts/RootLayout.tsx
@@ -1,4 +1,10 @@
-import { Link, Outlet, useMatches, useRouter, useRouterState } from '@tanstack/react-router';
+import {
+  Link,
+  Outlet,
+  useMatches,
+  useRouter,
+  useRouterState,
+} from '@tanstack/react-router';
 import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui/button';
 import {
@@ -122,7 +128,7 @@ export const RootLayout = () => {
     : null;
 
   return (
-    <div className="mx-auto flex h-dvh min-h-0 max-w-[648px] flex-col">
+    <div className="mx-auto flex min-h-dvh max-w-[648px] flex-col">
       {pageHeaderProps ? (
         <PageHeader {...pageHeaderProps} onBack={onBack} />
       ) : null}
@@ -130,7 +136,7 @@ export const RootLayout = () => {
         className={cn(
           'mx-auto min-h-0 w-full flex-1',
           pageHeaderProps ? undefined : 'min-h-screen',
-          showBottomNav && 'pb-16',
+          showBottomNav && 'mb-16',
         )}
       >
         <div className="mx-auto w-full max-w-7xl px-5 py-8">

--- a/frontend/src/app/layouts/RootLayout.tsx
+++ b/frontend/src/app/layouts/RootLayout.tsx
@@ -22,7 +22,9 @@ export const RootLayout = () => {
   const matches = useMatches();
   const activeMatch = matches.at(-1);
   const pathname = useRouterState({ select: (s) => s.location.pathname });
-  const showBottomNav = !HIDDEN_NAV_PATHS.some((p) => pathname.startsWith(p));
+  const showBottomNav = !HIDDEN_NAV_PATHS.some(
+    (p) => pathname === p || pathname.startsWith(`${p}/`),
+  );
   const currentParams = (activeMatch?.params ?? {}) as Record<string, string>;
 
   const header = resolveHeader(
@@ -142,6 +144,7 @@ export const RootLayout = () => {
       {pageHeaderProps ? (
         <PageHeader {...pageHeaderProps} onBack={onBack} />
       ) : null}
+
       <main
         className={cn(
           'mx-auto min-h-0 w-full flex-1',

--- a/frontend/src/app/layouts/RootLayout.tsx
+++ b/frontend/src/app/layouts/RootLayout.tsx
@@ -1,4 +1,4 @@
-import { Link, Outlet, useMatches, useRouter } from '@tanstack/react-router';
+import { Link, Outlet, useMatches, useRouter, useRouterState } from '@tanstack/react-router';
 import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui/button';
 import {
@@ -6,11 +6,17 @@ import {
   type RouteStaticData,
   resolveHeader,
 } from '@/widgets/page-header';
+import { BottomNavBar } from '@/widgets/bottom-nav';
+
+/** 하단 네비게이션을 표시하지 않을 경로 목록 */
+const HIDDEN_NAV_PATHS = ['/login', '/signup', '/onboarding'];
 
 export const RootLayout = () => {
   const router = useRouter();
   const matches = useMatches();
   const activeMatch = matches.at(-1);
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const showBottomNav = !HIDDEN_NAV_PATHS.some((p) => pathname.startsWith(p));
   const currentParams = (activeMatch?.params ?? {}) as Record<string, string>;
 
   const header = resolveHeader(
@@ -124,12 +130,14 @@ export const RootLayout = () => {
         className={cn(
           'mx-auto min-h-0 w-full flex-1',
           pageHeaderProps ? undefined : 'min-h-screen',
+          showBottomNav && 'pb-16',
         )}
       >
         <div className="mx-auto w-full max-w-7xl px-5 py-8">
           <Outlet />
         </div>
       </main>
+      {showBottomNav ? <BottomNavBar /> : null}
     </div>
   );
 };

--- a/frontend/src/app/layouts/RootLayout.tsx
+++ b/frontend/src/app/layouts/RootLayout.tsx
@@ -122,10 +122,20 @@ export const RootLayout = () => {
   const pageHeaderProps = header
     ? {
         title: header.title ?? '',
+        titleSize: header.titleSize,
         showBack: header.showBack,
         rightContent,
+        heightVariant: header.heightVariant,
+        renderRight: header.renderRight,
       }
     : null;
+
+  const HEIGHT_MARGIN_CLASSES = {
+    xs: 'mt-9',
+    sm: 'mt-14',
+    md: 'mt-[60px]',
+    lg: 'mt-16',
+  };
 
   return (
     <div className="mx-auto flex min-h-dvh max-w-[648px] flex-col">
@@ -137,6 +147,7 @@ export const RootLayout = () => {
           'mx-auto min-h-0 w-full flex-1',
           pageHeaderProps ? undefined : 'min-h-screen',
           showBottomNav && 'mb-16',
+          pageHeaderProps && HEIGHT_MARGIN_CLASSES[header?.heightVariant || 'lg'],
         )}
       >
         <div className="mx-auto w-full max-w-7xl px-5 py-8">

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -7,6 +7,7 @@ export const createAppRouter = () => {
     routeTree,
     context: {} as RouterContext,
     defaultPendingMinMs: 150,
+    scrollRestoration: true,
   });
 };
 

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import { BandList } from '@/widgets/band-list/ui/BandList';
 import { createFileRoute } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/')({
@@ -11,11 +10,7 @@ export const Route = createFileRoute('/')({
   },
 });
 
-// 홈(내 밴드 목록) 라우트 전용 화면
+// 홈 라우트 전용 화면
 function MyBandsRoutePage() {
-  return (
-    <div data-testid="my-bands-page" className="mt-header-64">
-      <BandList />
-    </div>
-  );
+  return <div data-testid="my-bands-page">홈 화면 구현 예정</div>;
 }

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -12,5 +12,5 @@ export const Route = createFileRoute('/')({
 
 // 홈 라우트 전용 화면
 function MyBandsRoutePage() {
-  return <div data-testid="my-bands-page">홈 화면 구현 예정</div>;
+  return <div data-testid="home-page">홈 화면 구현 예정</div>;
 }

--- a/frontend/src/pages/my-bands.tsx
+++ b/frontend/src/pages/my-bands.tsx
@@ -1,19 +1,54 @@
+import { Search, Bell, Plus } from 'lucide-react';
+import { BandList } from '@/widgets/band-list/ui/BandList';
 import { createFileRoute } from '@tanstack/react-router';
+
+// 내 밴드 전용 우측 다중 아이콘 액션 버튼 컴포넌트
+function MyBandsHeaderActions() {
+  return (
+    <div className="flex items-center gap-3 pr-2">
+      <button 
+        onClick={() => alert('검색 페이지 혹은 레이어 열기')} 
+        className="p-1.5 text-foreground hover:bg-overlay-24 rounded-full transition-colors focus-visible:outline-2 focus-visible:outline-key"
+        aria-label="검색"
+      >
+        <Search className="size-6" />
+      </button>
+      <button 
+        onClick={() => alert('알림 페이지 혹은 레이어 열기')} 
+        className="relative p-1.5 text-foreground hover:bg-overlay-24 rounded-full transition-colors focus-visible:outline-2 focus-visible:outline-key"
+        aria-label="알림"
+      >
+        <Bell className="size-6" />
+        <span className="absolute top-1.5 right-1.5 size-2 bg-red-500 rounded-full" />
+      </button>
+      <button 
+        onClick={() => alert('밴드 생성 모달 열기')} 
+        className="p-1.5 text-foreground hover:bg-overlay-24 rounded-full transition-colors focus-visible:outline-2 focus-visible:outline-key"
+        aria-label="밴드 추가"
+      >
+        <Plus className="size-6" />
+      </button>
+    </div>
+  );
+}
 
 export const Route = createFileRoute('/my-bands')({
   component: MyBandsPage,
   staticData: {
     header: {
       title: '내 밴드',
+      titleSize: 'lg',
       showBack: false,
+      heightVariant: 'lg', // 64px 기본 높이
+      renderRight: () => <MyBandsHeaderActions />,
     },
   },
 });
 
 function MyBandsPage() {
   return (
-    <div data-testid="my-bands-route-page" className="flex items-center justify-center py-20">
-      <p className="text-muted-foreground typo-base-r">내 밴드 목록 준비 중입니다.</p>
+    <div data-testid="my-bands-route-page">
+      <BandList />
     </div>
   );
 }

--- a/frontend/src/pages/my-bands.tsx
+++ b/frontend/src/pages/my-bands.tsx
@@ -23,7 +23,7 @@ function MyBandsHeaderActions() {
       <Link
         to="/profile"
         className="rounded-full transition-colors"
-        aria-label="설정"
+        aria-label="마이 페이지"
       >
         <Plus className="size-6" />
       </Link>

--- a/frontend/src/pages/my-bands.tsx
+++ b/frontend/src/pages/my-bands.tsx
@@ -5,24 +5,24 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 // 내 밴드 전용 우측 다중 아이콘 액션 버튼 컴포넌트
 function MyBandsHeaderActions() {
   return (
-    <div className="flex items-center gap-3 text-grey-100">
+    <div className="flex items-center gap-4.5 text-grey-100">
       <Link
         to="/search"
-        className="rounded-full p-1.5 transition-colors hover:bg-overlay-24 focus-visible:outline-2 focus-visible:outline-key"
+        className="rounded-full transition-colors"
         aria-label="검색"
       >
         <Search className="size-6" />
       </Link>
       <Link
         to="/notifications"
-        className="relative rounded-full p-1.5 transition-colors hover:bg-overlay-24 focus-visible:outline-2 focus-visible:outline-key"
+        className="relative rounded-full transition-colors"
         aria-label="알림"
       >
         <Bell className="size-6" />
       </Link>
       <Link
         to="/profile"
-        className="rounded-full p-1.5 transition-colors hover:bg-overlay-24 focus-visible:outline-2 focus-visible:outline-key"
+        className="rounded-full transition-colors"
         aria-label="설정"
       >
         <Plus className="size-6" />

--- a/frontend/src/pages/my-bands.tsx
+++ b/frontend/src/pages/my-bands.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/my-bands')({
+  component: MyBandsPage,
+  staticData: {
+    header: {
+      title: '내 밴드',
+      showBack: false,
+    },
+  },
+});
+
+function MyBandsPage() {
+  return (
+    <div data-testid="my-bands-route-page" className="flex items-center justify-center py-20">
+      <p className="text-muted-foreground typo-base-r">내 밴드 목록 준비 중입니다.</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/my-bands.tsx
+++ b/frontend/src/pages/my-bands.tsx
@@ -1,4 +1,4 @@
-import { Search, Bell, Plus } from 'lucide-react';
+import { Search, Bell, Plus, Settings } from 'lucide-react';
 import { BandList } from '@/widgets/band-list/ui/BandList';
 import { createFileRoute, Link } from '@tanstack/react-router';
 
@@ -25,7 +25,7 @@ function MyBandsHeaderActions() {
         className="rounded-full transition-colors"
         aria-label="마이 페이지"
       >
-        <Plus className="size-6" />
+        <Settings className="size-6" />
       </Link>
     </div>
   );

--- a/frontend/src/pages/my-bands.tsx
+++ b/frontend/src/pages/my-bands.tsx
@@ -1,4 +1,4 @@
-import { Search, Bell, Plus, Settings } from 'lucide-react';
+import { Search, Bell, Settings } from 'lucide-react';
 import { BandList } from '@/widgets/band-list/ui/BandList';
 import { createFileRoute, Link } from '@tanstack/react-router';
 

--- a/frontend/src/pages/my-bands.tsx
+++ b/frontend/src/pages/my-bands.tsx
@@ -1,33 +1,32 @@
 import { Search, Bell, Plus } from 'lucide-react';
 import { BandList } from '@/widgets/band-list/ui/BandList';
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, Link } from '@tanstack/react-router';
 
 // 내 밴드 전용 우측 다중 아이콘 액션 버튼 컴포넌트
 function MyBandsHeaderActions() {
   return (
-    <div className="flex items-center gap-3 pr-2">
-      <button 
-        onClick={() => alert('검색 페이지 혹은 레이어 열기')} 
-        className="p-1.5 text-foreground hover:bg-overlay-24 rounded-full transition-colors focus-visible:outline-2 focus-visible:outline-key"
+    <div className="flex items-center gap-3 text-grey-100">
+      <Link
+        to="/search"
+        className="rounded-full p-1.5 transition-colors hover:bg-overlay-24 focus-visible:outline-2 focus-visible:outline-key"
         aria-label="검색"
       >
         <Search className="size-6" />
-      </button>
-      <button 
-        onClick={() => alert('알림 페이지 혹은 레이어 열기')} 
-        className="relative p-1.5 text-foreground hover:bg-overlay-24 rounded-full transition-colors focus-visible:outline-2 focus-visible:outline-key"
+      </Link>
+      <Link
+        to="/notifications"
+        className="relative rounded-full p-1.5 transition-colors hover:bg-overlay-24 focus-visible:outline-2 focus-visible:outline-key"
         aria-label="알림"
       >
         <Bell className="size-6" />
-        <span className="absolute top-1.5 right-1.5 size-2 bg-red-500 rounded-full" />
-      </button>
-      <button 
-        onClick={() => alert('밴드 생성 모달 열기')} 
-        className="p-1.5 text-foreground hover:bg-overlay-24 rounded-full transition-colors focus-visible:outline-2 focus-visible:outline-key"
-        aria-label="밴드 추가"
+      </Link>
+      <Link
+        to="/profile"
+        className="rounded-full p-1.5 transition-colors hover:bg-overlay-24 focus-visible:outline-2 focus-visible:outline-key"
+        aria-label="설정"
       >
         <Plus className="size-6" />
-      </button>
+      </Link>
     </div>
   );
 }

--- a/frontend/src/pages/notifications.tsx
+++ b/frontend/src/pages/notifications.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/notifications')({
+  component: NotificationsPage,
+  staticData: {
+    header: {
+      title: '알림',
+      showBack: true, // 알림 페이지에서는 뒤로 가기가 가능하도록 설정
+      heightVariant: 'lg',
+    },
+  },
+});
+
+function NotificationsPage() {
+  return (
+    <div data-testid="notifications-page" className="flex flex-col items-center justify-center py-20 text-center">
+      <p className="text-muted-foreground typo-base-r">알림 페이지 구현 예정입니다.</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/search')({
+  component: SearchPage,
+  staticData: {
+    header: {
+      title: '검색',
+      showBack: false,
+    },
+  },
+});
+
+function SearchPage() {
+  return (
+    <div data-testid="search-page" className="flex items-center justify-center py-20">
+      <p className="text-muted-foreground typo-base-r">검색 기능 준비 중입니다.</p>
+    </div>
+  );
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SignupRouteImport } from './pages/signup'
 import { Route as SearchRouteImport } from './pages/search'
 import { Route as ProfileRouteImport } from './pages/profile'
 import { Route as OnboardingRouteImport } from './pages/onboarding'
+import { Route as NotificationsRouteImport } from './pages/notifications'
 import { Route as MyBandsRouteImport } from './pages/my-bands'
 import { Route as LoginRouteImport } from './pages/login'
 import { Route as ForgotPasswordRouteImport } from './pages/forgot-password'
@@ -46,6 +47,11 @@ const ProfileRoute = ProfileRouteImport.update({
 const OnboardingRoute = OnboardingRouteImport.update({
   id: '/onboarding',
   path: '/onboarding',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const NotificationsRoute = NotificationsRouteImport.update({
+  id: '/notifications',
+  path: '/notifications',
   getParentRoute: () => rootRouteImport,
 } as any)
 const MyBandsRoute = MyBandsRouteImport.update({
@@ -127,6 +133,7 @@ export interface FileRoutesByFullPath {
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
   '/my-bands': typeof MyBandsRoute
+  '/notifications': typeof NotificationsRoute
   '/onboarding': typeof OnboardingRoute
   '/profile': typeof ProfileRoute
   '/search': typeof SearchRoute
@@ -147,6 +154,7 @@ export interface FileRoutesByTo {
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
   '/my-bands': typeof MyBandsRoute
+  '/notifications': typeof NotificationsRoute
   '/onboarding': typeof OnboardingRoute
   '/profile': typeof ProfileRoute
   '/search': typeof SearchRoute
@@ -166,6 +174,7 @@ export interface FileRoutesById {
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
   '/my-bands': typeof MyBandsRoute
+  '/notifications': typeof NotificationsRoute
   '/onboarding': typeof OnboardingRoute
   '/profile': typeof ProfileRoute
   '/search': typeof SearchRoute
@@ -188,6 +197,7 @@ export interface FileRouteTypes {
     | '/forgot-password'
     | '/login'
     | '/my-bands'
+    | '/notifications'
     | '/onboarding'
     | '/profile'
     | '/search'
@@ -208,6 +218,7 @@ export interface FileRouteTypes {
     | '/forgot-password'
     | '/login'
     | '/my-bands'
+    | '/notifications'
     | '/onboarding'
     | '/profile'
     | '/search'
@@ -226,6 +237,7 @@ export interface FileRouteTypes {
     | '/forgot-password'
     | '/login'
     | '/my-bands'
+    | '/notifications'
     | '/onboarding'
     | '/profile'
     | '/search'
@@ -247,6 +259,7 @@ export interface RootRouteChildren {
   ForgotPasswordRoute: typeof ForgotPasswordRoute
   LoginRoute: typeof LoginRoute
   MyBandsRoute: typeof MyBandsRoute
+  NotificationsRoute: typeof NotificationsRoute
   OnboardingRoute: typeof OnboardingRoute
   ProfileRoute: typeof ProfileRoute
   SearchRoute: typeof SearchRoute
@@ -284,6 +297,13 @@ declare module '@tanstack/react-router' {
       path: '/onboarding'
       fullPath: '/onboarding'
       preLoaderRoute: typeof OnboardingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/notifications': {
+      id: '/notifications'
+      path: '/notifications'
+      fullPath: '/notifications'
+      preLoaderRoute: typeof NotificationsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/my-bands': {
@@ -427,6 +447,7 @@ const rootRouteChildren: RootRouteChildren = {
   ForgotPasswordRoute: ForgotPasswordRoute,
   LoginRoute: LoginRoute,
   MyBandsRoute: MyBandsRoute,
+  NotificationsRoute: NotificationsRoute,
   OnboardingRoute: OnboardingRoute,
   ProfileRoute: ProfileRoute,
   SearchRoute: SearchRoute,

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -10,8 +10,10 @@
 
 import { Route as rootRouteImport } from './pages/__root'
 import { Route as SignupRouteImport } from './pages/signup'
+import { Route as SearchRouteImport } from './pages/search'
 import { Route as ProfileRouteImport } from './pages/profile'
 import { Route as OnboardingRouteImport } from './pages/onboarding'
+import { Route as MyBandsRouteImport } from './pages/my-bands'
 import { Route as LoginRouteImport } from './pages/login'
 import { Route as ForgotPasswordRouteImport } from './pages/forgot-password'
 import { Route as AdminRouteImport } from './pages/admin'
@@ -31,6 +33,11 @@ const SignupRoute = SignupRouteImport.update({
   path: '/signup',
   getParentRoute: () => rootRouteImport,
 } as any)
+const SearchRoute = SearchRouteImport.update({
+  id: '/search',
+  path: '/search',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ProfileRoute = ProfileRouteImport.update({
   id: '/profile',
   path: '/profile',
@@ -39,6 +46,11 @@ const ProfileRoute = ProfileRouteImport.update({
 const OnboardingRoute = OnboardingRouteImport.update({
   id: '/onboarding',
   path: '/onboarding',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MyBandsRoute = MyBandsRouteImport.update({
+  id: '/my-bands',
+  path: '/my-bands',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -114,8 +126,10 @@ export interface FileRoutesByFullPath {
   '/admin': typeof AdminRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
+  '/my-bands': typeof MyBandsRoute
   '/onboarding': typeof OnboardingRoute
   '/profile': typeof ProfileRoute
+  '/search': typeof SearchRoute
   '/signup': typeof SignupRoute
   '/band/$bandId': typeof BandBandIdRouteWithChildren
   '/band/$bandId/settings': typeof BandBandIdSettingsRoute
@@ -132,8 +146,10 @@ export interface FileRoutesByTo {
   '/admin': typeof AdminRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
+  '/my-bands': typeof MyBandsRoute
   '/onboarding': typeof OnboardingRoute
   '/profile': typeof ProfileRoute
+  '/search': typeof SearchRoute
   '/signup': typeof SignupRoute
   '/band/$bandId/settings': typeof BandBandIdSettingsRoute
   '/band/$bandId/songs': typeof BandBandIdSongsRoute
@@ -149,8 +165,10 @@ export interface FileRoutesById {
   '/admin': typeof AdminRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
+  '/my-bands': typeof MyBandsRoute
   '/onboarding': typeof OnboardingRoute
   '/profile': typeof ProfileRoute
+  '/search': typeof SearchRoute
   '/signup': typeof SignupRoute
   '/band/$bandId': typeof BandBandIdRouteWithChildren
   '/band/$bandId/settings': typeof BandBandIdSettingsRoute
@@ -169,8 +187,10 @@ export interface FileRouteTypes {
     | '/admin'
     | '/forgot-password'
     | '/login'
+    | '/my-bands'
     | '/onboarding'
     | '/profile'
+    | '/search'
     | '/signup'
     | '/band/$bandId'
     | '/band/$bandId/settings'
@@ -187,8 +207,10 @@ export interface FileRouteTypes {
     | '/admin'
     | '/forgot-password'
     | '/login'
+    | '/my-bands'
     | '/onboarding'
     | '/profile'
+    | '/search'
     | '/signup'
     | '/band/$bandId/settings'
     | '/band/$bandId/songs'
@@ -203,8 +225,10 @@ export interface FileRouteTypes {
     | '/admin'
     | '/forgot-password'
     | '/login'
+    | '/my-bands'
     | '/onboarding'
     | '/profile'
+    | '/search'
     | '/signup'
     | '/band/$bandId'
     | '/band/$bandId/settings'
@@ -222,8 +246,10 @@ export interface RootRouteChildren {
   AdminRoute: typeof AdminRoute
   ForgotPasswordRoute: typeof ForgotPasswordRoute
   LoginRoute: typeof LoginRoute
+  MyBandsRoute: typeof MyBandsRoute
   OnboardingRoute: typeof OnboardingRoute
   ProfileRoute: typeof ProfileRoute
+  SearchRoute: typeof SearchRoute
   SignupRoute: typeof SignupRoute
   BandBandIdRoute: typeof BandBandIdRouteWithChildren
   SongSongIdTeamsRoute: typeof SongSongIdTeamsRoute
@@ -239,6 +265,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SignupRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/search': {
+      id: '/search'
+      path: '/search'
+      fullPath: '/search'
+      preLoaderRoute: typeof SearchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/profile': {
       id: '/profile'
       path: '/profile'
@@ -251,6 +284,13 @@ declare module '@tanstack/react-router' {
       path: '/onboarding'
       fullPath: '/onboarding'
       preLoaderRoute: typeof OnboardingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/my-bands': {
+      id: '/my-bands'
+      path: '/my-bands'
+      fullPath: '/my-bands'
+      preLoaderRoute: typeof MyBandsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -386,8 +426,10 @@ const rootRouteChildren: RootRouteChildren = {
   AdminRoute: AdminRoute,
   ForgotPasswordRoute: ForgotPasswordRoute,
   LoginRoute: LoginRoute,
+  MyBandsRoute: MyBandsRoute,
   OnboardingRoute: OnboardingRoute,
   ProfileRoute: ProfileRoute,
+  SearchRoute: SearchRoute,
   SignupRoute: SignupRoute,
   BandBandIdRoute: BandBandIdRouteWithChildren,
   SongSongIdTeamsRoute: SongSongIdTeamsRoute,

--- a/frontend/src/widgets/band-list/ui/BandList.test.tsx
+++ b/frontend/src/widgets/band-list/ui/BandList.test.tsx
@@ -24,9 +24,6 @@ describe('BandList', () => {
 
     expect(await screen.findByText('합주하자')).toBeInTheDocument();
     expect(screen.getByText('락스타')).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: '밴드 메뉴 열기' }),
-    ).toBeInTheDocument();
   });
 
   it('로딩 중일 때 로딩 상태를 표시한다', async () => {

--- a/frontend/src/widgets/bottom-nav/index.ts
+++ b/frontend/src/widgets/bottom-nav/index.ts
@@ -1,0 +1,1 @@
+export { BottomNavBar } from './ui/BottomNavBar';

--- a/frontend/src/widgets/bottom-nav/index.ts
+++ b/frontend/src/widgets/bottom-nav/index.ts
@@ -1,1 +1,2 @@
 export { BottomNavBar } from './ui/BottomNavBar';
+export { NAV_ITEMS, type NavItem } from './nav-items';

--- a/frontend/src/widgets/bottom-nav/nav-items.ts
+++ b/frontend/src/widgets/bottom-nav/nav-items.ts
@@ -1,4 +1,4 @@
-import { Home, Search, Music2, User } from 'lucide-react';
+import { Home, Search, TargetIcon, User } from 'lucide-react';
 import type { ComponentType } from 'react';
 
 export type NavItem = {
@@ -11,6 +11,6 @@ export type NavItem = {
 export const NAV_ITEMS: NavItem[] = [
   { key: 'home', label: '홈', to: '/', icon: Home },
   { key: 'search', label: '검색', to: '/search', icon: Search },
-  { key: 'my-bands', label: '내 밴드', to: '/my-bands', icon: Music2 },
+  { key: 'my-bands', label: '내 밴드', to: '/my-bands', icon: TargetIcon },
   { key: 'my', label: '마이', to: '/profile', icon: User },
 ];

--- a/frontend/src/widgets/bottom-nav/nav-items.ts
+++ b/frontend/src/widgets/bottom-nav/nav-items.ts
@@ -1,0 +1,16 @@
+import { Home, Search, Music2, User } from 'lucide-react';
+import type { ComponentType } from 'react';
+
+export type NavItem = {
+  key: string;
+  label: string;
+  to: string;
+  icon: ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
+};
+
+export const NAV_ITEMS: NavItem[] = [
+  { key: 'home', label: '홈', to: '/', icon: Home },
+  { key: 'search', label: '검색', to: '/search', icon: Search },
+  { key: 'my-bands', label: '내 밴드', to: '/my-bands', icon: Music2 },
+  { key: 'my', label: '마이', to: '/profile', icon: User },
+];

--- a/frontend/src/widgets/bottom-nav/ui/BottomNavBar.test.tsx
+++ b/frontend/src/widgets/bottom-nav/ui/BottomNavBar.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { BottomNavBar, type NavItem } from './BottomNavBar';
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouterState: vi.fn(),
+  Link: ({
+    to,
+    children,
+    ...props
+  }: {
+    to: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { useRouterState } from '@tanstack/react-router';
+
+const mockUseRouterState = vi.mocked(useRouterState);
+
+/** 테스트 전용 mock 메뉴 아이템 — 실제 NAV_ITEMS와 무관하게 동작을 검증한다 */
+const MOCK_ITEMS: NavItem[] = [
+  { key: 'alpha', label: 'Alpha', to: '/alpha', icon: () => <svg aria-hidden /> },
+  { key: 'beta', label: 'Beta', to: '/beta', icon: () => <svg aria-hidden /> },
+  { key: 'gamma', label: 'Gamma', to: '/gamma', icon: () => <svg aria-hidden /> },
+];
+
+function renderNav(pathname: string, items = MOCK_ITEMS) {
+  mockUseRouterState.mockReturnValue(
+    pathname as unknown as ReturnType<typeof useRouterState>,
+  );
+  return render(<BottomNavBar items={items} />);
+}
+
+describe('BottomNavBar', () => {
+  it('전달된 items를 모두 렌더링한다', () => {
+    renderNav('/alpha');
+
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+    expect(screen.getByText('Gamma')).toBeInTheDocument();
+  });
+
+  it('nav landmark와 aria-label이 올바르게 설정된다', () => {
+    renderNav('/alpha');
+
+    expect(
+      screen.getByRole('navigation', { name: '하단 네비게이션' }),
+    ).toBeInTheDocument();
+  });
+
+  it('현재 pathname과 일치하는 메뉴에 aria-current="page"가 설정된다', () => {
+    renderNav('/beta');
+
+    expect(screen.getByText('Beta').closest('a')).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+  });
+
+  it('현재 pathname과 일치하지 않는 메뉴에는 aria-current가 없다', () => {
+    renderNav('/beta');
+
+    expect(screen.getByText('Alpha').closest('a')).not.toHaveAttribute('aria-current');
+    expect(screen.getByText('Gamma').closest('a')).not.toHaveAttribute('aria-current');
+  });
+
+  it('각 메뉴 링크의 href가 item.to와 일치한다', () => {
+    renderNav('/alpha');
+
+    expect(screen.getByText('Alpha').closest('a')).toHaveAttribute('href', '/alpha');
+    expect(screen.getByText('Beta').closest('a')).toHaveAttribute('href', '/beta');
+    expect(screen.getByText('Gamma').closest('a')).toHaveAttribute('href', '/gamma');
+  });
+
+  it('pathname이 변경되면 active 메뉴도 변경된다', () => {
+    const { rerender } = renderNav('/alpha');
+    expect(screen.getByText('Alpha').closest('a')).toHaveAttribute('aria-current', 'page');
+
+    mockUseRouterState.mockReturnValue(
+      '/gamma' as unknown as ReturnType<typeof useRouterState>,
+    );
+    rerender(<BottomNavBar items={MOCK_ITEMS} />);
+
+    expect(screen.getByText('Alpha').closest('a')).not.toHaveAttribute('aria-current');
+    expect(screen.getByText('Gamma').closest('a')).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('items를 전달하지 않으면 기본 NAV_ITEMS로 렌더링된다', () => {
+    mockUseRouterState.mockReturnValue(
+      '/' as unknown as ReturnType<typeof useRouterState>,
+    );
+    render(<BottomNavBar />);
+
+    // 실제 메뉴 항목 수(4개)만 검증 — 레이블 하드코딩 없이
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(4);
+  });
+});

--- a/frontend/src/widgets/bottom-nav/ui/BottomNavBar.test.tsx
+++ b/frontend/src/widgets/bottom-nav/ui/BottomNavBar.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { BottomNavBar, type NavItem } from './BottomNavBar';
+import { BottomNavBar } from './BottomNavBar';
+import type { NavItem } from '../nav-items';
 
 vi.mock('@tanstack/react-router', () => ({
   useRouterState: vi.fn(),

--- a/frontend/src/widgets/bottom-nav/ui/BottomNavBar.tsx
+++ b/frontend/src/widgets/bottom-nav/ui/BottomNavBar.tsx
@@ -3,21 +3,25 @@ import { Home, Search, Music2, User } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import type { ComponentType } from 'react';
 
-type NavItem = {
+export type NavItem = {
   key: string;
   label: string;
   to: string;
   icon: ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
 };
 
-const NAV_ITEMS: NavItem[] = [
+export const NAV_ITEMS: NavItem[] = [
   { key: 'home', label: '홈', to: '/', icon: Home },
   { key: 'search', label: '검색', to: '/search', icon: Search },
   { key: 'my-bands', label: '내 밴드', to: '/my-bands', icon: Music2 },
   { key: 'my', label: '마이', to: '/profile', icon: User },
 ];
 
-export function BottomNavBar() {
+type BottomNavBarProps = {
+  items?: NavItem[];
+};
+
+export function BottomNavBar({ items = NAV_ITEMS }: BottomNavBarProps) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
 
   return (
@@ -35,7 +39,7 @@ export function BottomNavBar() {
       }}
     >
       <ul className="flex h-16 items-center justify-around px-2">
-        {NAV_ITEMS.map((item) => {
+        {items.map((item) => {
           const isActive = pathname === item.to;
           const Icon = item.icon;
 

--- a/frontend/src/widgets/bottom-nav/ui/BottomNavBar.tsx
+++ b/frontend/src/widgets/bottom-nav/ui/BottomNavBar.tsx
@@ -13,7 +13,7 @@ export function BottomNavBar({ items = NAV_ITEMS }: BottomNavBarProps) {
     <nav
       aria-label="하단 네비게이션"
       className={cn(
-        'fixed bottom-0 z-50 w-full max-w-[648px] bg-gradient-top/60 drop-shadow-2xl',
+        'fixed bottom-0 z-40 w-full max-w-[648px] bg-gradient-top/60 drop-shadow-2xl',
         'backdrop-blur-sm',
       )}
       style={{

--- a/frontend/src/widgets/bottom-nav/ui/BottomNavBar.tsx
+++ b/frontend/src/widgets/bottom-nav/ui/BottomNavBar.tsx
@@ -1,21 +1,6 @@
 import { Link, useRouterState } from '@tanstack/react-router';
-import { Home, Search, Music2, User } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
-import type { ComponentType } from 'react';
-
-export type NavItem = {
-  key: string;
-  label: string;
-  to: string;
-  icon: ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
-};
-
-export const NAV_ITEMS: NavItem[] = [
-  { key: 'home', label: '홈', to: '/', icon: Home },
-  { key: 'search', label: '검색', to: '/search', icon: Search },
-  { key: 'my-bands', label: '내 밴드', to: '/my-bands', icon: Music2 },
-  { key: 'my', label: '마이', to: '/profile', icon: User },
-];
+import { NAV_ITEMS, type NavItem } from '../nav-items';
 
 type BottomNavBarProps = {
   items?: NavItem[];

--- a/frontend/src/widgets/bottom-nav/ui/BottomNavBar.tsx
+++ b/frontend/src/widgets/bottom-nav/ui/BottomNavBar.tsx
@@ -13,17 +13,15 @@ export function BottomNavBar({ items = NAV_ITEMS }: BottomNavBarProps) {
     <nav
       aria-label="하단 네비게이션"
       className={cn(
-        'fixed bottom-0 z-50 w-full max-w-[648px]',
-        'border-t border-border backdrop-blur-sm',
+        'fixed bottom-0 z-50 w-full max-w-[648px] bg-gradient-top/60 drop-shadow-2xl',
+        'backdrop-blur-sm',
       )}
       style={{
-        background:
-          'linear-gradient(135deg, var(--gradient-top) 0%, var(--gradient-bottom) 100%)',
         backgroundAttachment: 'fixed',
         paddingBottom: 'env(safe-area-inset-bottom)',
       }}
     >
-      <ul className="flex h-16 items-center justify-around px-2">
+      <ul className="flex h-18 items-center justify-around px-2">
         {items.map((item) => {
           const isActive = pathname === item.to;
           const Icon = item.icon;
@@ -34,26 +32,16 @@ export function BottomNavBar({ items = NAV_ITEMS }: BottomNavBarProps) {
                 to={item.to}
                 aria-current={isActive ? 'page' : undefined}
                 className={cn(
-                  'flex flex-col items-center justify-center gap-1 rounded-xl py-2 transition-colors',
-                  'hover:bg-overlay-24 focus-visible:outline-2 focus-visible:outline-key',
-                  isActive ? 'text-primary' : 'text-muted-foreground',
+                  'flex flex-col items-center justify-center gap-2 py-3 transition-colors',
+                  'hover:text-primary focus-visible:outline-2 focus-visible:outline-key',
+                  isActive ? 'text-primary' : 'text-gray-300',
                 )}
               >
                 <Icon
                   aria-hidden={true}
-                  className={cn(
-                    'size-6 transition-transform duration-200',
-                    isActive && 'scale-110',
-                  )}
+                  className={cn('size-6 transition-transform duration-200')}
                 />
-                <span
-                  className={cn(
-                    'transition-colors',
-                    isActive ? 'typo-xs-sb' : 'typo-xs-r',
-                  )}
-                >
-                  {item.label}
-                </span>
+                <span className="typo-xs-sb">{item.label}</span>
               </Link>
             </li>
           );

--- a/frontend/src/widgets/bottom-nav/ui/BottomNavBar.tsx
+++ b/frontend/src/widgets/bottom-nav/ui/BottomNavBar.tsx
@@ -1,0 +1,75 @@
+import { Link, useRouterState } from '@tanstack/react-router';
+import { Home, Search, Music2, User } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+import type { ComponentType } from 'react';
+
+type NavItem = {
+  key: string;
+  label: string;
+  to: string;
+  icon: ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
+};
+
+const NAV_ITEMS: NavItem[] = [
+  { key: 'home', label: '홈', to: '/', icon: Home },
+  { key: 'search', label: '검색', to: '/search', icon: Search },
+  { key: 'my-bands', label: '내 밴드', to: '/my-bands', icon: Music2 },
+  { key: 'my', label: '마이', to: '/profile', icon: User },
+];
+
+export function BottomNavBar() {
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+
+  return (
+    <nav
+      aria-label="하단 네비게이션"
+      className={cn(
+        'fixed bottom-0 z-50 w-full max-w-[648px]',
+        'border-t border-border backdrop-blur-sm',
+      )}
+      style={{
+        background:
+          'linear-gradient(135deg, var(--gradient-top) 0%, var(--gradient-bottom) 100%)',
+        backgroundAttachment: 'fixed',
+        paddingBottom: 'env(safe-area-inset-bottom)',
+      }}
+    >
+      <ul className="flex h-16 items-center justify-around px-2">
+        {NAV_ITEMS.map((item) => {
+          const isActive = pathname === item.to;
+          const Icon = item.icon;
+
+          return (
+            <li key={item.key} className="flex-1">
+              <Link
+                to={item.to}
+                aria-current={isActive ? 'page' : undefined}
+                className={cn(
+                  'flex flex-col items-center justify-center gap-1 rounded-xl py-2 transition-colors',
+                  'hover:bg-overlay-24 focus-visible:outline-2 focus-visible:outline-key',
+                  isActive ? 'text-primary' : 'text-muted-foreground',
+                )}
+              >
+                <Icon
+                  aria-hidden={true}
+                  className={cn(
+                    'size-6 transition-transform duration-200',
+                    isActive && 'scale-110',
+                  )}
+                />
+                <span
+                  className={cn(
+                    'transition-colors',
+                    isActive ? 'typo-xs-sb' : 'typo-xs-r',
+                  )}
+                >
+                  {item.label}
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/frontend/src/widgets/bottom-nav/ui/BottomNavBar.tsx
+++ b/frontend/src/widgets/bottom-nav/ui/BottomNavBar.tsx
@@ -23,7 +23,10 @@ export function BottomNavBar({ items = NAV_ITEMS }: BottomNavBarProps) {
     >
       <ul className="flex h-18 items-center justify-around px-2">
         {items.map((item) => {
-          const isActive = pathname === item.to;
+          const isActive =
+            item.to === '/'
+              ? pathname === '/'
+              : pathname === item.to || pathname.startsWith(`${item.to}/`);
           const Icon = item.icon;
 
           return (

--- a/frontend/src/widgets/page-header/page-header.test.tsx
+++ b/frontend/src/widgets/page-header/page-header.test.tsx
@@ -50,4 +50,40 @@ describe('PageHeader', () => {
       'sr-only',
     );
   });
+
+  it('heightVariant 크기에 맞춰 높이 클래스를 정상 적용해야 한다', () => {
+    const { rerender } = render(<PageHeader title="테스트" heightVariant="xs" />);
+    expect(screen.getByRole('banner').firstElementChild).toHaveClass('min-h-9');
+
+    rerender(<PageHeader title="테스트" heightVariant="sm" />);
+    expect(screen.getByRole('banner').firstElementChild).toHaveClass('min-h-14');
+
+    rerender(<PageHeader title="테스트" heightVariant="md" />);
+    expect(screen.getByRole('banner').firstElementChild).toHaveClass('min-h-[60px]');
+
+    rerender(<PageHeader title="테스트" heightVariant="lg" />);
+    expect(screen.getByRole('banner').firstElementChild).toHaveClass('min-h-16');
+  });
+
+  it('titleSize가 md이면 typo-lg-sb 클래스를 사용해야 한다', () => {
+    render(<PageHeader title="중간 크기 타이틀" titleSize="md" />);
+    expect(screen.getByRole('heading', { name: '중간 크기 타이틀' })).toHaveClass('typo-lg-sb');
+  });
+
+  it('title로 함수가 전달되면 기본 래퍼 없이 컴포넌트 자체를 렌더링한다', () => {
+    render(<PageHeader title={() => <span data-testid="custom-title">로고</span>} />);
+    expect(screen.getByTestId('custom-title')).toBeInTheDocument();
+    expect(screen.queryByRole('heading')).toBeNull(); // h1 태그가 존재하지 않아야 함
+  });
+
+  it('renderRight 함수가 제공되면 해당 컴포넌트를 우측 컨텐츠로 렌더링한다', () => {
+    render(
+      <PageHeader 
+        title="커스텀 우측" 
+        renderRight={() => <button data-testid="custom-btn">클릭</button>} 
+      />
+    );
+    expect(screen.getByTestId('custom-btn')).toBeInTheDocument();
+  });
 });
+

--- a/frontend/src/widgets/page-header/page-header.test.tsx
+++ b/frontend/src/widgets/page-header/page-header.test.tsx
@@ -39,8 +39,9 @@ describe('PageHeader', () => {
       'mx-auto',
       'w-full',
       'max-w-7xl',
-      'px-6',
+      'px-5',
     );
+
   });
 
   it('타이틀은 기본 상태에서도 모바일에서 보여야 한다', () => {

--- a/frontend/src/widgets/page-header/page-header.tsx
+++ b/frontend/src/widgets/page-header/page-header.tsx
@@ -1,22 +1,58 @@
 import type { ReactNode } from 'react';
 import ArrowRightIcon from '@/assets/icons/arrow-right.svg?react';
+import { cn } from '@/shared/lib/utils';
 
 export type PageHeaderProps = {
-  title: string;
+  title: string | (() => ReactNode);
+  titleSize?: 'md' | 'lg';
   showBack?: boolean;
   onBack?: () => void;
   rightContent?: ReactNode;
+  heightVariant?: 'xs' | 'sm' | 'md' | 'lg';
+  renderRight?: () => ReactNode;
+};
+
+const HEIGHT_CLASSES = {
+  xs: 'min-h-9',
+  sm: 'min-h-14',
+  md: 'min-h-[60px]',
+  lg: 'min-h-16',
 };
 
 /**
- * 라우트 레벨에서 공통으로 사용하는 표준 페이지 헤더
+ * 라우트 레벨에서 공통으로 사용하는 표준 페이지 헤더 (높이 및 타이틀 커스텀 확장)
  */
 export const PageHeader = ({
   title,
+  titleSize = 'lg',
   showBack = false,
   onBack,
   rightContent,
+  heightVariant = 'lg',
+  renderRight,
 }: PageHeaderProps) => {
+  
+  const renderTitleArea = () => {
+    if (!title) return null;
+
+    // Case 1: 타이틀이 함수(컴포넌트 렌더러)인 경우 -> 기본 h1 스타일 무시하고 통째로 렌더링
+    if (typeof title === 'function') {
+      return <div className="flex-1 min-w-0">{title()}</div>;
+    }
+
+    // Case 2: 타이틀이 일반 텍스트(string)인 경우
+    const titleClass = cn(
+      "min-w-0 truncate text-foreground",
+      titleSize === 'md' ? 'typo-lg-sb' : 'typo-xl-sb sm:typo-2xl-b'
+    );
+
+    return (
+      <h1 className={titleClass}>
+        {title}
+      </h1>
+    );
+  };
+
   return (
     <header
       className="fixed top-0 z-50 w-full max-w-[648px] shrink-0 backdrop-blur-sm"
@@ -26,7 +62,12 @@ export const PageHeader = ({
         backgroundAttachment: 'fixed',
       }}
     >
-      <div className="mx-auto grid min-h-16 w-full max-w-7xl grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-6">
+      <div 
+        className={cn(
+          "mx-auto grid w-full max-w-7xl grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-6 transition-all duration-200",
+          HEIGHT_CLASSES[heightVariant]
+        )}
+      >
         <div className="flex min-w-0 items-center gap-3">
           {showBack ? (
             <button
@@ -43,14 +84,12 @@ export const PageHeader = ({
             </button>
           ) : null}
 
-          <h1 className="min-w-0 truncate typo-xl-sb text-foreground sm:typo-2xl-b">
-            {title}
-          </h1>
+          {renderTitleArea()}
         </div>
 
-        {rightContent ? (
+        {(renderRight || rightContent) ? (
           <div className="flex min-w-0 items-center justify-end gap-2">
-            {rightContent}
+            {renderRight ? renderRight() : rightContent}
           </div>
         ) : null}
       </div>

--- a/frontend/src/widgets/page-header/page-header.tsx
+++ b/frontend/src/widgets/page-header/page-header.tsx
@@ -31,26 +31,21 @@ export const PageHeader = ({
   heightVariant = 'lg',
   renderRight,
 }: PageHeaderProps) => {
-  
   const renderTitleArea = () => {
     if (!title) return null;
 
     // Case 1: 타이틀이 함수(컴포넌트 렌더러)인 경우 -> 기본 h1 스타일 무시하고 통째로 렌더링
     if (typeof title === 'function') {
-      return <div className="flex-1 min-w-0">{title()}</div>;
+      return <div className="min-w-0 flex-1">{title()}</div>;
     }
 
     // Case 2: 타이틀이 일반 텍스트(string)인 경우
     const titleClass = cn(
-      "min-w-0 truncate text-foreground",
-      titleSize === 'md' ? 'typo-lg-sb' : 'typo-xl-sb sm:typo-2xl-b'
+      'min-w-0 truncate text-grey-50',
+      titleSize === 'md' ? 'typo-lg-sb' : 'typo-xl-sb',
     );
 
-    return (
-      <h1 className={titleClass}>
-        {title}
-      </h1>
-    );
+    return <h1 className={titleClass}>{title}</h1>;
   };
 
   return (
@@ -62,10 +57,10 @@ export const PageHeader = ({
         backgroundAttachment: 'fixed',
       }}
     >
-      <div 
+      <div
         className={cn(
-          "mx-auto grid w-full max-w-7xl grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-6 transition-all duration-200",
-          HEIGHT_CLASSES[heightVariant]
+          'mx-auto grid w-full max-w-7xl grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-5 transition-all duration-200',
+          HEIGHT_CLASSES[heightVariant],
         )}
       >
         <div className="flex min-w-0 items-center gap-3">
@@ -87,7 +82,7 @@ export const PageHeader = ({
           {renderTitleArea()}
         </div>
 
-        {(renderRight || rightContent) ? (
+        {renderRight || rightContent ? (
           <div className="flex min-w-0 items-center justify-end gap-2">
             {renderRight ? renderRight() : rightContent}
           </div>

--- a/frontend/src/widgets/page-header/types.ts
+++ b/frontend/src/widgets/page-header/types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 /**
  * 헤더 탭 아이템 정의
  */
@@ -28,19 +30,23 @@ export type HeaderResolveContext = {
  * 동적 resolve 함수가 반환할 수 있는 헤더 필드
  */
 export type HeaderResolveResult = {
-  title?: string;
+  title?: string | (() => ReactNode);
+  titleSize?: 'md' | 'lg';
   subtitle?: string;
   brandLabel?: string;
   meta?: string[];
   tabs?: HeaderTab[];
   rightActionLabel?: string;
+  heightVariant?: 'xs' | 'sm' | 'md' | 'lg';
+  renderRight?: () => ReactNode;
 };
 
 /**
  * 라우트 staticData에 저장되는 헤더 설정
  */
 export type HeaderStaticConfig = {
-  title?: string;
+  title?: string | (() => ReactNode);
+  titleSize?: 'md' | 'lg';
   subtitle?: string;
   brandLabel?: string;
   showBack?: boolean;
@@ -55,6 +61,9 @@ export type HeaderStaticConfig = {
     params: Record<string, string>,
   ) => Record<string, string>;
   resolve?: (ctx: HeaderResolveContext) => HeaderResolveResult;
+  
+  heightVariant?: 'xs' | 'sm' | 'md' | 'lg';
+  renderRight?: () => ReactNode;
 };
 
 /**
@@ -63,3 +72,4 @@ export type HeaderStaticConfig = {
 export type RouteStaticData = {
   header?: HeaderStaticConfig;
 };
+


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간:  5m

<br/>

## 📌 작업 요약

https://github.com/user-attachments/assets/e4bdb82c-e266-451b-8034-781d17370219

(영상에선 페이지 이동 시 스크롤이 남아있게되는데 페이지 이동 시 스크롤이 초기화 되도록 변경 했습니다.)


네비게이션 바 구현 및 상단 헤더 수정

<br/>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요 (이미지 첨부 가능)

1. 네비게이션 바 구현했습니다.
2. 홈 라우트를 비우고 밴드리스트는 my-bands 라우트를 추가해 옮겼습니다.
3. 상단 헤더의 설정 값들을 추가했습니다. (title 사이즈, header 높이 설정, title을 컴포넌트로 커스텀해서 넣기, rightActions 등...)
4. my-bands의 헤더를 피그마와 비슷하게 맞췄습니다.


## 💬 리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 하단 네비게이션 바 추가: 홈, 검색, 내 밴드, 마이 페이지로 구성
  * 새 페이지 추가: 내 밴드, 알림, 검색 페이지

* **개선사항**
  * 페이지 헤더 확장: 타이틀 크기, 높이 변형, 우측 컨텐츠 커스터마이징 가능
  * 라우트별 하단 네비게이션 동적 노출 제어
  * 페이지 레이아웃 및 여백 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BandCo-House/BandCo/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->