### PR TITLE
👷 ci: 배포 IMAGE를 job output 대신 직접 조립 (invalid reference format 수정)

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -28,9 +28,6 @@ jobs:
     name: Build and push backend image
     runs-on: ubuntu-latest
 
-    outputs:
-      image: ${{ steps.image.outputs.image }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -56,10 +53,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Export image tag
-        id: image
-        run: echo "image=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPOSITORY }}:${{ github.sha }}" >> "$GITHUB_OUTPUT"
-
   deploy:
     name: Deploy backend
     runs-on: ubuntu-latest
@@ -69,7 +62,7 @@ jobs:
       - name: Deploy through SSH
         uses: appleboy/ssh-action@7eaf76671a0d7eec5d98ee897acda4f968735a17
         env:
-          IMAGE: ${{ needs.build-and-push.outputs.image }}
+          IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPOSITORY }}:${{ github.sha }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           CONTAINER_NAME: ${{ env.CONTAINER_NAME }}


### PR DESCRIPTION
## 문제

SSH 인증·빌드는 통과했으나 deploy 스텝에서 실패:

```
Login Succeeded
invalid reference format
Process exited with status 1
```

## 원인

deploy 잡의 `IMAGE` 환경변수가 **빈 문자열**이라 서버에서 `docker pull ""`이 실행되어 `invalid reference format`이 발생했습니다.

빈 값이 된 이유는 빌드 잡의 경고에서 드러납니다:

```
##[warning]Skip output 'image' since it may contain secret.
```

이미지 이름을 `${{ secrets.DOCKERHUB_USERNAME }}/jamplay-backend:<sha>`로 만들어 **job output**(`outputs.image`)으로 전달했는데, GitHub Actions는 **출력값에 시크릿이 포함되면 보안상 그 output을 설정하지 않습니다.** 그래서 `needs.build-and-push.outputs.image`가 비었고, deploy 잡의 `IMAGE`도 비었습니다.

## 수정

시크릿을 job output에 태우는 구조를 제거하고, deploy 잡에서 이미지 이름을 직접 조립합니다 (deploy 잡도 `secrets`·`github.sha`에 접근 가능):

```yaml
env:
  IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPOSITORY }}:${{ github.sha }}
```

- 불필요해진 `Export image tag` 스텝과 `build-and-push` 잡의 `outputs` 블록 제거
- 빌드→배포 순서는 `needs: build-and-push`로 그대로 유지

머지 후 `workflow_dispatch`로 재실행하면 `docker pull`이 정상 동작합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
