### PR TITLE
로그인 버그 해결

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Headers, Post, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
 import { ApiBasicAuth, ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { type ApiSuccessResponse, createSuccessResponse } from '../common/api-response';
@@ -6,7 +6,7 @@ import { type ApiSuccessResponse, createSuccessResponse } from '../common/api-re
 import { CheckEmailDto } from './dto/check-email.dto';
 import { RegisterEmailDto } from './dto/register-email.dto';
 import { BasicTokenGuard } from './guard/basic-token.guard';
-import { AccessTokenGuard, RefreshTokenGuard } from './guard/bearer-token.guard';
+import { RefreshTokenGuard } from './guard/bearer-token.guard';
 import { AuthService } from './auth.service';
 
 @ApiTags('인증')
@@ -15,15 +15,15 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('token/access')
-  @UseGuards(AccessTokenGuard)
-  @ApiBearerAuth('access-token')
+  @UseGuards(RefreshTokenGuard)
+  @ApiBearerAuth('refresh-token')
   @ApiOperation({ summary: '액세스 토큰 재발급' })
   @ApiResponse({ status: 201, description: '액세스 토큰 재발급 성공' })
   @ApiResponse({ status: 401, description: '인증 실패' })
-  TokenAccess(@Headers('authorization') authHeader: string) {
-    const token = this.authService.extractTokenFromHeader(authHeader, true);
-    const newToken = this.authService.rotateToken(token, false);
-    return { accessToken: newToken };
+  TokenAccess(@Req() req: { user: { id: string; email: string } }) {
+    const { email, id } = req.user;
+    const accessToken = this.authService.signToken(email, id, false);
+    return { accessToken };
   }
 
   @Post('token/refresh')
@@ -32,10 +32,10 @@ export class AuthController {
   @ApiOperation({ summary: '리프레시 토큰 재발급' })
   @ApiResponse({ status: 201, description: '리프레시 토큰 재발급 성공' })
   @ApiResponse({ status: 401, description: '인증 실패' })
-  TokenRefresh(@Headers('authorization') authHeader: string) {
-    const token = this.authService.extractTokenFromHeader(authHeader, true);
-    const newToken = this.authService.rotateToken(token, true);
-    return { refreshToken: newToken };
+  TokenRefresh(@Req() req: { user: { id: string; email: string } }) {
+    const { email, id } = req.user;
+    const refreshToken = this.authService.signToken(email, id, true);
+    return { refreshToken };
   }
 
   @Post('login/email')

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -90,25 +90,6 @@ describe('AuthService', () => {
     });
   });
 
-  describe('rotateToken', () => {
-    it('refresh 토큰을 재발급한다', () => {
-      mockJwtService.verify.mockReturnValue({ email: 'u@u.com', id: 'uid', type: 'refresh' });
-      mockJwtService.sign.mockReturnValue('new-refresh');
-      expect(service.rotateToken('old', true)).toBe('new-refresh');
-    });
-
-    it('access 토큰을 재발급한다', () => {
-      mockJwtService.verify.mockReturnValue({ email: 'u@u.com', id: 'uid', type: 'access' });
-      mockJwtService.sign.mockReturnValue('new-access');
-      expect(service.rotateToken('old', false)).toBe('new-access');
-    });
-
-    it('토큰 타입이 isRefreshToken 인자와 다르면 UnauthorizedException을 던진다', () => {
-      mockJwtService.verify.mockReturnValue({ email: 'u@u.com', id: 'uid', type: 'access' });
-      expect(() => service.rotateToken('old', true)).toThrow(UnauthorizedException);
-    });
-  });
-
   describe('authenticateWithEmailAndPassword', () => {
     it('유저가 존재하지 않으면 UnauthorizedException을 던진다', async () => {
       mockUsersService.getUserByEmail.mockResolvedValue(null);

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -13,6 +13,7 @@ const mockJwtService = {
 
 const mockUsersService = {
   getUserByEmail: jest.fn(),
+  getUserForPasswordAuth: jest.fn(),
   createUserWithEmail: jest.fn(),
 };
 
@@ -92,28 +93,28 @@ describe('AuthService', () => {
 
   describe('authenticateWithEmailAndPassword', () => {
     it('유저가 존재하지 않으면 UnauthorizedException을 던진다', async () => {
-      mockUsersService.getUserByEmail.mockResolvedValue(null);
+      mockUsersService.getUserForPasswordAuth.mockResolvedValue(null);
       await expect(service.authenticateWithEmailAndPassword('u@u.com', 'pw')).rejects.toThrow(UnauthorizedException);
     });
 
     it('유저에 email이 없으면 UnauthorizedException을 던진다', async () => {
-      mockUsersService.getUserByEmail.mockResolvedValue({ id: 'uid', email: null, passwordHash: 'hash' });
+      mockUsersService.getUserForPasswordAuth.mockResolvedValue({ id: 'uid', email: null, passwordHash: 'hash' });
       await expect(service.authenticateWithEmailAndPassword('u@u.com', 'pw')).rejects.toThrow(UnauthorizedException);
     });
 
     it('유저에 passwordHash가 없으면 UnauthorizedException을 던진다', async () => {
-      mockUsersService.getUserByEmail.mockResolvedValue({ id: 'uid', email: 'u@u.com', passwordHash: null });
+      mockUsersService.getUserForPasswordAuth.mockResolvedValue({ id: 'uid', email: 'u@u.com', passwordHash: null });
       await expect(service.authenticateWithEmailAndPassword('u@u.com', 'pw')).rejects.toThrow(UnauthorizedException);
     });
 
     it('비밀번호가 틀리면 UnauthorizedException을 던진다', async () => {
-      mockUsersService.getUserByEmail.mockResolvedValue({ id: 'uid', email: 'u@u.com', passwordHash: 'hash' });
+      mockUsersService.getUserForPasswordAuth.mockResolvedValue({ id: 'uid', email: 'u@u.com', passwordHash: 'hash' });
       jest.spyOn(bcrypt, 'compare').mockImplementation(async () => false);
       await expect(service.authenticateWithEmailAndPassword('u@u.com', 'wrong')).rejects.toThrow(UnauthorizedException);
     });
 
     it('인증 성공 시 id와 email을 반환한다', async () => {
-      mockUsersService.getUserByEmail.mockResolvedValue({ id: 'uid', email: 'u@u.com', passwordHash: 'hash' });
+      mockUsersService.getUserForPasswordAuth.mockResolvedValue({ id: 'uid', email: 'u@u.com', passwordHash: 'hash' });
       jest.spyOn(bcrypt, 'compare').mockImplementation(async () => true);
       await expect(service.authenticateWithEmailAndPassword('u@u.com', 'correct')).resolves.toEqual({
         id: 'uid',
@@ -124,7 +125,7 @@ describe('AuthService', () => {
 
   describe('loginWithEmail', () => {
     it('인증 성공 시 토큰 쌍을 반환한다', async () => {
-      mockUsersService.getUserByEmail.mockResolvedValue({ id: 'uid', email: 'u@u.com', passwordHash: 'hash' });
+      mockUsersService.getUserForPasswordAuth.mockResolvedValue({ id: 'uid', email: 'u@u.com', passwordHash: 'hash' });
       jest.spyOn(bcrypt, 'compare').mockImplementation(async () => true);
       mockJwtService.sign.mockReturnValueOnce('access').mockReturnValueOnce('refresh');
       await expect(service.loginWithEmail('u@u.com', 'correct')).resolves.toEqual({

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -86,15 +86,6 @@ export class AuthService {
     });
   }
 
-  rotateToken(token: string, isRefreshToken: boolean) {
-    const decoded = this.jwtService.verify(token, {
-      secret: 'jamplay',
-    }) as JwtPayload;
-    if (decoded.type !== (isRefreshToken ? 'refresh' : 'access')) {
-      throw new UnauthorizedException('재발급은 refresh 토큰만 가능합니다.');
-    }
-    return this.signToken(decoded.email, decoded.id, isRefreshToken);
-  }
   extractTokenFromHeader(rawToken: string, isBearer: boolean) {
     const splitToken = rawToken.split(' ');
     const prefix = isBearer ? 'Bearer' : 'Basic';

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -33,7 +33,7 @@ export class AuthService {
   }
 
   async authenticateWithEmailAndPassword(email: string, password: string): Promise<{ id: string; email: string }> {
-    const user = await this.usersService.getUserByEmail(email);
+    const user = await this.usersService.getUserForPasswordAuth(email);
 
     if (!user) {
       throw new UnauthorizedException('존재하지 않는 유저입니다.');

--- a/backend/src/auth/guard/bearer-token.guard.spec.ts
+++ b/backend/src/auth/guard/bearer-token.guard.spec.ts
@@ -12,7 +12,7 @@ const mockAuthService = {
 };
 
 const mockUsersService = {
-  getUserByEmail: jest.fn(),
+  getAuthUserById: jest.fn(),
 };
 
 const createContext = (authHeader?: string) => {
@@ -27,8 +27,8 @@ const createContext = (authHeader?: string) => {
 
 const setupValidBearer = (tokenType: 'access' | 'refresh') => {
   mockAuthService.extractTokenFromHeader.mockReturnValue('token');
-  mockAuthService.verifyToken.mockReturnValue({ email: 'u@u.com', type: tokenType });
-  mockUsersService.getUserByEmail.mockResolvedValue({ id: 'uid', email: 'u@u.com' });
+  mockAuthService.verifyToken.mockReturnValue({ id: 'uid', email: 'u@u.com', type: tokenType });
+  mockUsersService.getAuthUserById.mockResolvedValue({ id: 'uid', email: 'u@u.com', passwordHash: 'hash' });
 };
 
 describe('BearerTokenGuard', () => {
@@ -51,8 +51,8 @@ describe('BearerTokenGuard', () => {
   it('토큰의 유저가 존재하지 않으면 UnauthorizedException을 던진다', async () => {
     const { ctx } = createContext('Bearer token');
     mockAuthService.extractTokenFromHeader.mockReturnValue('token');
-    mockAuthService.verifyToken.mockReturnValue({ email: 'ghost@u.com', type: 'access' });
-    mockUsersService.getUserByEmail.mockResolvedValue(null);
+    mockAuthService.verifyToken.mockReturnValue({ id: 'ghost-id', email: 'ghost@u.com', type: 'access' });
+    mockUsersService.getAuthUserById.mockResolvedValue(null);
 
     await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
   });
@@ -67,6 +67,7 @@ describe('BearerTokenGuard', () => {
     expect(request.token).toBe('token');
     expect(request.tokenType).toBe('access');
     expect(request.user).toEqual({ id: 'uid', email: 'u@u.com' });
+    expect(mockUsersService.getAuthUserById).toHaveBeenCalledWith('uid');
   });
 });
 

--- a/backend/src/auth/guard/bearer-token.guard.ts
+++ b/backend/src/auth/guard/bearer-token.guard.ts
@@ -18,13 +18,13 @@ export class BearerTokenGuard implements CanActivate {
     }
     const token = this.authService.extractTokenFromHeader(rawToken, true);
     const result = await this.authService.verifyToken(token);
-    const user = await this.userService.getUserByEmail(result.email);
+    const user = await this.userService.getAuthUserById(result.id);
     if (!user) {
       throw new UnauthorizedException('존재하지 않는 유저입니다.');
     }
     req.token = token;
     req.tokenType = result.type;
-    req.user = user;
+    req.user = { id: user.id, email: user.email };
     return true;
   }
 }

--- a/backend/src/modules/bands/band-invitations.controller.ts
+++ b/backend/src/modules/bands/band-invitations.controller.ts
@@ -3,7 +3,7 @@ import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@ne
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
-import type { User } from '../../generated/prisma';
+import type { AuthUser } from '../users/repositoreis/user.repository';
 
 import { GetReceivedBandInvitationsQueryDto } from './dto/get-received-band-invitations-query.dto';
 import { GetSentBandInvitationsQueryDto } from './dto/get-sent-band-invitations-query.dto';
@@ -15,7 +15,7 @@ import type { GetSentBandInvitationsResult } from './types/sent-band-invitation-
 import { BandsService } from './bands.service';
 
 interface AuthenticatedRequest {
-  user: User;
+  user: AuthUser;
 }
 
 @ApiTags('초대')

--- a/backend/src/modules/bands/band-join-requests.controller.ts
+++ b/backend/src/modules/bands/band-join-requests.controller.ts
@@ -3,7 +3,7 @@ import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@ne
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
-import type { User } from '../../generated/prisma';
+import type { AuthUser } from '../users/repositoreis/user.repository';
 
 import { GetSentBandJoinRequestsQueryDto } from './dto/get-sent-band-join-requests-query.dto';
 import type { ApproveBandJoinRequestResult } from './types/approve-band-join-request-result.type';
@@ -12,7 +12,7 @@ import type { GetSentBandJoinRequestsResult } from './types/sent-band-join-reque
 import { BandsService } from './bands.service';
 
 interface AuthenticatedRequest {
-  user: User;
+  user: AuthUser;
 }
 
 @ApiTags('가입 요청')

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -3,7 +3,7 @@ import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@ne
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
-import type { User } from '../../generated/prisma';
+import type { AuthUser } from '../users/repositoreis/user.repository';
 
 import { CreateBandBodyDto } from './dto/create-band.dto';
 import { CreateBandInvitationBodyDto } from './dto/create-band-invitation.dto';
@@ -28,7 +28,7 @@ import type { UpdateBandResult } from './types/update-band-result.type';
 import { BandsService } from './bands.service';
 
 interface AuthenticatedRequest {
-  user: User;
+  user: AuthUser;
 }
 
 @ApiTags('밴드')

--- a/backend/src/modules/notifications/notifications.controller.ts
+++ b/backend/src/modules/notifications/notifications.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Delete, Get, Param, Patch, Query, Req, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
-import type { User } from 'src/generated/prisma';
+import type { AuthUser } from 'src/modules/users/repositoreis/user.repository';
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
@@ -27,7 +27,7 @@ export class NotificationsController {
   @ApiOperation({ summary: '알림 목록 조회' })
   @ApiResponse({ status: 200, description: '알림 목록 조회 성공' })
   @ApiResponse({ status: 401, description: '인증 실패' })
-  async getNotifications(@Req() req: { user: User }, @Query() query: GetNotificationsQueryDto): Promise<ApiSuccessResponse<GetNotificationsResult>> {
+  async getNotifications(@Req() req: { user: AuthUser }, @Query() query: GetNotificationsQueryDto): Promise<ApiSuccessResponse<GetNotificationsResult>> {
     const result = await this.notificationsService.getNotifications(req.user.id, query);
     return createSuccessResponse('알림 목록 조회 성공', result);
   }
@@ -36,7 +36,7 @@ export class NotificationsController {
   @ApiOperation({ summary: '전체 알림 읽음 처리' })
   @ApiResponse({ status: 200, description: '전체 알림 읽음 처리 성공' })
   @ApiResponse({ status: 401, description: '인증 실패' })
-  async markAllNotificationsAsRead(@Req() req: { user: User }): Promise<ApiSuccessResponse<MarkAllReadResult>> {
+  async markAllNotificationsAsRead(@Req() req: { user: AuthUser }): Promise<ApiSuccessResponse<MarkAllReadResult>> {
     const result = await this.notificationsService.markAllNotificationsAsRead(req.user.id);
     return createSuccessResponse('전체 알림 읽음 처리 성공', result);
   }
@@ -46,7 +46,7 @@ export class NotificationsController {
   @ApiResponse({ status: 200, description: '다건 알림 읽음 처리 성공' })
   @ApiResponse({ status: 400, description: '잘못된 요청' })
   @ApiResponse({ status: 401, description: '인증 실패' })
-  async markManyNotificationsAsRead(@Req() req: { user: User }, @Body() dto: MarkManyReadDto): Promise<ApiSuccessResponse<MarkManyReadResult>> {
+  async markManyNotificationsAsRead(@Req() req: { user: AuthUser }, @Body() dto: MarkManyReadDto): Promise<ApiSuccessResponse<MarkManyReadResult>> {
     const result = await this.notificationsService.markManyNotificationsAsRead(req.user.id, dto.notificationIds);
     return createSuccessResponse('다건 알림 읽음 처리 성공', result);
   }
@@ -58,7 +58,7 @@ export class NotificationsController {
   @ApiResponse({ status: 401, description: '인증 실패' })
   @ApiResponse({ status: 404, description: '알림을 찾을 수 없음' })
   async markNotificationAsRead(
-    @Req() req: { user: User },
+    @Req() req: { user: AuthUser },
     @Param('notificationId') notificationId: string,
   ): Promise<ApiSuccessResponse<MarkNotificationReadResult>> {
     const result = await this.notificationsService.markNotificationAsRead(req.user.id, notificationId);
@@ -71,7 +71,7 @@ export class NotificationsController {
   @ApiResponse({ status: 400, description: '잘못된 요청' })
   @ApiResponse({ status: 401, description: '인증 실패' })
   async deleteManyNotifications(
-    @Req() req: { user: User },
+    @Req() req: { user: AuthUser },
     @Body() dto: DeleteManyNotificationsDto,
   ): Promise<ApiSuccessResponse<DeleteManyNotificationsResult>> {
     const result = await this.notificationsService.deleteManyNotifications(req.user.id, dto.notificationIds);
@@ -85,7 +85,7 @@ export class NotificationsController {
   @ApiResponse({ status: 401, description: '인증 실패' })
   @ApiResponse({ status: 404, description: '알림을 찾을 수 없음' })
   async deleteNotification(
-    @Req() req: { user: User },
+    @Req() req: { user: AuthUser },
     @Param('notificationId') notificationId: string,
   ): Promise<ApiSuccessResponse<DeleteNotificationResult>> {
     const result = await this.notificationsService.deleteNotification(req.user.id, notificationId);

--- a/backend/src/modules/schedules/schedules.controller.ts
+++ b/backend/src/modules/schedules/schedules.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Delete, Get, Param, Patch, Post, Query, Req, UseGuard
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
-import type { User } from '../../generated/prisma';
+import type { AuthUser } from '../users/repositoreis/user.repository';
 
 import { CreateScheduleBodyDto } from './dto/create-schedule.dto';
 import { GetSchedulesQueryDto } from './dto/get-schedules-query.dto';
@@ -16,7 +16,7 @@ import type { UpdateScheduleResult } from './types/update-schedule-result.type';
 import { SchedulesService } from './schedules.service';
 
 interface AuthenticatedRequest {
-  user: User;
+  user: AuthUser;
 }
 
 @Controller()

--- a/backend/src/modules/songs/songs.controller.ts
+++ b/backend/src/modules/songs/songs.controller.ts
@@ -3,7 +3,7 @@ import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@ne
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
-import type { User } from '../../generated/prisma';
+import type { AuthUser } from '../users/repositoreis/user.repository';
 
 import { CreateSongBodyDto } from './dto/create-song.dto';
 import { GetBandSongsQueryDto } from './dto/get-band-songs-query.dto';
@@ -17,7 +17,7 @@ import type { UpdateSongResult } from './types/update-song-result.type';
 import { SongsService } from './songs.service';
 
 interface AuthenticatedRequest {
-  user: User;
+  user: AuthUser;
 }
 
 @ApiTags('곡')

--- a/backend/src/modules/users/guard/self-user.guard.ts
+++ b/backend/src/modules/users/guard/self-user.guard.ts
@@ -1,10 +1,10 @@
 import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
-import type { User } from 'src/generated/prisma';
 
 @Injectable()
 export class SelfUserGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
-    const req = context.switchToHttp().getRequest<{ user: User; params: { userId: string } }>();
+    // AccessTokenGuard가 세팅한 req.user(id, email)를 받아 본인 여부만 검사한다.
+    const req = context.switchToHttp().getRequest<{ user: { id: string }; params: { userId: string } }>();
     if (req.user.id !== req.params.userId) {
       throw new ForbiddenException('본인 프로필만 수정할 수 있습니다.');
     }

--- a/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
+++ b/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
@@ -1,12 +1,13 @@
 import { Test } from '@nestjs/testing';
 import { PrismaService } from 'src/database/prisma/prisma.service';
+import type { Prisma } from 'src/generated/prisma';
 
 import type { GetUsersQuery } from '../dto/get-users-query.dto';
 
 import { UsersPrismaRepository } from './user.prisma-repository';
 
 const mockPrisma = {
-  user: { findUnique: jest.fn(), findMany: jest.fn(), create: jest.fn(), update: jest.fn() },
+  user: { findUnique: jest.fn(), findFirst: jest.fn(), findMany: jest.fn(), create: jest.fn(), update: jest.fn() },
   userProfile: { create: jest.fn(), update: jest.fn() },
   userSkill: { deleteMany: jest.fn(), createMany: jest.fn() },
   favoriteGenre: { deleteMany: jest.fn(), createMany: jest.fn() },
@@ -42,7 +43,10 @@ describe('UsersPrismaRepository', () => {
     it('이메일로 user.findUnique를 호출한다', async () => {
       mockPrisma.user.findUnique.mockResolvedValue(userRecord);
       const result = await repository.findByEmail('test@example.com');
-      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({ where: { email: 'test@example.com' } });
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+        where: { email: 'test@example.com' },
+        select: { id: true, email: true },
+      });
       expect(result?.id).toBe('user-001');
     });
 
@@ -53,9 +57,43 @@ describe('UsersPrismaRepository', () => {
 
     it('tx가 전달되면 tx 클라이언트를 사용한다', async () => {
       const txClient = { user: { findUnique: jest.fn().mockResolvedValue(null) } };
-      await repository.findByEmail('test@example.com', txClient as any);
+      await repository.findByEmail('test@example.com', txClient as unknown as Prisma.TransactionClient);
       expect(txClient.user.findUnique).toHaveBeenCalled();
       expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findAuthUserById', () => {
+    it('ACTIVE 상태이고 삭제되지 않은 유저를 id/email만 조회한다', async () => {
+      mockPrisma.user.findFirst.mockResolvedValue(userRecord);
+      const result = await repository.findAuthUserById('user-001');
+      expect(mockPrisma.user.findFirst).toHaveBeenCalledWith({
+        where: { id: 'user-001', deletedAt: null, status: 'ACTIVE' },
+        select: { id: true, email: true },
+      });
+      expect(result).toEqual({ id: 'user-001', email: 'test@example.com' });
+    });
+
+    it('email이 없으면 null을 반환한다', async () => {
+      mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-001', email: null });
+      await expect(repository.findAuthUserById('user-001')).resolves.toBeNull();
+    });
+  });
+
+  describe('findUserForPasswordAuth', () => {
+    it('로그인에 필요한 passwordHash까지만 조회한다', async () => {
+      mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-001', email: 'test@example.com', passwordHash: 'hash' });
+      const result = await repository.findUserForPasswordAuth('test@example.com');
+      expect(mockPrisma.user.findFirst).toHaveBeenCalledWith({
+        where: { email: 'test@example.com', deletedAt: null, status: 'ACTIVE' },
+        select: { id: true, email: true, passwordHash: true },
+      });
+      expect(result).toEqual({ id: 'user-001', email: 'test@example.com', passwordHash: 'hash' });
+    });
+
+    it('email이 없으면 null을 반환한다', async () => {
+      mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-001', email: null, passwordHash: 'hash' });
+      await expect(repository.findUserForPasswordAuth('test@example.com')).resolves.toBeNull();
     });
   });
 
@@ -78,7 +116,7 @@ describe('UsersPrismaRepository', () => {
         userProfile: { create: jest.fn().mockResolvedValue({}) },
       };
 
-      await repository.createUserWithEmail('tx@example.com', 'hashed', txClient as any);
+      await repository.createUserWithEmail('tx@example.com', 'hashed', txClient as unknown as Prisma.TransactionClient);
 
       expect(mockPrisma.$transaction).not.toHaveBeenCalled();
       expect(txClient.user.create).toHaveBeenCalled();

--- a/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
+++ b/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
@@ -78,6 +78,17 @@ describe('UsersPrismaRepository', () => {
       mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-001', email: null });
       await expect(repository.findAuthUserById('user-001')).resolves.toBeNull();
     });
+
+    it('tx가 전달되면 tx 클라이언트로 findFirst를 호출한다', async () => {
+      const txClient = { user: { findFirst: jest.fn().mockResolvedValue(userRecord) } };
+      const result = await repository.findAuthUserById('user-001', txClient as unknown as Prisma.TransactionClient);
+      expect(txClient.user.findFirst).toHaveBeenCalledWith({
+        where: { id: 'user-001', deletedAt: null, status: 'ACTIVE' },
+        select: { id: true, email: true },
+      });
+      expect(mockPrisma.user.findFirst).not.toHaveBeenCalled();
+      expect(result).toEqual({ id: 'user-001', email: 'test@example.com' });
+    });
   });
 
   describe('findUserForPasswordAuth', () => {
@@ -94,6 +105,19 @@ describe('UsersPrismaRepository', () => {
     it('email이 없으면 null을 반환한다', async () => {
       mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-001', email: null, passwordHash: 'hash' });
       await expect(repository.findUserForPasswordAuth('test@example.com')).resolves.toBeNull();
+    });
+
+    it('tx가 전달되면 tx 클라이언트로 findFirst를 호출한다', async () => {
+      const txClient = {
+        user: { findFirst: jest.fn().mockResolvedValue({ id: 'user-001', email: 'test@example.com', passwordHash: 'hash' }) },
+      };
+      const result = await repository.findUserForPasswordAuth('test@example.com', txClient as unknown as Prisma.TransactionClient);
+      expect(txClient.user.findFirst).toHaveBeenCalledWith({
+        where: { email: 'test@example.com', deletedAt: null, status: 'ACTIVE' },
+        select: { id: true, email: true, passwordHash: true },
+      });
+      expect(mockPrisma.user.findFirst).not.toHaveBeenCalled();
+      expect(result).toEqual({ id: 'user-001', email: 'test@example.com', passwordHash: 'hash' });
     });
   });
 

--- a/backend/src/modules/users/repositoreis/user.prisma-repository.ts
+++ b/backend/src/modules/users/repositoreis/user.prisma-repository.ts
@@ -8,7 +8,7 @@ import type { GetUsersResult, UserListItem } from '../types/user-list.type';
 import type { GetUserProfileResult } from '../types/user-profile.type';
 import { generateRandomNickname } from '../util/nickname_maker';
 
-import type { UsersRepository } from './user.repository';
+import type { AuthUser, PasswordAuthUser, UsersRepository } from './user.repository';
 
 type UserListRecord = Prisma.UserGetPayload<{
   include: {
@@ -29,15 +29,49 @@ function mapUserListItem(user: UserListRecord): UserListItem {
   };
 }
 
+function mapAuthUser(user: { id: string; email: string | null } | null): AuthUser | null {
+  if (!user?.email) return null;
+  return { id: user.id, email: user.email };
+}
+
 @Injectable()
 export class UsersPrismaRepository implements UsersRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findByEmail(email: string, tx?: Prisma.TransactionClient): Promise<User | null> {
+  async findByEmail(email: string, tx?: Prisma.TransactionClient): Promise<AuthUser | null> {
     const client = tx ?? this.prisma;
-    return client.user.findUnique({
+    const user = await client.user.findUnique({
       where: { email },
+      select: { id: true, email: true },
     });
+
+    return mapAuthUser(user);
+  }
+
+  async findAuthUserById(id: string, tx?: Prisma.TransactionClient): Promise<AuthUser | null> {
+    const client = tx ?? this.prisma;
+    const user = await client.user.findFirst({
+      where: { id, deletedAt: null, status: 'ACTIVE' },
+      select: { id: true, email: true },
+    });
+
+    return mapAuthUser(user);
+  }
+
+  async findUserForPasswordAuth(email: string, tx?: Prisma.TransactionClient): Promise<PasswordAuthUser | null> {
+    const client = tx ?? this.prisma;
+    const user = await client.user.findFirst({
+      where: { email, deletedAt: null, status: 'ACTIVE' },
+      select: { id: true, email: true, passwordHash: true },
+    });
+
+    if (!user?.email) return null;
+
+    return {
+      id: user.id,
+      email: user.email,
+      passwordHash: user.passwordHash,
+    };
   }
 
   async createUserWithEmail(email: string, passwordHash: string, tx?: Prisma.TransactionClient): Promise<User> {

--- a/backend/src/modules/users/repositoreis/user.repository.ts
+++ b/backend/src/modules/users/repositoreis/user.repository.ts
@@ -7,8 +7,19 @@ import type { GetUserProfileResult } from '../types/user-profile.type';
 
 export const USERS_REPOSITORY = Symbol('USERS_REPOSITORY');
 
+export type AuthUser = {
+  id: string;
+  email: string;
+};
+
+export type PasswordAuthUser = AuthUser & {
+  passwordHash: string | null;
+};
+
 export interface UsersRepository {
-  findByEmail(email: string, tx?: Prisma.TransactionClient): Promise<User | null>;
+  findByEmail(email: string, tx?: Prisma.TransactionClient): Promise<AuthUser | null>;
+  findAuthUserById(id: string, tx?: Prisma.TransactionClient): Promise<AuthUser | null>;
+  findUserForPasswordAuth(email: string, tx?: Prisma.TransactionClient): Promise<PasswordAuthUser | null>;
   createUserWithEmail(email: string, passwordHash: string, tx?: Prisma.TransactionClient): Promise<User>;
   findUsers(query: GetUsersQuery, tx?: Prisma.TransactionClient): Promise<GetUsersResult>;
   findUserProfileById(userId: string, tx?: Prisma.TransactionClient): Promise<GetUserProfileResult | null>;

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -9,7 +9,7 @@ import type { GetUsersResult } from './types/user-list.type';
 import type { GetUserProfileResult } from './types/user-profile.type';
 import { UsersService } from './users.service';
 
-const mockUser = { id: 'user-001', email: 'test@example.com' } as User;
+const mockUser = { id: 'user-001', email: 'test@example.com' };
 
 const mockProfile: GetUserProfileResult = {
   user: { id: 'user-001', email: 'test@example.com', status: 'ACTIVE', createdAt: '2026-01-01T00:00:00.000Z' },
@@ -28,6 +28,12 @@ const mockListResult: GetUsersResult = {
 const repositoryStub: UsersRepository = {
   async findByEmail(email) {
     return email === 'test@example.com' ? mockUser : null;
+  },
+  async findAuthUserById(id) {
+    return id === 'user-001' ? mockUser : null;
+  },
+  async findUserForPasswordAuth(email) {
+    return email === 'test@example.com' ? { id: 'user-001', email: 'test@example.com', passwordHash: 'hash' } : null;
   },
   async createUserWithEmail(email) {
     return { ...mockUser, email } as User;
@@ -62,6 +68,30 @@ describe('UsersService', () => {
 
     it('이메일이 없으면 null을 반환한다', async () => {
       const result = await service.getUserByEmail('none@example.com');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getAuthUserById', () => {
+    it('id가 존재하면 인증용 유저 정보를 반환한다', async () => {
+      const result = await service.getAuthUserById('user-001');
+      expect(result).toEqual({ id: 'user-001', email: 'test@example.com' });
+    });
+
+    it('id가 없으면 null을 반환한다', async () => {
+      const result = await service.getAuthUserById('unknown-id');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getUserForPasswordAuth', () => {
+    it('이메일이 존재하면 passwordHash를 포함한 로그인용 유저 정보를 반환한다', async () => {
+      const result = await service.getUserForPasswordAuth('test@example.com');
+      expect(result).toEqual({ id: 'user-001', email: 'test@example.com', passwordHash: 'hash' });
+    });
+
+    it('이메일이 없으면 null을 반환한다', async () => {
+      const result = await service.getUserForPasswordAuth('none@example.com');
       expect(result).toBeNull();
     });
   });

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -16,6 +16,14 @@ export class UsersService {
     return this.usersRepository.findByEmail(email, tx);
   }
 
+  async getAuthUserById(id: string, tx?: Prisma.TransactionClient) {
+    return this.usersRepository.findAuthUserById(id, tx);
+  }
+
+  async getUserForPasswordAuth(email: string, tx?: Prisma.TransactionClient) {
+    return this.usersRepository.findUserForPasswordAuth(email, tx);
+  }
+
   async createUserWithEmail(email: string, passwordHash: string, tx?: Prisma.TransactionClient) {
     const existingUser = await this.usersRepository.findByEmail(email, tx);
     if (existingUser) {


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 20분

## 📌 작업 요약

인증 로직의 결함 두 가지를 수정하고, 가드가 주입하는 `req.user` 타입을 실제 값에 맞춥니다. (1) 토큰 재발급을 refresh 토큰 전용으로, (2) guard 검증용/로그인용 user 조회를 분리, (3) 컨트롤러·가드의 `req.user` 타입을 `AuthUser`로 정렬.

## 📝 작업 내용

1. **토큰 재발급은 리프레시 토큰으로만** — `POST /auth/token/access`, `POST /auth/token/refresh` 가드를 `RefreshTokenGuard`로 통일하고, 헤더 파싱하던 `rotateToken`을 제거해 가드가 검증한 `req.user`로 발급
2. **guard용 / 로그인용 user 조회 분리** — guard는 토큰 `id`로 조회(`findAuthUserById`, `id`/`email`만), 로그인은 `email`로 조회(`findUserForPasswordAuth`, `passwordHash` 포함). `AuthUser`/`PasswordAuthUser` 타입 추가, `deletedAt: null`·`status: 'ACTIVE'`·`select` 적용
3. **`req.user` 타입을 `AuthUser`로 일치** — 가드는 `{ id, email }`만 주입하는데 컨트롤러·`SelfUserGuard`가 전체 `User`로 선언해 가드가 안 넣는 필드(`passwordHash` 등) 참조가 컴파일 통과하던 문제 제거

## 🚨 주요 고민 및 해결 과정

### 문제
- access 토큰으로도 재발급이 가능해 refresh 토큰의 의미가 약화됨
- guard 검증과 로그인 인증이 같은 조회를 공유해 불필요한 컬럼(`passwordHash` 등)이 가드 경로까지 노출
- 가드가 주입하지 않는 필드를 타입이 막지 못함

### 해결 과정
- 재발급 엔드포인트를 `RefreshTokenGuard`로 묶어 토큰 검증 책임을 가드로 일원화
- 조회를 용도별로 분리하고 `select`로 컬럼 최소화 + 소프트딜리트/상태 조건 적용
- `req.user` 타입을 가드 출력 타입(`AuthUser`)으로 좁힘

## 💬 리뷰 요구사항
- 재발급 엔드포인트를 `RefreshTokenGuard`로 통일한 것이 기존 클라이언트 계약과 어긋나지 않는지
- guard 조회를 `email` → `id` 기반으로 바꾼 것이 다른 인증 흐름에 영향이 없는지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 액세스/리프레시 토큰 발급·갱신 엔드포인트의 인증 흐름을 개선하여 안정성 향상

* **Security**
  * 인증 정보로 전달되는 사용자 데이터 최소화
  * 비밀번호 인증 및 토큰 검증 로직 강화로 보안성 개선

* **Chores**
  * 인증 관련 타입 및 조회 흐름 정비로 일관성 개선 (내부 변경)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->