### PR TITLE
[KAN-74] 초대 알림 targetPath에 invitationId 추가

### DIFF
--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -173,7 +173,7 @@ export class BandsService {
           userId: input.inviteeUserId,
           title: '밴드 초대가 도착했습니다.',
           description: '새 밴드 초대가 도착했습니다.',
-          targetPath: '/invitations/received',
+          targetPath: `/invitations/received?invitationId=${result.invitationId}`,
         },
         client,
       );


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 5분

<br/>

## 📌 작업 요약

초대 알림 `targetPath`에 `invitationId`를 담아 어떤 초대인지 FE에서 알 수 있게 했습니다.

<br/>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요 (이미지 첨부 가능)

1. `createBandInvitation` 알림의 `targetPath`를 `/invitations/received`에서 `/invitations/received?invitationId={id}`로 바꿨습니다.

<br/>

## 🚨 주요 고민 및 해결 과정

> 주요 고민이나 문제 해결 과정 공유

### 문제

알림만 봐서는 어떤 초대인지 알 수 없어, 수락·거절을 누르거나 해당 밴드 멤버를 불러올 방법이 없었습니다. `Notification`에는 초대를 가리키는 컬럼도 FK도 없어서, 받아온 알림으로 초대를 join해서 찾는 것도 불가능합니다.

### 해결 과정

- **A. targetPath에 담기 (선택)**: 다른 알림(`/bandspaces/${spaceId}` 등)도 이미 이렇게 ID를 담고 있어서 같은 방식으로 맞췄습니다. 스키마는 건드리지 않습니다.
- **B. 응답 본문에 별도 필드로 담기**: 경로와 식별값을 나눌 수 있고 타입도 안전하지만 컬럼 추가와 마이그레이션이 필요합니다. 지금은 초대 알림 한 곳에만 필요해서 과하다고 판단했습니다. 알림 종류가 늘어난다면 이렇게 해도 좋아보여요.

`bandId`는 초대 목록의 `band.bandId`로 알 수 있어서 따로 담지 않고 `invitationId`만 넘깁니다.

<br/>

## 📑 참고 문서/ ADR

> 참고한 외부 문서, 레퍼런스, 기술 블로그, 공식 문서 등의 링크

<br/>

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요