### PR TITLE
✨ feat: 커서 기반 페이지네이션 next path 생성 공통 유틸 추가

### DIFF
--- a/backend/docs/backend/designs/common/build-next-path.md
+++ b/backend/docs/backend/designs/common/build-next-path.md
@@ -1,0 +1,72 @@
+# 설계: common/url — buildNextPath 유틸리티
+
+## 작업 배경
+
+커서 기반 목록 조회에서 `next` URL path를 생성하는 로직이 모듈마다 중복되거나 일관성 없이 구현되어 있다.
+(notifications는 직접 URL 문자열 생성, 나머지는 cursor 객체 반환).
+공통 유틸 함수를 만들어 path 생성 방식을 통일한다.
+
+프로토콜·오리진은 FE가 붙이며, 이 함수는 path 이하만 반환한다.
+
+---
+
+## 작업 범위
+
+```
+신규: src/common/url/url.util.ts
+신규: src/common/url/index.ts
+신규: src/common/url/url.util.spec.ts
+```
+
+---
+
+## 함수 설계
+
+### 시그니처
+
+```typescript
+export function buildNextPath(
+  basePath: string,
+  params: Record<string, string | number | boolean | null | undefined>,
+): string
+```
+
+### 동작 규칙
+
+1. `params` 객체를 순회하며 `URLSearchParams`에 추가한다.
+2. 값이 `undefined` 또는 `null`인 키는 제외한다.
+3. `boolean`, `number` 값은 `String()`으로 변환한다.
+4. 반환값: `${basePath}?${searchParams.toString()}`
+
+### 반환 형태 예시
+
+```
+/notifications/me?where__is_read=false&order__created_at=desc&order__id=desc&take=20&cursor__id=uuid
+```
+
+---
+
+## 트랜잭션 경계
+
+해당 없음 (순수 유틸리티 함수).
+
+---
+
+## 테스트 계획
+
+Service가 없으므로 함수 단위 테스트만 작성한다.
+
+| 케이스 | 설명 |
+|---|---|
+| happy path | basePath + 모든 params가 쿼리 문자열에 포함됨 |
+| undefined 제외 | undefined 값을 가진 키는 쿼리 문자열에서 빠짐 |
+| null 제외 | null 값을 가진 키는 쿼리 문자열에서 빠짐 |
+| 빈 params | params가 `{}` 이면 `basePath?` 반환 |
+| boolean 변환 | `true` → `"true"`, `false` → `"false"` |
+| number 변환 | `20` → `"20"` |
+
+---
+
+## 미결 사항
+
+없음.

--- a/backend/src/common/url/index.ts
+++ b/backend/src/common/url/index.ts
@@ -1,0 +1,1 @@
+export { buildNextPath } from './url.util';

--- a/backend/src/common/url/url.util.spec.ts
+++ b/backend/src/common/url/url.util.spec.ts
@@ -1,0 +1,55 @@
+import { buildNextPath } from './url.util';
+
+describe('buildNextPath', () => {
+  it('모든 params를 쿼리 문자열로 반환한다', () => {
+    const result = buildNextPath('/notifications/me', {
+      order__created_at: 'desc',
+      order__id: 'desc',
+      take: 20,
+      cursor__id: 'some-uuid',
+    });
+
+    expect(result).toBe('/notifications/me?order__created_at=desc&order__id=desc&take=20&cursor__id=some-uuid');
+  });
+
+  it('undefined 값인 키는 쿼리 문자열에서 제외한다', () => {
+    const result = buildNextPath('/notifications/me', {
+      where__is_read: undefined,
+      where__type: undefined,
+      order__id: 'desc',
+    });
+
+    expect(result).toBe('/notifications/me?order__id=desc');
+  });
+
+  it('null 값인 키는 쿼리 문자열에서 제외한다', () => {
+    const result = buildNextPath('/notifications/me', {
+      where__type: null,
+      order__id: 'asc',
+    });
+
+    expect(result).toBe('/notifications/me?order__id=asc');
+  });
+
+  it('params가 비어있으면 basePath?를 반환한다', () => {
+    const result = buildNextPath('/bands', {});
+
+    expect(result).toBe('/bands?');
+  });
+
+  it('boolean 값을 문자열로 변환한다', () => {
+    const result = buildNextPath('/notifications/me', {
+      where__is_read: false,
+    });
+
+    expect(result).toBe('/notifications/me?where__is_read=false');
+  });
+
+  it('number 값을 문자열로 변환한다', () => {
+    const result = buildNextPath('/bands', {
+      take: 20,
+    });
+
+    expect(result).toBe('/bands?take=20');
+  });
+});

--- a/backend/src/common/url/url.util.ts
+++ b/backend/src/common/url/url.util.ts
@@ -1,0 +1,17 @@
+/**
+ * 커서 기반 목록 조회의 다음 페이지 경로를 생성한다.
+ * undefined / null 값은 쿼리 파라미터에서 제외된다.
+ *
+ * @param basePath - 기본 경로 (예: /notifications/me)
+ * @param params - 쿼리 파라미터 객체
+ * @returns 쿼리 파라미터가 포함된 경로 문자열
+ */
+export function buildNextPath(basePath: string, params: Record<string, string | number | boolean | null | undefined>): string {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null) {
+      searchParams.set(key, String(value));
+    }
+  }
+  return `${basePath}?${searchParams.toString()}`;
+}


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 5분

<br/>

## 📌 작업 요약

커서 기반 페이지네이션의 `next` path를 일관되게 생성하기 위한 공통 유틸 함수 추가

<br/>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요 (이미지 첨부 가능)

1. `src/common/url/url.util.ts`에 `buildNextPath` 유틸 함수 추가
2. `undefined` / `null` 값은 쿼리 파라미터에서 자동 제외
3. 반환값은 path만 (프로토콜·오리진 제외) — FE가 오리진을 붙이는 방식

<br/>

## 🚨 주요 고민 및 해결 과정

> 주요 고민이나 문제 해결 과정 공유

### 문제

각 모듈에서 next path를 직접 문자열로 조합하면 `undefined`/`null` 파라미터가 그대로 포함되거나, 포맷이 제각각이 되는 문제

### 해결 과정

공통 유틸로 추출하고, 값이 없는 파라미터는 `URLSearchParams` 생성 전에 필터링하여 일관된 path 반환

<br/>

## 📑 참고 문서/ ADR

> 참고한 외부 문서, 레퍼런스, 기술 블로그, 공식 문서 등의 링크

<br/>

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- happy path / `undefined` / `null` / 빈 params / `boolean`·`number` 변환 총 5개 케이스 테스트 포함