### PR TITLE
[KAN-61] 환경변수 기반 설정 모듈 도입 (ConfigModule)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,3 +6,6 @@ POSTGRES_PORT=5432
 DATABASE_URL="postgresql://postgres:postgres@db:5432/jamplay?schema=public"
 SPOTIFY_CLIENT_ID=
 SPOTIFY_CLIENT_SECRET=
+JWT_SECRET=
+BCRYPT_SALT_ROUNDS=10
+ 

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@nestjs/common": "^11.1.13",
+    "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^11.1.13",
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/mapped-types": "*",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@nestjs/common':
         specifier: ^11.1.13
         version: 11.1.13(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/config':
+        specifier: ^4.0.4
+        version: 4.0.4(@nestjs/common@11.1.13(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^11.1.13
         version: 11.1.13(@nestjs/common@11.1.13(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.13)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -841,6 +844,12 @@ packages:
         optional: true
       class-validator:
         optional: true
+
+  '@nestjs/config@4.0.4':
+    resolution: {integrity: sha512-CJPjNitr0bAufSEnRe2N+JbnVmMmDoo6hvKCPzXgZoGwJSmp/dZPk9f/RMbuD/+Q1ZJPjwsRpq0vxna++Knwow==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      rxjs: ^7.1.0
 
   '@nestjs/core@11.1.13':
     resolution: {integrity: sha512-Tq9EIKiC30EBL8hLK93tNqaToy0hzbuVGYt29V8NhkVJUsDzlmiVf6c3hSPtzx2krIUVbTgQ2KFeaxr72rEyzQ==}
@@ -1803,8 +1812,16 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dotenv-expand@12.0.3:
+    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
+    engines: {node: '>=12'}
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.1:
+    resolution: {integrity: sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -4660,6 +4677,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nestjs/config@4.0.4(@nestjs/common@11.1.13(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 11.1.13(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      dotenv: 17.4.1
+      dotenv-expand: 12.0.3
+      lodash: 4.18.1
+      rxjs: 7.8.2
+
   '@nestjs/core@11.1.13(@nestjs/common@11.1.13(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.13)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.13(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -5693,7 +5718,13 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dotenv-expand@12.0.3:
+    dependencies:
+      dotenv: 16.6.1
+
   dotenv@16.6.1: {}
+
+  dotenv@17.4.1: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 
 import { AuthModule } from './auth/auth.module';
 import { PrismaModule } from './database/prisma';
@@ -13,6 +14,7 @@ import { UsersModule } from './modules/users/users.module';
 
 @Module({
   imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
     PrismaModule,
     BandSpacesModule,
     AuthModule,

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -29,21 +29,43 @@ const mockConfigService = {
   }),
 };
 
+const buildModule = (configOverride?: Partial<typeof mockConfigService>) =>
+  Test.createTestingModule({
+    providers: [
+      AuthService,
+      { provide: JwtService, useValue: mockJwtService },
+      { provide: UsersService, useValue: mockUsersService },
+      { provide: ConfigService, useValue: { ...mockConfigService, ...configOverride } },
+    ],
+  }).compile();
+
 describe('AuthService', () => {
   let service: AuthService;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        AuthService,
-        { provide: JwtService, useValue: mockJwtService },
-        { provide: UsersService, useValue: mockUsersService },
-        { provide: ConfigService, useValue: mockConfigService },
-      ],
-    }).compile();
-
+    const module: TestingModule = await buildModule();
     service = module.get<AuthService>(AuthService);
     jest.clearAllMocks();
+  });
+
+  describe('생성자 설정 검증', () => {
+    it('JWT_SECRET이 빈 문자열이면 초기화 시 에러를 던진다', async () => {
+      await expect(
+        buildModule({ getOrThrow: jest.fn((key: string) => (key === 'JWT_SECRET' ? '' : String(TEST_BCRYPT_SALT_ROUNDS))) }),
+      ).rejects.toThrow('JWT_SECRET must not be empty');
+    });
+
+    it('BCRYPT_SALT_ROUNDS가 숫자가 아니면 초기화 시 에러를 던진다', async () => {
+      await expect(
+        buildModule({ getOrThrow: jest.fn((key: string) => (key === 'JWT_SECRET' ? TEST_JWT_SECRET : 'abc')) }),
+      ).rejects.toThrow('BCRYPT_SALT_ROUNDS must be a number between 4 and 15');
+    });
+
+    it('BCRYPT_SALT_ROUNDS가 허용 범위(4~15)를 벗어나면 초기화 시 에러를 던진다', async () => {
+      await expect(
+        buildModule({ getOrThrow: jest.fn((key: string) => (key === 'JWT_SECRET' ? TEST_JWT_SECRET : '3')) }),
+      ).rejects.toThrow('BCRYPT_SALT_ROUNDS must be a number between 4 and 15');
+    });
   });
 
   describe('extractTokenFromHeader', () => {

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,10 +1,14 @@
 import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { Test, type TestingModule } from '@nestjs/testing';
 import * as bcrypt from 'bcrypt';
 import { UsersService } from 'src/modules/users/users.service';
 
 import { AuthService } from './auth.service';
+
+const TEST_JWT_SECRET = 'test-secret';
+const TEST_BCRYPT_SALT_ROUNDS = 10;
 
 const mockJwtService = {
   sign: jest.fn(),
@@ -17,12 +21,25 @@ const mockUsersService = {
   createUserWithEmail: jest.fn(),
 };
 
+const mockConfigService = {
+  getOrThrow: jest.fn((key: string) => {
+    if (key === 'JWT_SECRET') return TEST_JWT_SECRET;
+    if (key === 'BCRYPT_SALT_ROUNDS') return String(TEST_BCRYPT_SALT_ROUNDS);
+    throw new Error(`Unknown config key: ${key}`);
+  }),
+};
+
 describe('AuthService', () => {
   let service: AuthService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService, { provide: JwtService, useValue: mockJwtService }, { provide: UsersService, useValue: mockUsersService }],
+      providers: [
+        AuthService,
+        { provide: JwtService, useValue: mockJwtService },
+        { provide: UsersService, useValue: mockUsersService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);
@@ -63,14 +80,17 @@ describe('AuthService', () => {
     it('access 타입으로 서명 시 5m 만료로 호출된다', () => {
       mockJwtService.sign.mockReturnValue('signed-access');
       const result = service.signToken('u@u.com', 'uid', false);
-      expect(mockJwtService.sign).toHaveBeenCalledWith({ email: 'u@u.com', id: 'uid', type: 'access' }, { secret: 'jamplay', expiresIn: '5m' });
+      expect(mockJwtService.sign).toHaveBeenCalledWith({ email: 'u@u.com', id: 'uid', type: 'access' }, { secret: TEST_JWT_SECRET, expiresIn: '5m' });
       expect(result).toBe('signed-access');
     });
 
     it('refresh 타입으로 서명 시 1h 만료로 호출된다', () => {
       mockJwtService.sign.mockReturnValue('signed-refresh');
       const result = service.signToken('u@u.com', 'uid', true);
-      expect(mockJwtService.sign).toHaveBeenCalledWith({ email: 'u@u.com', id: 'uid', type: 'refresh' }, { secret: 'jamplay', expiresIn: '1h' });
+      expect(mockJwtService.sign).toHaveBeenCalledWith(
+        { email: 'u@u.com', id: 'uid', type: 'refresh' },
+        { secret: TEST_JWT_SECRET, expiresIn: '1h' },
+      );
       expect(result).toBe('signed-refresh');
     });
   });
@@ -87,7 +107,7 @@ describe('AuthService', () => {
       const payload = { email: 'u@u.com', id: 'uid', type: 'access' };
       mockJwtService.verify.mockReturnValue(payload);
       expect(service.verifyToken('some.token')).toEqual(payload);
-      expect(mockJwtService.verify).toHaveBeenCalledWith('some.token', { secret: 'jamplay' });
+      expect(mockJwtService.verify).toHaveBeenCalledWith('some.token', { secret: TEST_JWT_SECRET });
     });
   });
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -17,7 +17,12 @@ export class AuthService {
     private readonly configService: ConfigService,
   ) {
     this.jwtSecret = this.configService.getOrThrow<string>('JWT_SECRET');
+    if (!this.jwtSecret) throw new Error('JWT_SECRET must not be empty');
+
     this.bcryptSaltRounds = parseInt(this.configService.getOrThrow<string>('BCRYPT_SALT_ROUNDS'), 10);
+    if (isNaN(this.bcryptSaltRounds) || this.bcryptSaltRounds < 4 || this.bcryptSaltRounds > 15) {
+      throw new Error('BCRYPT_SALT_ROUNDS must be a number between 4 and 15');
+    }
   }
 
   async loginWithEmail(email: string, password: string) {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import { UsersService } from 'src/modules/users/users.service';
@@ -7,10 +8,17 @@ import { JwtPayload } from './types/auth.types';
 
 @Injectable()
 export class AuthService {
+  private readonly jwtSecret: string;
+  private readonly bcryptSaltRounds: number;
+
   constructor(
     private readonly jwtService: JwtService,
     private readonly usersService: UsersService,
-  ) {}
+    private readonly configService: ConfigService,
+  ) {
+    this.jwtSecret = this.configService.getOrThrow<string>('JWT_SECRET');
+    this.bcryptSaltRounds = parseInt(this.configService.getOrThrow<string>('BCRYPT_SALT_ROUNDS'), 10);
+  }
 
   async loginWithEmail(email: string, password: string) {
     const user = await this.authenticateWithEmailAndPassword(email, password);
@@ -21,7 +29,7 @@ export class AuthService {
     const payload: JwtPayload = { email, id, type: isRefreshToken ? 'refresh' : 'access' };
 
     return this.jwtService.sign(payload, {
-      secret: 'jamplay',
+      secret: this.jwtSecret,
       expiresIn: isRefreshToken ? '1h' : '5m',
     });
   }
@@ -64,7 +72,7 @@ export class AuthService {
   }
 
   async registerWithEmail(email: string, password: string) {
-    const hash = await bcrypt.hash(password, 10);
+    const hash = await bcrypt.hash(password, this.bcryptSaltRounds);
     const newUser = await this.usersService.createUserWithEmail(email, hash);
     return this.loginUser(newUser.email!, newUser.id);
   }
@@ -82,7 +90,7 @@ export class AuthService {
 
   verifyToken(token: string) {
     return this.jwtService.verify(token, {
-      secret: 'jamplay',
+      secret: this.jwtSecret,
     });
   }
 

--- a/backend/src/modules/places/places.controller.ts
+++ b/backend/src/modules/places/places.controller.ts
@@ -123,7 +123,10 @@ export class PlacesController {
    */
   @Delete('places/:placeId')
   @UseGuards(AccessTokenGuard)
-  async deletePlace(@Req() request: AuthenticatedRequest, @Param('placeId', new ParseUUIDPipe()) placeId: string): Promise<ApiSuccessResponse<DeletePlaceResult>> {
+  async deletePlace(
+    @Req() request: AuthenticatedRequest,
+    @Param('placeId', new ParseUUIDPipe()) placeId: string,
+  ): Promise<ApiSuccessResponse<DeletePlaceResult>> {
     const result = await this.placesService.deletePlace(request.user.id, placeId);
 
     return createSuccessResponse('장소 삭제 성공', result);


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 5분

<br/>

## 📌 작업 요약

하드코딩된 JWT secret과 bcrypt salt rounds를 환경변수로 분리하고 ConfigModule을 전역 등록한다.

<br/>

## 📝 작업 내용

1. `@nestjs/config` 패키지 추가 및 `ConfigModule.forRoot({ isGlobal: true })` AppModule 등록
2. `AuthService`의 하드코딩 값(`'jamplay'`, `10`)을 `JWT_SECRET`, `BCRYPT_SALT_ROUNDS` 환경변수로 교체
3. `.env.example`에 신규 환경변수 키 추가
4. `AuthService` 테스트에 `ConfigService` mock 추가
5. `PlacesController deletePlace` 메서드 시그니처 포맷 정리

<br/>

## 🚨 주요 고민 및 해결 과정

### 문제

`AuthService`에 JWT secret이 `'jamplay'`로 하드코딩되어 있어 환경별 분리가 불가능하고 보안 취약점이 존재했다.

### 해결 과정

`ConfigService.getOrThrow()`를 생성자에서 호출하여 환경변수 누락 시 앱 시작 시점에 즉시 실패하도록 구현했다. 런타임 중간에 발생하는 오류보다 Fast-fail 방식이 디버깅에 유리하다.

<br/>

## 📑 참고 문서/ ADR

<br/>

## 💬 리뷰 요구사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 환경 설정 관리 시스템이 개선되었습니다.

* **Tests**
  * 인증 서비스 테스트가 업데이트되었습니다.

* **Style**
  * 코드 포맷팅이 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->