### PR TITLE
👷 ci: 백엔드 배포 워크플로우 DOCKER_CONTEXT 예약어 충돌 수정

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   IMAGE_REPOSITORY: jamplay-backend
-  DOCKER_CONTEXT: ./backend
+  BUILD_CONTEXT: ./backend
   DOCKERFILE_PATH: ./backend/Dockerfile
   CONTAINER_NAME: jamplay-backend
   CONTAINER_PORT: 3000
@@ -47,7 +47,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
-          context: ${{ env.DOCKER_CONTEXT }}
+          context: ${{ env.BUILD_CONTEXT }}
           file: ${{ env.DOCKERFILE_PATH }}
           push: true
           tags: |


### PR DESCRIPTION
## 문제

`Backend CI/CD` 워크플로우가 **Set up Docker Buildx** 스텝에서 즉시 실패:

```
Failed to initialize: unable to resolve docker endpoint:
context "./backend": context not found
```

## 원인

워크플로우 `env`에 정의한 `DOCKER_CONTEXT: ./backend`가 문제. **`DOCKER_CONTEXT`는 Docker CLI의 예약 환경변수**로, "사용할 docker context 이름"으로 읽힙니다 (`docker --context`와 동일). 빌드 컨텍스트 경로로 쓰려던 `./backend`를 Docker가 context 이름으로 해석 → 존재하지 않아 buildx 셋업이 실패했습니다.

b825d6a(서드파티 SHA 핀) 작업 중 추가된 변수명이 하필 예약어와 겹친 케이스입니다.

## 수정

`DOCKER_CONTEXT` → `BUILD_CONTEXT`로 변수명 변경 (정의부 + `build-push-action` 참조부). 동작은 동일하고 Docker 예약어 충돌만 제거됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
