### PR TITLE
Band-BandSpace 관계 필드명을 bandSpaces로 통일

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -129,7 +129,7 @@ model Band {
   inviteLinks      BandInviteLink[]
   joinRequests     BandJoinRequest[]
   members          BandMember[]
-  spaces           BandSpace[]
+  bandSpaces       BandSpace[]
   bandMasterUser   User              @relation("BandManager", fields: [bandMasterUserId], references: [id])
   places           Place[]
   songs            Song[]


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 5분

## 📌 작업 요약

`Band`의 `BandSpace` 관계 필드명을 `spaces` → `bandSpaces`로 변경해 도메인 네이밍을 통일하고, 이로 인해 깨져 있던 일정 모듈 빌드를 복구합니다.

## 📝 작업 내용

1. `prisma/schema.prisma`의 `Band.spaces` 관계 필드를 `bandSpaces`로 리네임
2. `schedules.prisma-repository.ts`가 이미 `band: { bandSpaces: ... }`로 참조하고 있어, 스키마 변경으로 빌드가 통과됨

## 🚨 주요 고민 및 해결 과정

### 문제
- 모델 `BandSpace`, 테이블 `band_spaces`, 모듈 `bandspaces`, 파라미터 `bandspaceId` 등 도메인 전반이 `bandSpace` 네이밍인데 관계 필드만 `spaces`로 어긋나 있었음
- 일정 기능 PR(#107, `createSchedule`)에서 관계를 `bandSpaces`로 참조했으나 스키마는 `spaces`라 `tsc` 빌드가 깨진 상태였음 (테스트가 손수 만든 Stub을 써서 Prisma 타입 에러가 드러나지 않아 머지됨)

### 해결 과정
- 관계 필드명을 도메인 네이밍에 맞춰 `bandSpaces`로 통일
- 가상 back-relation 필드명 변경이라 **DB 마이그레이션 없음** (FK는 `BandSpace.band` 쪽, named relation 아님). `prisma generate` 후 빌드 통과 확인

## 💬 리뷰 요구사항
- 관계 필드 리네임이라 DB 영향이 없다는 점 확인 부탁드립니다 (`prisma migrate` 무발생)
- 이 PR이 먼저 머지되면 dev 빌드가 복구되고, 이후 auth PR도 green이 됩니다
