### PR TITLE
👷 ci: 배포 이미지·컨테이너 이름을 서버 실제 배포(bandco-be/bandco-nest)에 맞춤

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -16,10 +16,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_REPOSITORY: jamplay-backend
+  IMAGE_REPOSITORY: bandco-be
   BUILD_CONTEXT: ./backend
   DOCKERFILE_PATH: ./backend/Dockerfile
-  CONTAINER_NAME: jamplay-backend
+  CONTAINER_NAME: bandco-nest
   CONTAINER_PORT: 3000
   HOST_PORT: ${{ vars.BACKEND_HOST_PORT || '3000' }}
 


### PR DESCRIPTION
## 문제

서버에서 실제 운영 중인 컨테이너와 워크플로우 배포 대상의 이름이 달랐습니다.

| 항목 | 서버 실제 (`docker ps`) | 워크플로우(기존) |
|------|------------------------|------------------|
| 이미지 | `devjuns/bandco-be:latest` | `devjuns/jamplay-backend:<sha>` |
| 컨테이너 | `bandco-nest` | `jamplay-backend` |
| 포트 | `3000:3000` | `3000:3000` |

이름이 어긋나면 배포 스크립트의 `docker stop/rm "$CONTAINER_NAME"`이 기존 `bandco-nest`를 내리지 못하고, 새 컨테이너가 이미 점유된 포트 3000을 잡으려다 충돌해 `docker run`이 실패합니다.

## 수정

워크플로우 env를 서버 현실에 맞춤:

- `IMAGE_REPOSITORY`: `jamplay-backend` → `bandco-be`
- `CONTAINER_NAME`: `jamplay-backend` → `bandco-nest`

이제 deploy 스크립트가 기존 `bandco-nest`를 정확히 stop/rm 후 동일 이름으로 교체 배포하므로 포트 충돌이 없고, DockerHub도 기존 `bandco-be` 레포를 재사용합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
