### PR TITLE
[KAN-68] 프로필 음악 메타데이터 저장/조회 구현

### DIFF
--- a/backend/docs/backend/api-docs/users.md
+++ b/backend/docs/backend/api-docs/users.md
@@ -1,0 +1,421 @@
+# users API
+
+> 최종 동기화: 2026-05-31 | Notion: https://www.notion.so/ab542fc9fb31839fbdd60168c20bcd41
+>
+> ⚠️ 변환 노트: Notion 원본 응답 형식은 `{ "status": "success", "error": null, "message": "...", "data": {...} }` 구조이나, 프로젝트 컨벤션인 `{ "data": ..., "success": true }` 형식으로 변환함. 실제 서버 응답은 Notion 원본 형식을 따름.
+>
+> ⚠️ 설계자 보완 [2026-05-31]: (1) `GET /profile-music/search` 경로를 `GET /users/profile-music/search`로 수정 (users 컨트롤러 prefix 반영). (2) `PATCH /users/profiles` 명세 경로를 `PATCH /users/:userId/profiles`로 수정 (실제 컨트롤러 구현 기준). (3) 프로필 음악 검색 응답 `items` 배열 래핑 추가.
+
+---
+
+## POST /auth/register/email
+
+**설명:** 이메일과 비밀번호로 회원가입
+**인증:** 불필요
+
+### Request
+
+**Body**
+
+```json
+{
+  "email": "dejunsday@gmail.com",
+  "password": "p@assw@rd"
+}
+```
+
+### Response 200
+
+```json
+{
+  "data": {
+    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400  | 잘못된 입력 (이메일 형식 오류, 비밀번호 조건 미충족 등) |
+| 409  | 이미 가입된 이메일 |
+
+---
+
+## POST /auth/login/email
+
+**설명:** 이메일/비밀번호 기반 로그인 (Basic 인증)
+**인증:** 불필요 (Authorization 헤더 사용)
+
+### Request
+
+**Headers**
+
+| 헤더 | 형식 | 필수 | 설명 |
+|------|------|:----:|------|
+| Authorization | `Basic {base64}` | ✅ | `email:password`를 Base64 인코딩한 값 (공백 없이). 예: `Basic ZGV2anVuc2RheUBnbWFpbC5jb206cEBzc3dAcmQ=` |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400  | Authorization 헤더 누락 또는 형식 오류 |
+| 401  | 이메일 또는 비밀번호 불일치 |
+
+---
+
+## GET /users/{userId}/profiles
+
+**설명:** 특정 유저의 프로필 조회 (유저 정보 + 프로필 + 스킬 + 좋아하는 장르)
+**인증:** 불필요
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| userId | string (UUID) | ✅ | 조회할 유저의 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "user": {
+      "id": "b6d0f0b1-7c7d-4e23-9c7b-0c0d9f6a2a21",
+      "email": "devjunsday@gmail.com",
+      "status": "ACTIVE",
+      "createdAt": "2026-03-01T10:15:22.123+09:00"
+    },
+    "profile": {
+      "nickname": "devjun",
+      "selfDescription": "기타를 좋아합니다 🎸",
+      "profileMusic": {
+        "externalTrackId": "123456789",
+        "sourceType": "DEEZER",
+        "title": "Bohemian Rhapsody",
+        "artistName": "Queen",
+        "albumName": "A Night at the Opera",
+        "albumImageUrl": "https://cdn.deezer.com/images/album/cover.jpg",
+        "durationMs": 354000,
+        "previewUrl": "https://cdn.deezer.com/preview/abc123.mp3",
+        "sourceUrl": "https://www.deezer.com/track/123456789"
+      },
+      "avatarUrl": "https://cdn.domain.com/avatar.png"
+    },
+    "skills": [
+      {
+        "skillTypeId": "f1a2b3c4-...",
+        "skillName": "GUITAR",
+        "level": "ADVANCED",
+        "isPrimary": true
+      },
+      {
+        "skillTypeId": "d9e8f7a6-...",
+        "skillName": "VOCAL",
+        "level": "INTERMEDIATE",
+        "isPrimary": false
+      }
+    ],
+    "favoriteGenres": [
+      {
+        "genreId": "1111-2222-...",
+        "name": "ROCK"
+      },
+      {
+        "genreId": "3333-4444-...",
+        "name": "JAZZ"
+      }
+    ]
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 404  | 존재하지 않는 userId |
+
+---
+
+## GET /users/
+
+**설명:** 유저 전체 검색 (닉네임 또는 이메일 기반 필터, 커서 페이지네이션)
+**인증:** 불필요
+
+### Request
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|---------|------|:----:|:-----:|------|
+| where__nickname__contain | string | 선택 | - | nickname에 포함된 단어로 검색 |
+| where__email__contain | string | 선택 | - | email에 포함된 단어로 검색 |
+| order__created_at | string (`ASC`\|`DESC`) | 선택 | `DESC` | 생성일 기준 정렬 |
+| order__id | string (`ASC`\|`DESC`) | 선택 | - | ID 기준 정렬 |
+| take | number | 선택 | `20` | 페이지당 항목 수 |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "items": [
+      {
+        "id": "b6d0f0b1-7c7d-4e23-9c7b-0c0d9f6a2a21",
+        "email": "devjunsday@gmail.com",
+        "nickname": "devjun",
+        "status": "ACTIVE",
+        "avatarUrl": "https://cdn.domain.com/avatar.png",
+        "createdAt": "2026-03-01T10:15:22.123+09:00"
+      },
+      {
+        "id": "c1a2b3d4-9e7f-4c1d-a111-92ad9f1c22bb",
+        "email": "devjun2@gmail.com",
+        "nickname": "devjun_guitar",
+        "status": "ACTIVE",
+        "avatarUrl": null,
+        "createdAt": "2026-02-28T09:11:10.000+09:00"
+      }
+    ],
+    "meta": {
+      "count": 2,
+      "take": 20,
+      "cursor": {
+        "createdAt": "2026-02-28T09:11:10.000+09:00",
+        "id": "c1a2b3d4-9e7f-4c1d-a111-92ad9f1c22bb"
+      },
+      "next": null
+    }
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400  | 잘못된 쿼리 파라미터 형식 |
+
+---
+
+## PATCH /users/:userId/profiles
+
+**설명:** 로그인한 유저의 프로필 수정 (유저 정보 + 프로필 + 스킬 + 좋아하는 장르 일괄 처리)
+**인증:** 필요 (JWT Bearer)
+
+### Request
+
+**Body**
+
+```json
+{
+  "profile": {
+    "nickname": "devjun",
+    "selfDescription": "기타 좋아함 🎸",
+    "profileMusic": {
+      "externalTrackId": "123456789",
+      "sourceType": "DEEZER",
+      "title": "Bohemian Rhapsody",
+      "artistName": "Queen",
+      "albumName": "A Night at the Opera",
+      "albumImageUrl": "https://cdn.deezer.com/images/album/cover.jpg",
+      "durationMs": 354000,
+      "previewUrl": "https://cdn.deezer.com/preview/abc123.mp3",
+      "sourceUrl": "https://www.deezer.com/track/123456789"
+    },
+    "avatarUrl": "https://cdn.domain.com/avatar.png"
+  },
+  "personalInfo": {
+    "email": "newmail@gmail.com"
+  },
+  "skills": [
+    {
+      "skillTypeId": "uuid-1",
+      "level": "ADVANCED",
+      "isPrimary": true
+    },
+    {
+      "skillTypeId": "uuid-2",
+      "level": "INTERMEDIATE",
+      "isPrimary": false
+    }
+  ],
+  "favoriteGenres": [
+    "genre-uuid-1",
+    "genre-uuid-2"
+  ]
+}
+```
+
+> 모든 요청이 한 번에 처리됨 (FE 낙관적 업데이트 기준). 변경사항이 있는 부분만 `true` 반환.
+
+### Response 200
+
+```json
+{
+  "data": {
+    "updated": {
+      "profile": true,
+      "personalInfo": true,
+      "skills": true,
+      "favoriteGenres": true
+    }
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400  | 잘못된 입력 |
+| 401  | 인증 실패 (토큰 없음 또는 만료) |
+| 404  | 유저 없음 |
+
+---
+
+## DELETE /users/ _(미구현)_
+
+**설명:** 회원탈퇴. deletedAt 소프트 삭제 후 특정일 경과 시 완전 삭제 예정
+**인증:** 필요 (JWT Bearer)
+
+### Request
+
+요청 바디 없음.
+
+### Response 200
+
+```json
+{
+  "data": {
+    "userId": "b6d0f0b1-7c7d-4e23-9c7b-0c0d9f6a2a21",
+    "deletedAt": "2026-03-03T18:02:10.123+09:00"
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 401  | 인증 실패 |
+| 404  | 유저 없음 |
+
+---
+
+## POST /auth/email
+
+**설명:** 이메일 중복 확인
+**인증:** 불필요
+
+### Request
+
+**Body**
+
+```json
+{
+  "email": "devjunsday@gmail.com"
+}
+```
+
+### Response 200
+
+중복된 이메일인 경우:
+
+```json
+{
+  "data": {
+    "email": "devjunsday@gmail.com"
+  },
+  "success": true
+}
+```
+
+> `message` 값으로 중복 여부를 구분: `"중복 된 이메일입니다."` / `"사용할 수 있는 이메일입니다."`
+
+사용 가능한 이메일인 경우도 동일한 200 응답 구조 사용.
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400  | 이메일 형식 오류 |
+
+---
+
+## GET /users/profile-music/search
+
+**설명:** 프로필 음악 검색 (곡명 또는 아티스트명 기반, Deezer 연동)
+**인증:** 필요 (JWT Bearer)
+
+### Request
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|---------|------|:----:|:-----:|------|
+| query | string | ✅ | - | 검색어 (곡명 또는 아티스트명) |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "items": [
+      {
+        "externalTrackId": "123456789",
+        "sourceType": "DEEZER",
+        "title": "Bohemian Rhapsody",
+        "artistName": "Queen",
+        "albumName": "A Night at the Opera",
+        "albumImageUrl": "https://cdn.deezer.com/images/album/cover.jpg",
+        "durationMs": 354000,
+        "previewUrl": "https://cdn.deezer.com/preview/abc123.mp3",
+        "sourceUrl": "https://www.deezer.com/track/123456789"
+      }
+    ]
+  },
+  "success": true
+}
+```
+
+> `previewUrl`은 Deezer 만료 파라미터 포함 가능 — 장기 저장 금지.
+> 곡 선택 후 저장 시 `PATCH /users/profiles` body의 `profileMusic`에 전체 메타데이터를 담아 전송.
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400  | query 파라미터 누락 |
+| 401  | 인증 실패 |
+
+---
+
+## #48 비밀번호 찾기 _(미구현, 경로 미정)_
+
+**설명:** 비밀번호 찾기 기능 (미구현, Notion 페이지 내용 없음)
+**인증:** 미정
+
+> Notion 원본 페이지가 blank 상태로, 경로 및 명세 미정.

--- a/backend/docs/backend/designs/users/profile-music-metadata.md
+++ b/backend/docs/backend/designs/users/profile-music-metadata.md
@@ -1,0 +1,498 @@
+# 설계 문서: 프로필 음악 메타데이터 저장/조회 기능
+
+**날짜:** 2026-05-31
+**API 명세 위치:** `docs/backend/api-docs/users.md`
+
+---
+
+## 0. 배경 및 결정 사항
+
+### DB 스키마 방식 결정: inline 컬럼 방식 채택
+
+UserProfile에 별도 모델(`UserProfileMusic`) 없이 inline 컬럼으로 프로필 음악 메타데이터를 저장한다.
+
+**이유:**
+- 프로필 음악은 UserProfile과 1:1 관계 — 별도 테이블이 JOIN만 추가할 뿐 이점 없음
+- 필드 수(9개)가 많지 않고, 음악 메타데이터 전체를 항상 함께 조회/저장함
+- 기존 inline 컬럼 패턴(`profileMusicUrl`)과 일관성 유지
+
+### profileMusicSourceType enum 정의
+
+스키마에 신규 enum `ProfileMusicSourceType`을 추가한다. 현재는 `DEEZER`만 필요하지만 enum으로 관리해 확장성을 확보한다.
+
+---
+
+## 1. 작업 범위
+
+```
+신규:
+- src/modules/users/dto/profile-music.dto.ts          (ProfileMusicDto — 요청/응답 공용 nested DTO)
+- src/modules/users/dto/search-profile-music-query.dto.ts  (GET 쿼리 DTO)
+- src/modules/users/types/profile-music-preview.type.ts    (ProfileMusicPreview 타입)
+
+수정:
+- prisma/schema.prisma
+    - UserProfile.profileMusicUrl 제거
+    - UserProfile에 profileMusic* 컬럼 9개 추가
+    - enum ProfileMusicSourceType 추가 (DEEZER)
+- src/modules/users/dto/update-user-profile.dto.ts
+    - UpdateProfileDto.profileMusicUrl 제거
+    - UpdateProfileDto.profileMusic?: ProfileMusicDto 추가
+- src/modules/users/types/user-profile.type.ts
+    - UserProfileDetail.profileMusicUrl 제거
+    - UserProfileDetail.profileMusic 추가 (ProfileMusicDetail | null)
+- src/modules/users/repositoreis/user.repository.ts
+    - searchProfileMusicPreviews(query: string, tx?) 메서드 시그니처 추가
+- src/modules/users/repositoreis/user.prisma-repository.ts
+    - updateUserProfile의 profile 업데이트 시 profileMusic 처리 반영
+    - findUserProfileById의 profile 매핑에서 profileMusic 반영
+    - searchProfileMusicPreviews 구현 추가
+- src/modules/users/users.service.ts
+    - searchProfileMusicPreviews(query: string, tx?) 메서드 추가
+    - DeezerTrackClient (또는 DeezerTrackSearcher 인터페이스) 주입 추가
+- src/modules/users/users.controller.ts
+    - GET /users/profile-music/search 엔드포인트 추가
+- src/modules/users/users.module.ts
+    - DeezerTrackClient provider 추가
+    - SongsModule에서 import하거나 직접 등록 (아래 미결 사항 참고)
+- src/modules/users/users.service.spec.ts
+    - searchProfileMusicPreviews 테스트 케이스 추가
+    - 기존 mockProfile의 profileMusicUrl 제거, profileMusic 필드로 교체
+
+제거:
+- src/modules/songs/songs.controller.ts 에서 GET /songs/deezer/tracks/search 엔드포인트 제거
+  (songs.service.searchDeezerTrackPreviews는 다른 곳에서 사용되지 않으므로 함께 제거 가능 — 미결 사항 참고)
+```
+
+---
+
+## 2. DB 스키마 변경 상세
+
+### UserProfile 변경
+
+```prisma
+model UserProfile {
+  userId                    String                   @id @map("user_id") @db.Uuid
+  nickname                  String                   @db.VarChar(255)
+  selfDescription           String?                  @map("self_description")
+  // profileMusicUrl 제거
+  profileMusicExternalTrackId  String?               @map("profile_music_external_track_id")
+  profileMusicSourceType       ProfileMusicSourceType? @map("profile_music_source_type")
+  profileMusicTitle            String?               @map("profile_music_title") @db.VarChar(255)
+  profileMusicArtistName       String?               @map("profile_music_artist_name") @db.VarChar(255)
+  profileMusicAlbumName        String?               @map("profile_music_album_name") @db.VarChar(255)
+  profileMusicAlbumImageUrl    String?               @map("profile_music_album_image_url")
+  profileMusicDurationMs       Int?                  @map("profile_music_duration_ms")
+  profileMusicPreviewUrl       String?               @map("profile_music_preview_url")
+  profileMusicSourceUrl        String?               @map("profile_music_source_url")
+  avatarUrl                    String?               @map("avatar_url")
+  updatedAt                    DateTime?             @map("updated_at") @db.Timestamptz(6)
+  user                         User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("user_profiles")
+}
+
+enum ProfileMusicSourceType {
+  DEEZER
+}
+```
+
+> **일관성 규칙:** 프로필 음악 필드는 all-or-nothing으로 저장한다. `profileMusicSourceType`이 null이면 나머지 필드도 모두 null로 간주한다. 업데이트 시 `profileMusic: null`이 전달되면 전체 9개 필드를 null로 초기화한다.
+
+---
+
+## 3. Repository 인터페이스 변경
+
+```typescript
+// src/modules/users/repositoreis/user.repository.ts 에 추가
+
+import type { ProfileMusicPreview } from '../types/profile-music-preview.type';
+
+export interface UsersRepository {
+  // ... 기존 메서드 유지 ...
+
+  /**
+   * Deezer 검색 결과를 프로필 음악 미리보기 목록으로 반환한다.
+   * 외부 API 호출만 수행하므로 tx는 실제로 사용되지 않으나, 컨벤션 통일을 위해 선언한다.
+   */
+  searchProfileMusicPreviews(
+    query: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<ProfileMusicPreview[]>;
+}
+```
+
+> **설계 판단:** `searchProfileMusicPreviews`는 외부 API(Deezer)를 호출하는 로직이므로 Repository가 아닌 Service에 직접 두는 방법도 있다. 그러나 기존 songs 모듈은 DeezerTrackClient를 Service에 직접 주입해 사용한다. users 모듈도 같은 패턴을 따른다 — Repository에 넣지 않고 **Service에서 DeezerTrackClient를 직접 주입받아 사용**한다. 따라서 위 Repository 인터페이스 변경은 불필요하며, 아래 Service 설계를 따른다.
+
+---
+
+## 3. Service 비즈니스 규칙
+
+### 3.1 searchProfileMusicPreviews(query, tx?)
+
+```
+1. query가 빈 문자열이면 BadRequestException("검색어를 입력해주세요.")
+2. deezerTrackSearcher.searchTracks(query) 호출
+3. 각 결과를 parseDeezerTrackToSongPreview로 변환 후 ProfileMusicPreview[] 반환
+   - ProfileMusicPreview는 SongPreview에서 releaseDate 필드를 제외한 타입
+4. Deezer API 실패 시 BadGatewayException은 DeezerTrackClient에서 이미 throw함 — 별도 처리 불필요
+```
+
+### 3.2 updateUserProfile(userId, data, tx?) — 기존 메서드 수정
+
+```
+기존 흐름 유지. 변경 사항:
+- data.profile 처리 시 profileMusicUrl 대신 profileMusic 객체를 분해하여 UserProfile 컬럼에 매핑
+- data.profile.profileMusic이 null로 전달되면 9개 필드를 모두 null로 초기화
+- data.profile.profileMusic이 undefined이면 프로필 음악 필드를 변경하지 않음
+```
+
+### 3.3 getUserProfile(userId, tx?) — 기존 메서드, Repository 매핑만 변경
+
+```
+변경 없음. user-profile.type.ts의 UserProfileDetail 타입 변경에 따라
+prisma-repository에서 profileMusicUrl 대신 profileMusic 객체를 조합하여 반환한다.
+```
+
+---
+
+## 4. DTO 및 타입 정의
+
+### 4.1 ProfileMusicDto (신규)
+
+```typescript
+// src/modules/users/dto/profile-music.dto.ts
+
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNumber, IsOptional, IsString, IsUrl } from 'class-validator';
+
+export class ProfileMusicDto {
+  @ApiProperty({ description: 'Deezer 트랙 ID', example: '123456789' })
+  @IsString()
+  externalTrackId!: string;
+
+  @ApiProperty({ enum: ['DEEZER'], description: '음원 소스 타입', example: 'DEEZER' })
+  @IsEnum(['DEEZER'])
+  sourceType!: 'DEEZER';
+
+  @ApiProperty({ description: '곡 제목', example: 'Bohemian Rhapsody' })
+  @IsString()
+  title!: string;
+
+  @ApiProperty({ description: '아티스트 이름', example: 'Queen' })
+  @IsString()
+  artistName!: string;
+
+  @ApiProperty({ description: '앨범 이름', example: 'A Night at the Opera' })
+  @IsString()
+  albumName!: string;
+
+  @ApiPropertyOptional({ description: '앨범 커버 이미지 URL' })
+  @IsOptional()
+  @IsUrl()
+  albumImageUrl?: string | null;
+
+  @ApiProperty({ description: '곡 길이 (밀리초)', example: 354000 })
+  @IsNumber()
+  durationMs!: number;
+
+  @ApiPropertyOptional({ description: '미리듣기 URL' })
+  @IsOptional()
+  @IsUrl()
+  previewUrl?: string | null;
+
+  @ApiProperty({ description: '원본 소스 URL', example: 'https://www.deezer.com/track/123456789' })
+  @IsUrl()
+  sourceUrl!: string;
+}
+```
+
+### 4.2 UpdateProfileDto 수정 (update-user-profile.dto.ts 내 중첩 클래스)
+
+```typescript
+class UpdateProfileDto {
+  @IsOptional() @IsString() nickname?: string;
+  @IsOptional() @IsString() selfDescription?: string;
+
+  // profileMusicUrl 필드 제거
+  // 아래 추가:
+  @ApiPropertyOptional({ description: '프로필 음악 메타데이터. null 전달 시 제거', type: ProfileMusicDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ProfileMusicDto)
+  profileMusic?: ProfileMusicDto | null;
+
+  @IsOptional() @IsString() avatarUrl?: string;
+}
+```
+
+### 4.3 SearchProfileMusicQueryDto (신규)
+
+```typescript
+// src/modules/users/dto/search-profile-music-query.dto.ts
+
+export class SearchProfileMusicQueryDto {
+  @ApiProperty({ description: '검색어 (곡명 또는 아티스트명)', example: 'Queen' })
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty()
+  q!: string;
+}
+```
+
+> **주의:** 기존 songs 모듈의 `SearchDeezerTrackPreviewsQueryDto`는 파라미터명이 `query`이나, API 명세는 `q`를 사용한다. 새 DTO는 API 명세를 따른다.
+
+### 4.4 ProfileMusicPreview 타입 (신규)
+
+```typescript
+// src/modules/users/types/profile-music-preview.type.ts
+
+// SongPreview와 동일하나 releaseDate 제외
+// SongPreview를 직접 재사용하면 releaseDate: null | string이 응답에 포함됨
+// API 명세에는 releaseDate가 없으므로 별도 타입 정의
+export interface ProfileMusicPreview {
+  externalTrackId: string;
+  sourceType: 'DEEZER';
+  title: string;
+  artistName: string;
+  albumName: string;
+  albumImageUrl: string | null;
+  durationMs: number;
+  previewUrl: string | null;
+  sourceUrl: string;
+}
+```
+
+### 4.5 UserProfileDetail 타입 수정 (user-profile.type.ts)
+
+```typescript
+export interface ProfileMusicDetail {
+  externalTrackId: string;
+  sourceType: 'DEEZER';
+  title: string;
+  artistName: string;
+  albumName: string;
+  albumImageUrl: string | null;
+  durationMs: number;
+  previewUrl: string | null;
+  sourceUrl: string;
+}
+
+export interface UserProfileDetail {
+  nickname: string;
+  selfDescription: string | null;
+  // profileMusicUrl 제거
+  profileMusic: ProfileMusicDetail | null;  // 추가
+  avatarUrl: string | null;
+}
+```
+
+---
+
+## 5. Soft Delete 여부
+
+- `UserProfile` 모델에는 `deletedAt`이 없다. Soft delete 조건 불필요.
+- `User` 모델에는 `deletedAt`이 있다. `findUserProfileById`에서 이미 `where: { id: userId, deletedAt: null }` 조건을 사용 중 — 변경 없음.
+
+---
+
+## 6. 트랜잭션 경계
+
+| 메서드 | tx 필요 여부 | 이유 |
+|--------|:-----------:|------|
+| searchProfileMusicPreviews | 불필요 | 외부 API 호출만 수행, DB 쓰기 없음 |
+| updateUserProfile | 필요 (기존 유지) | 여러 테이블(userProfile, user, userSkill, favoriteGenre)을 원자적으로 처리 |
+| findUserProfileById | 불필요 (기존 유지) | 읽기 전용 |
+
+`updateUserProfile` 내 profileMusic 처리:
+
+```typescript
+// prisma-repository의 updateUserProfile run() 내부
+
+if (data.profile) {
+  const { profileMusic, ...restProfileData } = data.profile;
+
+  const profileMusicData =
+    profileMusic === null
+      ? {
+          // null이면 전체 초기화
+          profileMusicExternalTrackId: null,
+          profileMusicSourceType: null,
+          profileMusicTitle: null,
+          profileMusicArtistName: null,
+          profileMusicAlbumName: null,
+          profileMusicAlbumImageUrl: null,
+          profileMusicDurationMs: null,
+          profileMusicPreviewUrl: null,
+          profileMusicSourceUrl: null,
+        }
+      : profileMusic !== undefined
+        ? {
+            profileMusicExternalTrackId: profileMusic.externalTrackId,
+            profileMusicSourceType: profileMusic.sourceType,
+            profileMusicTitle: profileMusic.title,
+            profileMusicArtistName: profileMusic.artistName,
+            profileMusicAlbumName: profileMusic.albumName,
+            profileMusicAlbumImageUrl: profileMusic.albumImageUrl ?? null,
+            profileMusicDurationMs: profileMusic.durationMs,
+            profileMusicPreviewUrl: profileMusic.previewUrl ?? null,
+            profileMusicSourceUrl: profileMusic.sourceUrl,
+          }
+        : {}; // undefined이면 변경 없음
+
+  await client.userProfile.update({
+    where: { userId },
+    data: { ...restProfileData, ...profileMusicData },
+  });
+}
+```
+
+---
+
+## 7. UsersService — DeezerTrackClient 주입
+
+기존 songs 모듈 패턴을 따라 `DeezerTrackClient`를 직접 주입받는다.
+
+```typescript
+// users.service.ts
+
+import { DeezerTrackClient, type DeezerTrackSearcher } from '../songs/deezer-track.client';
+import { parseDeezerTrackToSongPreview } from '../songs/deezer-track.parser';
+import type { ProfileMusicPreview } from './types/profile-music-preview.type';
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @Inject(USERS_REPOSITORY)
+    private readonly usersRepository: UsersRepository,
+    @Inject(DeezerTrackClient)
+    private readonly deezerTrackSearcher: DeezerTrackSearcher,
+  ) {}
+
+  /**
+   * Deezer에서 프로필 음악 후보를 검색한다.
+   *
+   * @param {string} query - 검색어 (곡명 또는 아티스트명)
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client (외부 API 호출이므로 실제 미사용)
+   * @returns {Promise<ProfileMusicPreview[]>} 프로필 음악 후보 목록
+   */
+  async searchProfileMusicPreviews(query: string, tx?: Prisma.TransactionClient): Promise<ProfileMusicPreview[]> {
+    if (!query.trim()) {
+      throw new BadRequestException('검색어를 입력해주세요.');
+    }
+    const deezerTracks = await this.deezerTrackSearcher.searchTracks(query);
+    return deezerTracks.map(track => {
+      const preview = parseDeezerTrackToSongPreview(track);
+      // releaseDate 제외
+      const { releaseDate: _, ...profileMusicPreview } = preview;
+      return profileMusicPreview as ProfileMusicPreview;
+    });
+  }
+}
+```
+
+> **참고:** `parseDeezerTrackToSongPreview`는 songs 모듈 내부 함수이므로 import 경로는 `../songs/deezer-track.parser`가 된다. 모듈 경계를 넘는 유틸 import다 — 미결 사항 참고.
+
+---
+
+## 8. Controller 변경
+
+```typescript
+// users.controller.ts에 추가
+
+import { SearchProfileMusicQueryDto } from './dto/search-profile-music-query.dto';
+import type { ProfileMusicPreview } from './types/profile-music-preview.type';
+
+@Get('profile-music/search')
+@UseGuards(AccessTokenGuard)
+@ApiBearerAuth('access-token')
+@ApiOperation({ summary: '프로필 음악 검색' })
+@ApiResponse({ status: 200, description: '프로필 음악 검색 성공' })
+@ApiResponse({ status: 400, description: '검색어 누락' })
+@ApiResponse({ status: 401, description: '인증 실패' })
+async searchProfileMusicPreviews(
+  @Query() query: SearchProfileMusicQueryDto,
+): Promise<ApiSuccessResponse<{ items: ProfileMusicPreview[] }>> {
+  const items = await this.usersService.searchProfileMusicPreviews(query.q);
+  return createSuccessResponse('프로필 음악 검색 성공', { items });
+}
+```
+
+> **라우트 순서 주의:** `@Get('profile-music/search')`는 `@Get(':userId/profiles')` 앞에 선언해야 NestJS가 정적 경로를 먼저 매칭한다.
+
+---
+
+## 9. UsersModule 변경
+
+```typescript
+import { DeezerTrackClient } from '../songs/deezer-track.client';
+
+@Module({
+  // ...
+  providers: [
+    UsersService,
+    AccessTokenGuard,
+    SelfUserGuard,
+    DeezerTrackClient,  // 추가
+    {
+      provide: USERS_REPOSITORY,
+      useClass: UsersPrismaRepository,
+    },
+  ],
+  exports: [UsersService],
+})
+export class UsersModule {}
+```
+
+---
+
+## 10. 기존 임시 API 제거 (songs 모듈)
+
+`GET /songs/deezer/tracks/search` 엔드포인트를 songs.controller.ts에서 제거한다.
+
+제거 범위:
+- `songs.controller.ts`: `searchDeezerTrackPreviews` 핸들러 제거
+- `songs.controller.ts`: `SearchDeezerTrackPreviewsQueryDto` import 제거 (사용하는 곳이 없어지면)
+- `songs.service.ts`: `searchDeezerTrackPreviews` 메서드 제거 (미결 사항 참고)
+
+---
+
+## 11. 테스트 계획
+
+### users.service.spec.ts 수정 사항
+
+1. `mockProfile.profile.profileMusicUrl` 제거 → `profileMusic: null`로 교체
+
+### searchProfileMusicPreviews 신규 테스트
+
+| 케이스 | 검증 방법 |
+|--------|-----------|
+| happy path — 검색어 있음 | deezerTrackSearcher.searchTracks 호출 확인, ProfileMusicPreview[] 반환 |
+| 검색어가 빈 문자열 | BadRequestException 발생 |
+| 검색어가 공백만 있음 | BadRequestException 발생 |
+| Deezer API 실패 | BadGatewayException 전파 확인 (DeezerTrackClient stub에서 throw) |
+| 결과 없음 | 빈 배열 반환 |
+| releaseDate 필드 미포함 | 반환 객체에 releaseDate 없음 확인 |
+
+### updateUserProfile 테스트 케이스 보완
+
+| 케이스 | 검증 방법 |
+|--------|-----------|
+| profileMusic 객체 전달 | profile 업데이트 시 9개 필드 매핑 확인 |
+| profileMusic: null 전달 | 9개 필드 모두 null로 초기화 확인 |
+| profileMusic: undefined (미전달) | 음악 필드 변경 없음 확인 |
+
+### user.prisma-repository.spec.ts 수정
+
+- `findUserProfileById` 반환 타입에서 `profileMusicUrl` 제거, `profileMusic` 객체 반환 확인
+
+---
+
+## 12. 미결 사항
+
+| 번호 | 항목 | 현재 판단 | 확인 필요 여부 |
+|------|------|-----------|---------------|
+| 1 | `parseDeezerTrackToSongPreview` 및 `DeezerTrackClient`를 songs 모듈에서 직접 import — 모듈 경계 위반 여부 | songs 모듈에서 export하거나 공통 모듈로 분리하는 방법도 있음. 현재는 직접 import로 설계 | 팀 컨벤션 확인 권장 |
+| 2 | `songs.service.ts`의 `searchDeezerTrackPreviews` 메서드 제거 여부 | GET /songs/deezer/tracks/search 엔드포인트 제거 시 songs.service 메서드도 제거 대상. 단, 다른 곳에서 사용 중이면 유지 | 사용처 확인 후 결정 |
+| 3 | `ProfileMusicPreview` 타입을 `SongPreview`로 통일 가능 여부 | `releaseDate` 필드가 API 명세에 없어 별도 타입 정의. `SongPreview`에서 Omit으로 파생 가능하나 명시성 측면에서 별도 타입이 더 명확함 | 취향 차이, 현재 설계대로 진행 |
+| 4 | `PATCH /users/:userId/profiles` 응답이 `{ updated: { profile, personalInfo, skills, favoriteGenres } }` — profileMusic 변경 여부도 별도 플래그로 노출할지 | 현재 API 명세는 profile 섹션 단위로만 플래그 반환. profileMusic은 profile 하위이므로 profile: true로 충분 | 현재 설계대로 진행 |
+| 5 | `profileMusic: null` 전달 시 (음악 제거) 를 클라이언트가 명시적으로 null로 보내야 하는지 확인 필요 | class-validator에서 `@IsOptional()`과 `@ValidateNested()`를 조합할 때 null 허용 여부 설정 필요 | 구현 시 `@Allow()`나 `@IsOptional()` + `allowNull` 처리 확인 |

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -49,13 +49,21 @@ model Genre {
 }
 
 model UserProfile {
-  userId          String    @id @map("user_id") @db.Uuid
-  nickname        String    @db.VarChar(255)
-  selfDescription String?   @map("self_description")
-  profileMusicUrl String?   @map("profile_music_url")
-  avatarUrl       String?   @map("avatar_url")
-  updatedAt       DateTime? @map("updated_at") @db.Timestamptz(6)
-  user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId                      String                  @id @map("user_id") @db.Uuid
+  nickname                    String                  @db.VarChar(255)
+  selfDescription             String?                 @map("self_description")
+  profileMusicExternalTrackId String?                 @map("profile_music_external_track_id")
+  profileMusicSourceType      ProfileMusicSourceType? @map("profile_music_source_type")
+  profileMusicTitle           String?                 @map("profile_music_title") @db.VarChar(255)
+  profileMusicArtistName      String?                 @map("profile_music_artist_name") @db.VarChar(255)
+  profileMusicAlbumName       String?                 @map("profile_music_album_name") @db.VarChar(255)
+  profileMusicAlbumImageUrl   String?                 @map("profile_music_album_image_url")
+  profileMusicDurationMs      Int?                    @map("profile_music_duration_ms")
+  profileMusicPreviewUrl      String?                 @map("profile_music_preview_url")
+  profileMusicSourceUrl       String?                 @map("profile_music_source_url")
+  avatarUrl                   String?                 @map("avatar_url")
+  updatedAt                   DateTime?               @map("updated_at") @db.Timestamptz(6)
+  user                        User                    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("user_profiles")
 }
@@ -515,4 +523,8 @@ enum BandMemberRole {
 enum TeamMemberRole {
   LEADER
   MEMBER
+}
+
+enum ProfileMusicSourceType {
+  DEEZER
 }

--- a/backend/src/database/prisma/seed-user-conflict.util.spec.ts
+++ b/backend/src/database/prisma/seed-user-conflict.util.spec.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+
 import test from 'node:test';
 
 import { getConflictingSeedUserIds } from './seed-user-conflict.util';

--- a/backend/src/modules/songs/songs.controller.ts
+++ b/backend/src/modules/songs/songs.controller.ts
@@ -7,7 +7,6 @@ import type { User } from '../../generated/prisma';
 
 import { CreateSongBodyDto } from './dto/create-song.dto';
 import { GetBandSongsQueryDto } from './dto/get-band-songs-query.dto';
-import { SearchDeezerTrackPreviewsQueryDto } from './dto/search-deezer-track-previews-query.dto';
 import { UpdateSongBodyDto } from './dto/update-song.dto';
 import type { CreateSongResult } from './types/create-song-result.type';
 import type { DeleteSongResult } from './types/delete-song-result.type';
@@ -108,15 +107,5 @@ export class SongsController {
     const songPreview = await this.songsService.previewSpotifyTrack(trackId);
 
     return createSuccessResponse('Spotify 곡 미리보기 조회 성공', songPreview);
-  }
-
-  @Get('songs/deezer/tracks/search')
-  @ApiOperation({ summary: 'Deezer 곡 검색' })
-  @ApiResponse({ status: 200, description: 'Deezer 곡 검색 성공' })
-  @ApiResponse({ status: 400, description: '잘못된 요청' })
-  async searchDeezerTrackPreviews(@Query() query: SearchDeezerTrackPreviewsQueryDto): Promise<ApiSuccessResponse<SongPreview[]>> {
-    const songPreviews = await this.songsService.searchDeezerTrackPreviews(query.query);
-
-    return createSuccessResponse('Deezer 곡 미리보기 목록 조회 성공', songPreviews);
   }
 }

--- a/backend/src/modules/songs/songs.module.ts
+++ b/backend/src/modules/songs/songs.module.ts
@@ -7,7 +7,6 @@ import { UsersModule } from '../users/users.module';
 
 import { SongsPrismaRepository } from './repositories/songs.prisma-repository';
 import { SONGS_REPOSITORY } from './repositories/songs.repository';
-import { DeezerTrackClient } from './deezer-track.client';
 import { SongsController } from './songs.controller';
 import { SongsService } from './songs.service';
 import { SpotifyTrackClient } from './spotify-track.client';
@@ -19,7 +18,6 @@ import { SpotifyTrackClient } from './spotify-track.client';
     AccessTokenGuard,
     SongsService,
     SpotifyTrackClient,
-    DeezerTrackClient,
     SongsPrismaRepository,
     {
       provide: SONGS_REPOSITORY,

--- a/backend/src/modules/songs/songs.service.spec.ts
+++ b/backend/src/modules/songs/songs.service.spec.ts
@@ -4,7 +4,6 @@ import type { PrismaService } from '../../database/prisma';
 import type { SkillsService } from '../skills/skills.service';
 
 import type { SongsRepository } from './repositories/songs.repository';
-import type { DeezerTrackSearcher } from './deezer-track.client';
 import { SongsService } from './songs.service';
 import type { SpotifyTrackReader } from './spotify-track.client';
 
@@ -28,14 +27,11 @@ describe('SongsService', () => {
     const spotifyTrackReader: jest.Mocked<SpotifyTrackReader> = {
       findTrack: jest.fn(),
     };
-    const deezerTrackSearcher: jest.Mocked<DeezerTrackSearcher> = {
-      searchTracks: jest.fn(),
-    };
     const skillsService: jest.Mocked<SkillsService> = {
       findExistingSkillTypeIds: jest.fn(),
     } as unknown as jest.Mocked<SkillsService>;
 
-    const service = new SongsService(repository, prisma, skillsService, spotifyTrackReader, deezerTrackSearcher);
+    const service = new SongsService(repository, prisma, skillsService, spotifyTrackReader);
 
     return {
       service,
@@ -44,7 +40,6 @@ describe('SongsService', () => {
       transactionClient,
       skillsService,
       spotifyTrackReader,
-      deezerTrackSearcher,
     };
   };
 
@@ -81,44 +76,6 @@ describe('SongsService', () => {
       albumName: 'Cut To The Feeling',
       sourceUrl: 'https://open.spotify.com/track/11dFghVXANMlKmJXsNCbNl',
       sourceType: 'SPOTIFY',
-    });
-  });
-
-  it('Deezer 곡 미리보기 서비스는 Deezer track 검색 결과를 목록으로 변환한다', async () => {
-    const { service, deezerTrackSearcher } = createService();
-
-    deezerTrackSearcher.searchTracks.mockResolvedValue([
-      {
-        id: 3135556,
-        title: 'Harder, Better, Faster, Stronger',
-        duration: 224,
-        link: 'https://www.deezer.com/track/3135556',
-        preview: 'https://cdns-preview.dzcdn.net/stream/demo.mp3',
-        artist: {
-          name: 'Daft Punk',
-        },
-        album: {
-          title: 'Discovery',
-          cover: 'https://api.deezer.com/album/302127/image',
-          cover_medium: 'https://e-cdns-images.dzcdn.net/images/cover/medium.jpg',
-          cover_big: 'https://e-cdns-images.dzcdn.net/images/cover/big.jpg',
-          cover_xl: 'https://e-cdns-images.dzcdn.net/images/cover/xl.jpg',
-        },
-      },
-    ]);
-
-    const result = await service.searchDeezerTrackPreviews('Daft Punk Harder Better Faster Stronger');
-
-    expect(deezerTrackSearcher.searchTracks).toHaveBeenCalledWith('Daft Punk Harder Better Faster Stronger');
-    expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({
-      externalTrackId: '3135556',
-      title: 'Harder, Better, Faster, Stronger',
-      artistName: 'Daft Punk',
-      albumName: 'Discovery',
-      durationMs: 224000,
-      sourceUrl: 'https://www.deezer.com/track/3135556',
-      sourceType: 'DEEZER',
     });
   });
 

--- a/backend/src/modules/songs/songs.service.ts
+++ b/backend/src/modules/songs/songs.service.ts
@@ -13,8 +13,6 @@ import type { DeleteSongResult } from './types/delete-song-result.type';
 import type { GetBandSongsResult } from './types/song-list.type';
 import type { SongPreview } from './types/song-preview.type';
 import type { UpdateSongResult } from './types/update-song-result.type';
-import { DeezerTrackClient, type DeezerTrackSearcher } from './deezer-track.client';
-import { parseDeezerTrackToSongPreview } from './deezer-track.parser';
 import { SpotifyTrackClient, type SpotifyTrackReader } from './spotify-track.client';
 import { parseSpotifyTrackToSongPreview } from './spotify-track.parser';
 
@@ -27,8 +25,6 @@ export class SongsService {
     private readonly skillsService: SkillsService,
     @Inject(SpotifyTrackClient)
     private readonly spotifyTrackReader: SpotifyTrackReader,
-    @Inject(DeezerTrackClient)
-    private readonly deezerTrackSearcher: DeezerTrackSearcher,
   ) {}
 
   /**
@@ -41,18 +37,6 @@ export class SongsService {
     const spotifyTrack = await this.spotifyTrackReader.findTrack(trackId);
 
     return parseSpotifyTrackToSongPreview(spotifyTrack);
-  }
-
-  /**
-   * Deezer track 검색 결과를 곡 등록 미리보기 데이터 목록으로 변환한다.
-   *
-   * @param {string} query - 곡명과 아티스트명을 포함한 검색어
-   * @returns {Promise<SongPreview[]>} 곡 등록 미리보기 데이터 목록
-   */
-  async searchDeezerTrackPreviews(query: string): Promise<SongPreview[]> {
-    const deezerTracks = await this.deezerTrackSearcher.searchTracks(query);
-
-    return deezerTracks.map(deezerTrack => parseDeezerTrackToSongPreview(deezerTrack));
   }
 
   /**

--- a/backend/src/modules/users/dto/profile-music.dto.ts
+++ b/backend/src/modules/users/dto/profile-music.dto.ts
@@ -1,0 +1,38 @@
+import { IsEnum, IsInt, IsNotEmpty, IsOptional, IsString, IsUrl, Min } from 'class-validator';
+import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
+
+export class ProfileMusicDto {
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty()
+  externalTrackId!: string;
+
+  @IsEnum(['DEEZER'])
+  sourceType!: 'DEEZER';
+
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty()
+  title!: string;
+
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty()
+  artistName!: string;
+
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty()
+  albumName!: string;
+
+  @IsOptional()
+  @IsUrl()
+  albumImageUrl?: string | null;
+
+  @IsInt()
+  @Min(0)
+  durationMs!: number;
+
+  @IsOptional()
+  @IsUrl()
+  previewUrl?: string | null;
+
+  @IsUrl()
+  sourceUrl!: string;
+}

--- a/backend/src/modules/users/dto/search-profile-music-query.dto.ts
+++ b/backend/src/modules/users/dto/search-profile-music-query.dto.ts
@@ -1,0 +1,12 @@
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsString } from 'class-validator';
+import { trimStringValue } from 'src/common/validation/transform.util';
+import { notemptyValidationMessage } from 'src/common/validation-message/notempty-validation.message';
+import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
+
+export class SearchProfileMusicQueryDto {
+  @Transform(trimStringValue)
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty({ message: notemptyValidationMessage })
+  q!: string;
+}

--- a/backend/src/modules/users/dto/update-user-profile.dto.ts
+++ b/backend/src/modules/users/dto/update-user-profile.dto.ts
@@ -6,6 +6,8 @@ import { stringValidationMessage } from 'src/common/validation-message/string-va
 import { uuidValidationMessage } from 'src/common/validation-message/uuid-validation.message';
 import { SkillLevelType } from 'src/generated/prisma';
 
+import { ProfileMusicDto } from './profile-music.dto';
+
 class UpdateProfileDto {
   @ApiPropertyOptional({ description: '닉네임', example: '홍길동' })
   @IsOptional()
@@ -17,10 +19,11 @@ class UpdateProfileDto {
   @IsString({ message: stringValidationMessage })
   selfDescription?: string;
 
-  @ApiPropertyOptional({ description: '프로필 음악 URL', example: 'https://example.com/music.mp3' })
+  @ApiPropertyOptional({ description: '프로필 음악 메타데이터. null 전달 시 제거', type: ProfileMusicDto, nullable: true })
   @IsOptional()
-  @IsString({ message: stringValidationMessage })
-  profileMusicUrl?: string;
+  @ValidateNested()
+  @Type(() => ProfileMusicDto)
+  profileMusic?: ProfileMusicDto | null;
 
   @ApiPropertyOptional({ description: '프로필 이미지 URL', example: 'https://example.com/avatar.jpg' })
   @IsOptional()

--- a/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
+++ b/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
@@ -20,7 +20,20 @@ const userRecord = {
   email: 'test@example.com',
   status: 'ACTIVE',
   createdAt: new Date('2026-01-01T00:00:00.000Z'),
-  profile: { nickname: 'testuser', selfDescription: '안녕', profileMusicUrl: null, avatarUrl: null },
+  profile: {
+    nickname: 'testuser',
+    selfDescription: '안녕',
+    profileMusicSourceType: null,
+    profileMusicExternalTrackId: null,
+    profileMusicTitle: null,
+    profileMusicArtistName: null,
+    profileMusicAlbumName: null,
+    profileMusicAlbumImageUrl: null,
+    profileMusicDurationMs: null,
+    profileMusicPreviewUrl: null,
+    profileMusicSourceUrl: null,
+    avatarUrl: null,
+  },
   userSkills: [{ skillTypeId: 'skill-001', skillLevel: 'ADVANCED', isPrimary: true, skillType: { name: 'GUITAR' } }],
   favoriteGenres: [{ genreId: 'genre-001', genre: { name: 'ROCK' } }],
 };
@@ -166,8 +179,40 @@ describe('UsersPrismaRepository', () => {
       expect(result?.user.id).toBe('user-001');
       expect(result?.user.createdAt).toBe('2026-01-01T00:00:00.000Z');
       expect(result?.profile?.nickname).toBe('testuser');
+      expect(result?.profile?.profileMusic).toBeNull();
       expect(result?.skills[0]).toEqual({ skillTypeId: 'skill-001', skillName: 'GUITAR', level: 'ADVANCED', isPrimary: true });
       expect(result?.favoriteGenres[0]).toEqual({ genreId: 'genre-001', name: 'ROCK' });
+    });
+
+    it('profileMusicSourceType이 있으면 profileMusic 객체를 조합하여 반환한다', async () => {
+      const recordWithMusic = {
+        ...userRecord,
+        profile: {
+          ...userRecord.profile,
+          profileMusicSourceType: 'DEEZER',
+          profileMusicExternalTrackId: '123456789',
+          profileMusicTitle: 'Bohemian Rhapsody',
+          profileMusicArtistName: 'Queen',
+          profileMusicAlbumName: 'A Night at the Opera',
+          profileMusicAlbumImageUrl: 'https://cdn.deezer.com/cover.jpg',
+          profileMusicDurationMs: 354000,
+          profileMusicPreviewUrl: 'https://cdn.deezer.com/preview/abc123.mp3',
+          profileMusicSourceUrl: 'https://www.deezer.com/track/123456789',
+        },
+      };
+      mockPrisma.user.findUnique.mockResolvedValue(recordWithMusic);
+      const result = await repository.findUserProfileById('user-001');
+      expect(result?.profile?.profileMusic).toEqual({
+        externalTrackId: '123456789',
+        sourceType: 'DEEZER',
+        title: 'Bohemian Rhapsody',
+        artistName: 'Queen',
+        albumName: 'A Night at the Opera',
+        albumImageUrl: 'https://cdn.deezer.com/cover.jpg',
+        durationMs: 354000,
+        previewUrl: 'https://cdn.deezer.com/preview/abc123.mp3',
+        sourceUrl: 'https://www.deezer.com/track/123456789',
+      });
     });
 
     it('profile이 없으면 profile 필드가 null이다', async () => {
@@ -191,6 +236,55 @@ describe('UsersPrismaRepository', () => {
     it('profile이 있으면 userProfile.update를 호출한다', async () => {
       await repository.updateUserProfile('user-001', { profile: { nickname: '새닉네임' } });
       expect(mockPrisma.userProfile.update).toHaveBeenCalledWith({ where: { userId: 'user-001' }, data: { nickname: '새닉네임' } });
+    });
+
+    it('profileMusic 객체가 전달되면 9개 필드를 매핑하여 저장한다', async () => {
+      const profileMusic = {
+        externalTrackId: '123456789',
+        sourceType: 'DEEZER' as const,
+        title: 'Bohemian Rhapsody',
+        artistName: 'Queen',
+        albumName: 'A Night at the Opera',
+        albumImageUrl: 'https://cdn.deezer.com/cover.jpg',
+        durationMs: 354000,
+        previewUrl: 'https://cdn.deezer.com/preview/abc123.mp3',
+        sourceUrl: 'https://www.deezer.com/track/123456789',
+      };
+      await repository.updateUserProfile('user-001', { profile: { profileMusic } });
+      expect(mockPrisma.userProfile.update).toHaveBeenCalledWith({
+        where: { userId: 'user-001' },
+        data: expect.objectContaining({
+          profileMusicExternalTrackId: '123456789',
+          profileMusicSourceType: 'DEEZER',
+          profileMusicTitle: 'Bohemian Rhapsody',
+          profileMusicDurationMs: 354000,
+        }),
+      });
+    });
+
+    it('profileMusic이 null이면 9개 필드를 모두 null로 초기화한다', async () => {
+      await repository.updateUserProfile('user-001', { profile: { profileMusic: null } });
+      expect(mockPrisma.userProfile.update).toHaveBeenCalledWith({
+        where: { userId: 'user-001' },
+        data: expect.objectContaining({
+          profileMusicExternalTrackId: null,
+          profileMusicSourceType: null,
+          profileMusicTitle: null,
+          profileMusicArtistName: null,
+          profileMusicAlbumName: null,
+          profileMusicAlbumImageUrl: null,
+          profileMusicDurationMs: null,
+          profileMusicPreviewUrl: null,
+          profileMusicSourceUrl: null,
+        }),
+      });
+    });
+
+    it('profileMusic이 undefined이면 음악 필드를 변경하지 않는다', async () => {
+      await repository.updateUserProfile('user-001', { profile: { nickname: '닉네임만변경' } });
+      const callData = mockPrisma.userProfile.update.mock.calls[0]?.[0]?.data;
+      expect(callData).not.toHaveProperty('profileMusicExternalTrackId');
+      expect(callData).not.toHaveProperty('profileMusicSourceType');
     });
 
     it('personalInfo.email이 있으면 user.update를 호출한다', async () => {

--- a/backend/src/modules/users/repositoreis/user.prisma-repository.ts
+++ b/backend/src/modules/users/repositoreis/user.prisma-repository.ts
@@ -121,7 +121,19 @@ export class UsersPrismaRepository implements UsersRepository {
         ? {
             nickname: user.profile.nickname,
             selfDescription: user.profile.selfDescription,
-            profileMusicUrl: user.profile.profileMusicUrl,
+            profileMusic: user.profile.profileMusicSourceType
+              ? {
+                  externalTrackId: user.profile.profileMusicExternalTrackId!,
+                  sourceType: user.profile.profileMusicSourceType as 'DEEZER',
+                  title: user.profile.profileMusicTitle!,
+                  artistName: user.profile.profileMusicArtistName!,
+                  albumName: user.profile.profileMusicAlbumName!,
+                  albumImageUrl: user.profile.profileMusicAlbumImageUrl,
+                  durationMs: user.profile.profileMusicDurationMs!,
+                  previewUrl: user.profile.profileMusicPreviewUrl,
+                  sourceUrl: user.profile.profileMusicSourceUrl!,
+                }
+              : null,
             avatarUrl: user.profile.avatarUrl,
           }
         : null,
@@ -141,7 +153,36 @@ export class UsersPrismaRepository implements UsersRepository {
   async updateUserProfile(userId: string, data: UpdateUserProfileData, tx?: Prisma.TransactionClient): Promise<GetUserProfileResult> {
     const run = async (client: Prisma.TransactionClient) => {
       if (data.profile) {
-        await client.userProfile.update({ where: { userId }, data: data.profile });
+        const { profileMusic, ...restProfileData } = data.profile;
+
+        const profileMusicData =
+          profileMusic === null
+            ? {
+                profileMusicExternalTrackId: null,
+                profileMusicSourceType: null,
+                profileMusicTitle: null,
+                profileMusicArtistName: null,
+                profileMusicAlbumName: null,
+                profileMusicAlbumImageUrl: null,
+                profileMusicDurationMs: null,
+                profileMusicPreviewUrl: null,
+                profileMusicSourceUrl: null,
+              }
+            : profileMusic !== undefined
+              ? {
+                  profileMusicExternalTrackId: profileMusic.externalTrackId,
+                  profileMusicSourceType: profileMusic.sourceType,
+                  profileMusicTitle: profileMusic.title,
+                  profileMusicArtistName: profileMusic.artistName,
+                  profileMusicAlbumName: profileMusic.albumName,
+                  profileMusicAlbumImageUrl: profileMusic.albumImageUrl ?? null,
+                  profileMusicDurationMs: profileMusic.durationMs,
+                  profileMusicPreviewUrl: profileMusic.previewUrl ?? null,
+                  profileMusicSourceUrl: profileMusic.sourceUrl,
+                }
+              : {};
+
+        await client.userProfile.update({ where: { userId }, data: { ...restProfileData, ...profileMusicData } });
       }
 
       if (data.personalInfo?.email) {

--- a/backend/src/modules/users/types/profile-music-preview.type.ts
+++ b/backend/src/modules/users/types/profile-music-preview.type.ts
@@ -1,0 +1,11 @@
+export interface ProfileMusicPreview {
+  externalTrackId: string;
+  sourceType: 'DEEZER';
+  title: string;
+  artistName: string;
+  albumName: string;
+  albumImageUrl: string | null;
+  durationMs: number;
+  previewUrl: string | null;
+  sourceUrl: string;
+}

--- a/backend/src/modules/users/types/user-profile.type.ts
+++ b/backend/src/modules/users/types/user-profile.type.ts
@@ -7,10 +7,22 @@ export interface UserProfileUserDetail {
   createdAt: string;
 }
 
+export interface ProfileMusicDetail {
+  externalTrackId: string;
+  sourceType: 'DEEZER';
+  title: string;
+  artistName: string;
+  albumName: string;
+  albumImageUrl: string | null;
+  durationMs: number;
+  previewUrl: string | null;
+  sourceUrl: string;
+}
+
 export interface UserProfileDetail {
   nickname: string;
   selfDescription: string | null;
-  profileMusicUrl: string | null;
+  profileMusic: ProfileMusicDetail | null;
   avatarUrl: string | null;
 }
 

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -5,8 +5,10 @@ import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
 
 import { GetUsersQueryDto } from './dto/get-users-query.dto';
+import { SearchProfileMusicQueryDto } from './dto/search-profile-music-query.dto';
 import { UpdateUserProfileDto } from './dto/update-user-profile.dto';
 import { SelfUserGuard } from './guard/self-user.guard';
+import type { ProfileMusicPreview } from './types/profile-music-preview.type';
 import type { GetUsersResult } from './types/user-list.type';
 import type { GetUserProfileResult } from './types/user-profile.type';
 import { UsersService } from './users.service';
@@ -22,6 +24,18 @@ export class UsersController {
   async getUsers(@Query() query: GetUsersQueryDto): Promise<ApiSuccessResponse<GetUsersResult>> {
     const result = await this.usersService.getUsers(query);
     return createSuccessResponse('유저 목록 조회 성공', result);
+  }
+
+  @Get('profile-music/search')
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '프로필 음악 검색' })
+  @ApiResponse({ status: 200, description: '프로필 음악 검색 성공' })
+  @ApiResponse({ status: 400, description: '검색어 누락' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  async searchProfileMusicPreviews(@Query() query: SearchProfileMusicQueryDto): Promise<ApiSuccessResponse<{ items: ProfileMusicPreview[] }>> {
+    const items = await this.usersService.searchProfileMusicPreviews(query.q);
+    return createSuccessResponse('프로필 음악 검색 성공', { items });
   }
 
   @Get(':userId/profiles')

--- a/backend/src/modules/users/users.module.ts
+++ b/backend/src/modules/users/users.module.ts
@@ -3,6 +3,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { AuthModule } from 'src/auth/auth.module';
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
+import { DeezerTrackClient } from '../songs/deezer-track.client';
 
 import { SelfUserGuard } from './guard/self-user.guard';
 import { UsersPrismaRepository } from './repositoreis/user.prisma-repository';
@@ -17,6 +18,7 @@ import { UsersService } from './users.service';
     UsersService,
     AccessTokenGuard,
     SelfUserGuard,
+    DeezerTrackClient,
     {
       provide: USERS_REPOSITORY,
       useClass: UsersPrismaRepository,

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -2,6 +2,8 @@ import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import type { User } from 'src/generated/prisma';
 
+import { DeezerTrackClient } from '../songs/deezer-track.client';
+
 import type { GetUsersQuery } from './dto/get-users-query.dto';
 import type { UsersRepository } from './repositoreis/user.repository';
 import { USERS_REPOSITORY } from './repositoreis/user.repository';
@@ -13,7 +15,7 @@ const mockUser = { id: 'user-001', email: 'test@example.com' } as User;
 
 const mockProfile: GetUserProfileResult = {
   user: { id: 'user-001', email: 'test@example.com', status: 'ACTIVE', createdAt: '2026-01-01T00:00:00.000Z' },
-  profile: { nickname: 'testuser', selfDescription: null, profileMusicUrl: null, avatarUrl: null },
+  profile: { nickname: 'testuser', selfDescription: null, profileMusic: null, avatarUrl: null },
   skills: [],
   favoriteGenres: [],
 };
@@ -43,12 +45,35 @@ const repositoryStub: UsersRepository = {
   },
 };
 
+const mockDeezerTracks = [
+  {
+    id: 123456789,
+    title: 'Bohemian Rhapsody',
+    duration: 354,
+    preview: 'https://cdn.deezer.com/preview/abc123.mp3',
+    link: 'https://www.deezer.com/track/123456789',
+    artist: { name: 'Queen' },
+    album: {
+      title: 'A Night at the Opera',
+      cover: null,
+      cover_medium: null,
+      cover_big: null,
+      cover_xl: 'https://cdn.deezer.com/images/cover_xl.jpg',
+    },
+  },
+];
+
+const deezerClientStub = {
+  searchTracks: jest.fn().mockResolvedValue(mockDeezerTracks),
+};
+
 describe('UsersService', () => {
   let service: UsersService;
 
   beforeEach(async () => {
+    jest.clearAllMocks();
     const module = await Test.createTestingModule({
-      providers: [UsersService, { provide: USERS_REPOSITORY, useValue: repositoryStub }],
+      providers: [UsersService, { provide: USERS_REPOSITORY, useValue: repositoryStub }, { provide: DeezerTrackClient, useValue: deezerClientStub }],
     }).compile();
 
     service = module.get(UsersService);
@@ -102,6 +127,34 @@ describe('UsersService', () => {
     it('repository 결과를 그대로 반환한다', async () => {
       const result = await service.updateUserProfile('user-001', { profile: { nickname: '새닉네임' } });
       expect(result.user.id).toBe('user-001');
+    });
+  });
+
+  describe('searchProfileMusicPreviews', () => {
+    it('검색어가 있으면 Deezer 결과를 ProfileMusicPreview 목록으로 반환한다', async () => {
+      const result = await service.searchProfileMusicPreviews('Bohemian Rhapsody');
+      expect(deezerClientStub.searchTracks).toHaveBeenCalledWith('Bohemian Rhapsody');
+      expect(result).toHaveLength(1);
+      expect(result[0].title).toBe('Bohemian Rhapsody');
+      expect(result[0].artistName).toBe('Queen');
+      expect(result[0].sourceType).toBe('DEEZER');
+    });
+
+    it('반환 결과에 releaseDate 필드가 없다', async () => {
+      const result = await service.searchProfileMusicPreviews('Queen');
+      expect(result[0]).not.toHaveProperty('releaseDate');
+    });
+
+    it('Deezer API가 빈 배열을 반환하면 빈 배열을 반환한다', async () => {
+      deezerClientStub.searchTracks.mockResolvedValueOnce([]);
+      const result = await service.searchProfileMusicPreviews('없는곡');
+      expect(result).toHaveLength(0);
+    });
+
+    it('Deezer API가 실패하면 예외가 전파된다', async () => {
+      const { BadGatewayException } = await import('@nestjs/common');
+      deezerClientStub.searchTracks.mockRejectedValueOnce(new BadGatewayException('Deezer 실패'));
+      await expect(service.searchProfileMusicPreviews('Queen')).rejects.toThrow(BadGatewayException);
     });
   });
 });

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -1,15 +1,21 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma } from 'src/generated/prisma';
 
+import { DeezerTrackClient, type DeezerTrackSearcher } from '../songs/deezer-track.client';
+import { parseDeezerTrackToSongPreview } from '../songs/deezer-track.parser';
+
 import type { GetUsersQuery } from './dto/get-users-query.dto';
 import type { UpdateUserProfileData } from './dto/update-user-profile.dto';
 import { USERS_REPOSITORY, UsersRepository } from './repositoreis/user.repository';
+import type { ProfileMusicPreview } from './types/profile-music-preview.type';
 
 @Injectable()
 export class UsersService {
   constructor(
     @Inject(USERS_REPOSITORY)
     private readonly usersRepository: UsersRepository,
+    @Inject(DeezerTrackClient)
+    private readonly deezerTrackSearcher: DeezerTrackSearcher,
   ) {}
 
   async getUserByEmail(email: string, tx?: Prisma.TransactionClient) {
@@ -38,5 +44,20 @@ export class UsersService {
 
   async updateUserProfile(userId: string, data: UpdateUserProfileData, tx?: Prisma.TransactionClient) {
     return this.usersRepository.updateUserProfile(userId, data, tx);
+  }
+
+  /**
+   * Deezer에서 프로필 음악 후보를 검색한다.
+   *
+   * @param {string} query - 검색어 (곡명 또는 아티스트명)
+   * @returns {Promise<ProfileMusicPreview[]>} 프로필 음악 후보 목록
+   */
+  async searchProfileMusicPreviews(query: string, tx?: Prisma.TransactionClient): Promise<ProfileMusicPreview[]> {
+    void tx;
+    const deezerTracks = await this.deezerTrackSearcher.searchTracks(query);
+    return deezerTracks.map(track => {
+      const { releaseDate: _, ...profileMusicPreview } = parseDeezerTrackToSongPreview(track);
+      return profileMusicPreview as ProfileMusicPreview;
+    });
   }
 }


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 20분

<br/>

## 📌 작업 요약

- 프로필 음악을 URL 단일 문자열 대신 곡 메타데이터 객체로 저장/조회하도록 변경
- 프로필 음악 검색 API 신규 추가 (`GET /users/profile-music/search`)
- songs 모듈에 임시로 작성했던 Deezer 연동 테스트 API 제거

<br/>

## 📝 작업 내용

### 1. 신규 API

| #   | 메서드 | 경로                           | 설명             | 주요 스펙                         |
| --- | ------ | ------------------------------ | ---------------- | --------------------------------- |
| #66 | GET    | `/users/profile-music/search`  | 프로필 음악 검색 | req: `q` (검색어) / res: `items[]` (곡 메타데이터 목록) / 인증 필요 |

### 2. 수정 API

| #  | 메서드 | 경로                        | 변경 사항                                                          |
| -- | ------ | --------------------------- | ------------------------------------------------------------------ |
| #3 | GET    | `/users/:userId/profiles`   | `profile.profileMusicUrl: string` → `profile.profileMusic: object \| null` |
| #5 | PATCH  | `/users/:userId/profiles`   | `profile.profileMusicUrl: string` → `profile.profileMusic: object \| null` |

**profileMusic 객체 스펙:**
```ts
{
  externalTrackId: string
  sourceType: 'DEEZER'
  title: string
  artistName: string
  albumName: string
  albumImageUrl: string | null
  durationMs: number
  previewUrl: string | null   // Deezer 만료 가능, 장기 저장용 아님
  sourceUrl: string
}
```

> `profileMusic: null` 전달 시 음악 제거, `profileMusic` 미전달 시 기존 값 유지

### 3. DB 스키마 변경

**UserProfile 테이블**

| 변경 | 컬럼명 | 타입 |
| ---- | ------ | ---- |
| 제거 | `profile_music_url` | `varchar` |
| 추가 | `profile_music_external_track_id` | `text?` |
| 추가 | `profile_music_source_type` | `ProfileMusicSourceType?` (enum) |
| 추가 | `profile_music_title` | `varchar(255)?` |
| 추가 | `profile_music_artist_name` | `varchar(255)?` |
| 추가 | `profile_music_album_name` | `varchar(255)?` |
| 추가 | `profile_music_album_image_url` | `text?` |
| 추가 | `profile_music_duration_ms` | `int?` |
| 추가 | `profile_music_preview_url` | `text?` |
| 추가 | `profile_music_source_url` | `text?` |

**신규 Enum**

```prisma
enum ProfileMusicSourceType {
  DEEZER
}
```

> 필드 일관성 규칙: `profileMusicSourceType`이 null이면 나머지 8개 필드도 null (all-or-nothing)

### 4. 제거

- `GET /songs/deezer/tracks/search` — songs 모듈 임시 Deezer 연동 테스트 API 제거
- `SongsService.searchDeezerTrackPreviews` 메서드 제거
- `SongsModule`의 `DeezerTrackClient` provider 제거

<br/>

## 💬 리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로필 음악 검색 기능을 사용자 모듈에 추가했습니다.
  * 프로필 음악 정보를 제목, 아티스트, 앨범, 미리보기 URL 등 상세 메타데이터로 확대했습니다.

* **문서**
  * 사용자 인증 및 프로필 관리 API 명세를 완성했습니다.
  * 프로필 음악 메타데이터 설계 문서를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->