### PR TITLE
[KAN-67] vercel 백엔드 서버 연결

### DIFF
--- a/frontend/src/mocks/config.ts
+++ b/frontend/src/mocks/config.ts
@@ -1,1 +1,3 @@
-export const API_URL = '/api';
+import { API_BASE_URL } from '@/shared/api/config';
+
+export const API_URL = API_BASE_URL;

--- a/frontend/src/shared/api/config.ts
+++ b/frontend/src/shared/api/config.ts
@@ -1,4 +1,5 @@
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
+export const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || (import.meta.env.DEV ? '/api' : '');
 
 export const API_TIMEOUT = 10_000;
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,42 +1,48 @@
-import path from "path";
-import tailwindcss from "@tailwindcss/vite";
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
-import svgr from "vite-plugin-svgr";
-import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
+import path from 'path';
+import tailwindcss from '@tailwindcss/vite';
+import { defineConfig, loadEnv } from 'vite';
+import react from '@vitejs/plugin-react';
+import svgr from 'vite-plugin-svgr';
+import { TanStackRouterVite } from '@tanstack/router-plugin/vite';
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [
-    TanStackRouterVite({
-      target: "react",
-      routesDirectory: "./src/pages",
-      generatedRouteTree: "./src/routeTree.gen.ts",
-      autoCodeSplitting: false,
-    }),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const apiProxyTarget = env.API_PROXY_TARGET ?? 'http://localhost:3000';
 
-    react({
-      babel: {
-        plugins: [["babel-plugin-react-compiler"]],
-      },
-    }),
+  return {
+    plugins: [
+      TanStackRouterVite({
+        target: 'react',
+        routesDirectory: './src/pages',
+        generatedRouteTree: './src/routeTree.gen.ts',
+        autoCodeSplitting: false,
+      }),
 
-    tailwindcss(),
-    svgr(),
-  ],
+      react({
+        babel: {
+          plugins: [['babel-plugin-react-compiler']],
+        },
+      }),
 
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
-  },
+      tailwindcss(),
+      svgr(),
+    ],
 
-  server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
       },
     },
-  },
+
+    server: {
+      proxy: {
+        '/api': {
+          target: apiProxyTarget,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api/, ''),
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
`frontend/src/shared/api/config.ts`: dev는 msw, dev가 아니면 기본값 서버 주소
`frontend/vite.config.ts`: dev proxy `/api` -> 서버주소, 백엔드가 `/api` prefix를 안 쓰므로 proxy에서 `/api` 제거
`frontend/src/mocks/config.ts`: MSW도 공용 `API_BASE_URL`을 재사용