### PR TITLE
fix(users): 유저 API 검토 — 유효성 강화, 응답 형식 통일, 페이지네이션 개선, 회원탈퇴 구현

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -20,10 +20,10 @@ export class AuthController {
   @ApiOperation({ summary: '액세스 토큰 재발급' })
   @ApiResponse({ status: 201, description: '액세스 토큰 재발급 성공' })
   @ApiResponse({ status: 401, description: '인증 실패' })
-  TokenAccess(@Req() req: { user: { id: string; email: string } }) {
+  TokenAccess(@Req() req: { user: { id: string; email: string } }): ApiSuccessResponse<{ accessToken: string }> {
     const { email, id } = req.user;
     const accessToken = this.authService.signToken(email, id, false);
-    return { accessToken };
+    return createSuccessResponse('액세스 토큰 재발급 성공', { accessToken });
   }
 
   @Post('token/refresh')
@@ -32,10 +32,10 @@ export class AuthController {
   @ApiOperation({ summary: '리프레시 토큰 재발급' })
   @ApiResponse({ status: 201, description: '리프레시 토큰 재발급 성공' })
   @ApiResponse({ status: 401, description: '인증 실패' })
-  TokenRefresh(@Req() req: { user: { id: string; email: string } }) {
+  TokenRefresh(@Req() req: { user: { id: string; email: string } }): ApiSuccessResponse<{ refreshToken: string }> {
     const { email, id } = req.user;
     const refreshToken = this.authService.signToken(email, id, true);
-    return { refreshToken };
+    return createSuccessResponse('리프레시 토큰 재발급 성공', { refreshToken });
   }
 
   @Post('login/email')
@@ -43,19 +43,21 @@ export class AuthController {
   @ApiBasicAuth()
   @ApiOperation({ summary: '이메일 로그인' })
   @ApiResponse({ status: 201, description: '로그인 성공' })
-  @ApiResponse({ status: 401, description: '인증 실패' })
-  async loginEmail(@Req() req: { user: { id: string; email: string } }) {
+  @ApiResponse({ status: 401, description: 'Authorization 헤더 없음 | 잘못된 Basic 토큰 형식 | 존재하지 않는 유저 | 비밀번호 불일치' })
+  loginEmail(@Req() req: { user: { id: string; email: string } }): ApiSuccessResponse<{ accessToken: string; refreshToken: string }> {
     // BasicTokenGuard가 인증을 마치고 req.user에 담은 유저로 토큰을 발급한다.
     const { email, id } = req.user;
-    return this.authService.loginUser(email, id);
+    const tokens = this.authService.loginUser(email, id);
+    return createSuccessResponse('로그인 성공', tokens);
   }
 
   @Post('register/email')
   @ApiOperation({ summary: '이메일 회원가입' })
   @ApiResponse({ status: 201, description: '회원가입 성공' })
-  @ApiResponse({ status: 400, description: '잘못된 요청' })
-  async registerEmail(@Body() { email, password }: RegisterEmailDto) {
-    return this.authService.registerWithEmail(email, password);
+  @ApiResponse({ status: 400, description: '유효성 검사 실패 (이메일 형식 불일치, 비밀번호 패턴 불일치) | 이미 존재하는 이메일' })
+  async registerEmail(@Body() { email, password }: RegisterEmailDto): Promise<ApiSuccessResponse<{ accessToken: string; refreshToken: string }>> {
+    const tokens = await this.authService.registerWithEmail(email, password);
+    return createSuccessResponse('회원가입 성공', tokens);
   }
 
   @Post('email')

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -9,6 +9,6 @@ import { AuthService } from './auth.service';
   imports: [JwtModule.register({}), forwardRef(() => UsersModule)],
   controllers: [AuthController],
   providers: [AuthService],
-  exports: [AuthService],
+  exports: [AuthService, UsersModule],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -56,15 +56,15 @@ describe('AuthService', () => {
     });
 
     it('BCRYPT_SALT_ROUNDS가 숫자가 아니면 초기화 시 에러를 던진다', async () => {
-      await expect(
-        buildModule({ getOrThrow: jest.fn((key: string) => (key === 'JWT_SECRET' ? TEST_JWT_SECRET : 'abc')) }),
-      ).rejects.toThrow('BCRYPT_SALT_ROUNDS must be a number between 4 and 15');
+      await expect(buildModule({ getOrThrow: jest.fn((key: string) => (key === 'JWT_SECRET' ? TEST_JWT_SECRET : 'abc')) })).rejects.toThrow(
+        'BCRYPT_SALT_ROUNDS must be a number between 4 and 15',
+      );
     });
 
     it('BCRYPT_SALT_ROUNDS가 허용 범위(4~15)를 벗어나면 초기화 시 에러를 던진다', async () => {
-      await expect(
-        buildModule({ getOrThrow: jest.fn((key: string) => (key === 'JWT_SECRET' ? TEST_JWT_SECRET : '3')) }),
-      ).rejects.toThrow('BCRYPT_SALT_ROUNDS must be a number between 4 and 15');
+      await expect(buildModule({ getOrThrow: jest.fn((key: string) => (key === 'JWT_SECRET' ? TEST_JWT_SECRET : '3')) })).rejects.toThrow(
+        'BCRYPT_SALT_ROUNDS must be a number between 4 and 15',
+      );
     });
   });
 

--- a/backend/src/auth/dto/check-email.dto.ts
+++ b/backend/src/auth/dto/check-email.dto.ts
@@ -1,8 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail } from 'class-validator';
+import { emailValidationMessage } from 'src/common/validation-message/email-validation.message';
 
 export class CheckEmailDto {
   @ApiProperty({ description: '이메일 주소', example: 'user@example.com' })
-  @IsEmail()
+  @IsEmail({}, { message: emailValidationMessage })
   email!: string;
 }

--- a/backend/src/auth/dto/register-email.dto.ts
+++ b/backend/src/auth/dto/register-email.dto.ts
@@ -9,12 +9,14 @@ export class RegisterEmailDto {
   @IsEmail({}, { message: emailValidationMessage })
   email: string;
 
-  @ApiProperty({ description: '비밀번호 (최소 8자, 알파벳·숫자·특수문자(!@#$%^&*()) 조합, 특수문자 1개 이상)', example: 'Password123!' })
+  @ApiProperty({ description: '비밀번호 (최소 8자, 알파벳·숫자·특수문자(!@#$%^&*()) 각 1개 이상 포함)', example: 'Password123!' })
   @IsString({ message: stringValidationMessage })
   @MinLength(8, { message: lengthValidationMessage })
   @Matches(/^[a-zA-Z0-9!@#$%^&*()]+$/, {
     message: '비밀번호는 알파벳, 숫자, !@#$%^&*() 만 사용 가능합니다.',
   })
+  @Matches(/[a-zA-Z]/, { message: '비밀번호는 알파벳을 1개 이상 포함해야 합니다.' })
+  @Matches(/[0-9]/, { message: '비밀번호는 숫자를 1개 이상 포함해야 합니다.' })
   @Matches(/[!@#$%^&*()]/, {
     message: '비밀번호는 특수문자(!@#$%^&*())를 1개 이상 포함해야 합니다.',
   })

--- a/backend/src/auth/dto/register-email.dto.ts
+++ b/backend/src/auth/dto/register-email.dto.ts
@@ -1,15 +1,22 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString, Matches } from 'class-validator';
+import { IsEmail, IsString, Matches, MinLength } from 'class-validator';
+import { emailValidationMessage } from 'src/common/validation-message/email-validation.message';
+import { lengthValidationMessage } from 'src/common/validation-message/length-validation.message';
+import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
 
 export class RegisterEmailDto {
   @ApiProperty({ description: '이메일 주소', example: 'user@example.com' })
-  @IsEmail()
+  @IsEmail({}, { message: emailValidationMessage })
   email: string;
 
-  @ApiProperty({ description: '비밀번호 (알파벳, 숫자, !@#$%^&*() 조합)', example: 'Password123!' })
-  @IsString()
+  @ApiProperty({ description: '비밀번호 (최소 8자, 알파벳·숫자·특수문자(!@#$%^&*()) 조합, 특수문자 1개 이상)', example: 'Password123!' })
+  @IsString({ message: stringValidationMessage })
+  @MinLength(8, { message: lengthValidationMessage })
   @Matches(/^[a-zA-Z0-9!@#$%^&*()]+$/, {
     message: '비밀번호는 알파벳, 숫자, !@#$%^&*() 만 사용 가능합니다.',
+  })
+  @Matches(/[!@#$%^&*()]/, {
+    message: '비밀번호는 특수문자(!@#$%^&*())를 1개 이상 포함해야 합니다.',
   })
   password: string;
 }

--- a/backend/src/common/query/query-param.util.ts
+++ b/backend/src/common/query/query-param.util.ts
@@ -1,5 +1,79 @@
 import { BadRequestException } from '@nestjs/common';
 
+type OrderDirection = 'asc' | 'desc';
+
+export interface ParsedPrismaQuery<TWhere extends object = Record<string, unknown>> {
+  where: TWhere & Record<string, unknown>;
+  orderBy: Record<string, OrderDirection>[];
+  take?: number;
+}
+
+function toCamelCase(str: string): string {
+  return str.replace(/_([a-z])/g, (_, letter: string) => letter.toUpperCase());
+}
+
+function buildWhereValue(operator: string, value: unknown): unknown {
+  switch (operator) {
+    case 'contain':
+      return { contains: value, mode: 'insensitive' };
+    case 'equal':
+      return value;
+    case 'greater_than_equal':
+      return { gte: value };
+    case 'less_than_equal':
+      return { lte: value };
+    case 'greater_than':
+      return { gt: value };
+    case 'less_than':
+      return { lt: value };
+    default:
+      return value;
+  }
+}
+
+/**
+ * '__' 구분자 기반 쿼리 DTO를 Prisma findMany 공통 인자로 변환한다.
+ *
+ * 지원 패턴:
+ *   where__<field>__<operator>  → where 필터 (연산자 적용)
+ *   where__<field>              → where 필터 (직접 동등 비교)
+ *   order__<field>              → orderBy 배열
+ *   take                        → 조회 개수 제한
+ *
+ * 지원 연산자: contain | equal | greater_than_equal | less_than_equal | greater_than | less_than
+ * 필드명은 snake_case → camelCase 자동 변환된다.
+ * cursor 처리는 모델별 고유키에 의존하므로 Repository에서 직접 처리한다.
+ *
+ * @param dto 쿼리 DTO 객체
+ * @returns Prisma findMany에 바로 spread할 수 있는 공통 인자
+ */
+export function parseToPrismaQuery<TWhere extends object = Record<string, unknown>>(dto: object): ParsedPrismaQuery<TWhere> {
+  const where: Record<string, unknown> = {};
+  const orderBy: Record<string, OrderDirection>[] = [];
+  let take: number | undefined;
+
+  for (const [key, value] of Object.entries(dto)) {
+    if (value === undefined || value === null) continue;
+
+    const parts = key.split('__');
+    const prefix = parts[0];
+
+    if (prefix === 'where') {
+      if (parts.length === 2) {
+        where[toCamelCase(parts[1])] = value;
+      } else if (parts.length === 3) {
+        where[toCamelCase(parts[1])] = buildWhereValue(parts[2], value);
+      }
+    } else if (prefix === 'order' && parts.length === 2) {
+      orderBy.push({ [toCamelCase(parts[1])]: value as OrderDirection });
+    } else if (key === 'take') {
+      take = value as number;
+    }
+  }
+
+  return { where: where as unknown as TWhere & Record<string, unknown>, orderBy, ...(take !== undefined ? { take } : {}) };
+}
+
 /**
  * 빈 문자열을 의미 없는 입력으로 보고 undefined 로 정리한다.
  *

--- a/backend/src/common/query/query-param.util.ts
+++ b/backend/src/common/query/query-param.util.ts
@@ -27,7 +27,7 @@ function buildWhereValue(operator: string, value: unknown): unknown {
     case 'less_than':
       return { lt: value };
     default:
-      return value;
+      throw new BadRequestException(`지원하지 않는 연산자입니다: ${operator}`);
   }
 }
 

--- a/backend/src/common/validation-message/email-validation.message.ts
+++ b/backend/src/common/validation-message/email-validation.message.ts
@@ -1,0 +1,3 @@
+import type { ValidationArguments } from 'class-validator';
+
+export const emailValidationMessage = (args: ValidationArguments) => `${args.property}은(는) 올바른 이메일 형식이어야 합니다.`;

--- a/backend/src/modules/users/dto/update-user-profile.dto.ts
+++ b/backend/src/modules/users/dto/update-user-profile.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsArray, IsBoolean, IsEmail, IsEnum, IsOptional, IsString, IsUUID, ValidateNested } from 'class-validator';
+import { emailValidationMessage } from 'src/common/validation-message/email-validation.message';
 import { enumValidationMessage } from 'src/common/validation-message/enum-validation.message';
 import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
 import { uuidValidationMessage } from 'src/common/validation-message/uuid-validation.message';
@@ -31,7 +32,7 @@ class UpdateProfileDto {
 class UpdatePersonalInfoDto {
   @ApiPropertyOptional({ description: '이메일 주소', example: 'user@example.com' })
   @IsOptional()
-  @IsEmail()
+  @IsEmail({}, { message: emailValidationMessage })
   email?: string;
 }
 

--- a/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
+++ b/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
@@ -207,12 +207,36 @@ describe('UsersPrismaRepository', () => {
       expect(result.meta.next).toBeNull();
     });
 
-    it('결과가 take와 같으면 next에 마지막 항목의 커서가 설정된다', async () => {
+    it('결과가 take와 같으면 next에 다음 페이지 URL이 설정된다', async () => {
       const second = { ...listRecord, id: 'user-002', createdAt: new Date('2025-12-01T00:00:00.000Z') };
       mockPrisma.user.findMany.mockResolvedValue([listRecord, second]);
       const result = await repository.findUsers({ ...defaultQuery, take: 2 });
-      expect(result.meta.next?.id).toBe('user-002');
-      expect(result.meta.next?.createdAt).toBe('2025-12-01T00:00:00.000Z');
+      expect(typeof result.meta.next).toBe('string');
+      expect(result.meta.next).toContain('cursor__id=user-002');
+      expect(result.meta.next).toContain('cursor__created_at=');
+    });
+  });
+
+  describe('softDeleteUser', () => {
+    it('deletedAt과 status를 업데이트하고 결과를 반환한다', async () => {
+      const now = new Date();
+      mockPrisma.user.update.mockResolvedValue({ id: 'user-001', deletedAt: now });
+      const result = await repository.softDeleteUser('user-001');
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-001', deletedAt: null },
+        data: { deletedAt: expect.any(Date), status: 'INACTIVE' },
+        select: { id: true, deletedAt: true },
+      });
+      expect(result.userId).toBe('user-001');
+      expect(result.deletedAt).toBe(now.toISOString());
+    });
+
+    it('tx가 전달되면 tx 클라이언트를 사용한다', async () => {
+      const now = new Date();
+      const txClient = { user: { update: jest.fn().mockResolvedValue({ id: 'user-001', deletedAt: now }) } };
+      await repository.softDeleteUser('user-001', txClient as unknown as Prisma.TransactionClient);
+      expect(txClient.user.update).toHaveBeenCalled();
+      expect(mockPrisma.user.update).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
+++ b/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
@@ -177,20 +177,23 @@ describe('UsersPrismaRepository', () => {
       expect(callArgs.where.profile).toEqual({ nickname: { contains: 'nick', mode: 'insensitive' } });
     });
 
-    it('cursor__id가 있으면 cursor와 skip:1이 전달된다', async () => {
+    it('cursor__id와 cursor__created_at이 있으면 keyset WHERE 조건이 추가된다', async () => {
       mockPrisma.user.findMany.mockResolvedValue([]);
       await repository.findUsers({ ...defaultQuery, cursor__id: 'cursor-uuid', cursor__created_at: '2026-01-01T00:00:00.000Z' });
       const callArgs = mockPrisma.user.findMany.mock.calls[0]?.[0];
-      expect(callArgs.cursor).toEqual({ id: 'cursor-uuid' });
-      expect(callArgs.skip).toBe(1);
+      expect(callArgs.cursor).toBeUndefined();
+      expect(callArgs.skip).toBeUndefined();
+      expect(callArgs.where.AND).toBeDefined();
+      expect(callArgs.where.AND[0].OR).toHaveLength(2);
     });
 
-    it('cursor__id가 없으면 cursor와 skip이 전달되지 않는다', async () => {
+    it('cursor가 없으면 AND 조건이 추가되지 않는다', async () => {
       mockPrisma.user.findMany.mockResolvedValue([]);
       await repository.findUsers(defaultQuery);
       const callArgs = mockPrisma.user.findMany.mock.calls[0]?.[0];
       expect(callArgs.cursor).toBeUndefined();
       expect(callArgs.skip).toBeUndefined();
+      expect(callArgs.where.AND).toBeUndefined();
     });
 
     it('결과가 없으면 cursor와 next가 모두 null이다', async () => {

--- a/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
+++ b/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
@@ -1,6 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { PrismaService } from 'src/database/prisma/prisma.service';
-import type { Prisma } from 'src/generated/prisma';
+import { Prisma } from 'src/generated/prisma';
 
 import type { GetUsersQuery } from '../dto/get-users-query.dto';
 
@@ -230,8 +230,8 @@ describe('UsersPrismaRepository', () => {
         data: { deletedAt: expect.any(Date), status: 'INACTIVE' },
         select: { id: true, deletedAt: true },
       });
-      expect(result.userId).toBe('user-001');
-      expect(result.deletedAt).toBe(now.toISOString());
+      expect(result?.userId).toBe('user-001');
+      expect(result?.deletedAt).toBe(now.toISOString());
     });
 
     it('tx가 전달되면 tx 클라이언트를 사용한다', async () => {
@@ -240,6 +240,18 @@ describe('UsersPrismaRepository', () => {
       await repository.softDeleteUser('user-001', txClient as unknown as Prisma.TransactionClient);
       expect(txClient.user.update).toHaveBeenCalled();
       expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    });
+
+    it('존재하지 않거나 이미 삭제된 유저면 null을 반환한다 (P2025)', async () => {
+      const p2025 = new Prisma.PrismaClientKnownRequestError('Record not found', { code: 'P2025', clientVersion: '0' });
+      mockPrisma.user.update.mockRejectedValue(p2025);
+      const result = await repository.softDeleteUser('unknown-id');
+      expect(result).toBeNull();
+    });
+
+    it('P2025 외 에러는 그대로 전파한다', async () => {
+      mockPrisma.user.update.mockRejectedValue(new Error('db connection error'));
+      await expect(repository.softDeleteUser('user-001')).rejects.toThrow('db connection error');
     });
   });
 

--- a/backend/src/modules/users/repositoreis/user.prisma-repository.ts
+++ b/backend/src/modules/users/repositoreis/user.prisma-repository.ts
@@ -108,6 +108,16 @@ export class UsersPrismaRepository implements UsersRepository {
       delete where.nickname;
     }
 
+    // cursor__created_at + cursor__id 두 필드를 복합 keyset 조건으로 변환한다.
+    // Prisma cursor + skip 방식은 cursor 레코드 위치를 내부적으로 조회하므로
+    // soft-delete된 레코드가 커서가 될 경우 WHERE 필터와 충돌할 수 있다.
+    if (query.cursor__created_at && query.cursor__id) {
+      const cursorDate = new Date(query.cursor__created_at);
+      const dateOp = query.order__created_at === 'asc' ? 'gt' : 'lt';
+      const idOp = query.order__id === 'asc' ? 'gt' : 'lt';
+      where.AND = [{ OR: [{ createdAt: { [dateOp]: cursorDate } }, { createdAt: { equals: cursorDate }, id: { [idOp]: query.cursor__id } }] }];
+    }
+
     const users = await client.user.findMany({
       where,
       include: {
@@ -117,7 +127,6 @@ export class UsersPrismaRepository implements UsersRepository {
       },
       orderBy,
       take: take ?? query.take,
-      ...(query.cursor__id ? { cursor: { id: query.cursor__id }, skip: 1 } : {}),
     });
 
     const items = users.map(mapUserListItem);

--- a/backend/src/modules/users/repositoreis/user.prisma-repository.ts
+++ b/backend/src/modules/users/repositoreis/user.prisma-repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { parseToPrismaQuery } from 'src/common/query';
 import { buildNextPath } from 'src/common/url';
 import { PrismaService } from 'src/database/prisma/prisma.service';
-import type { Prisma, User } from 'src/generated/prisma';
+import { Prisma, type User } from 'src/generated/prisma';
 
 import type { GetUsersQuery } from '../dto/get-users-query.dto';
 import type { UpdateUserProfileData } from '../dto/update-user-profile.dto';
@@ -238,17 +238,20 @@ export class UsersPrismaRepository implements UsersRepository {
     return result;
   }
 
-  async softDeleteUser(userId: string, tx?: Prisma.TransactionClient): Promise<DeleteUserResult> {
+  async softDeleteUser(userId: string, tx?: Prisma.TransactionClient): Promise<DeleteUserResult | null> {
     const client = tx ?? this.prisma;
-    const user = await client.user.update({
-      where: { id: userId, deletedAt: null },
-      data: { deletedAt: new Date(), status: 'INACTIVE' },
-      select: { id: true, deletedAt: true },
-    });
-
-    return {
-      userId: user.id,
-      deletedAt: user.deletedAt!.toISOString(),
-    };
+    try {
+      const user = await client.user.update({
+        where: { id: userId, deletedAt: null },
+        data: { deletedAt: new Date(), status: 'INACTIVE' },
+        select: { id: true, deletedAt: true },
+      });
+      return { userId: user.id, deletedAt: user.deletedAt!.toISOString() };
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
+        return null;
+      }
+      throw e;
+    }
   }
 }

--- a/backend/src/modules/users/repositoreis/user.prisma-repository.ts
+++ b/backend/src/modules/users/repositoreis/user.prisma-repository.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@nestjs/common';
+import { parseToPrismaQuery } from 'src/common/query';
+import { buildNextPath } from 'src/common/url';
 import { PrismaService } from 'src/database/prisma/prisma.service';
 import type { Prisma, User } from 'src/generated/prisma';
 
@@ -8,7 +10,7 @@ import type { GetUsersResult, UserListItem } from '../types/user-list.type';
 import type { GetUserProfileResult } from '../types/user-profile.type';
 import { generateRandomNickname } from '../util/nickname_maker';
 
-import type { AuthUser, PasswordAuthUser, UsersRepository } from './user.repository';
+import type { AuthUser, DeleteUserResult, PasswordAuthUser, UsersRepository } from './user.repository';
 
 type UserListRecord = Prisma.UserGetPayload<{
   include: {
@@ -95,15 +97,15 @@ export class UsersPrismaRepository implements UsersRepository {
 
   async findUsers(query: GetUsersQuery, tx?: Prisma.TransactionClient): Promise<GetUsersResult> {
     const client = tx ?? this.prisma;
+    const { where, orderBy, take } = parseToPrismaQuery<Prisma.UserWhereInput>(query);
 
-    const where: Prisma.UserWhereInput = { deletedAt: null };
+    // 삭제되지 않은 유저만 조회
+    where.deletedAt = null;
 
-    if (query.where__email__contain) {
-      where.email = { contains: query.where__email__contain, mode: 'insensitive' };
-    }
-
-    if (query.where__nickname__contain) {
-      where.profile = { nickname: { contains: query.where__nickname__contain, mode: 'insensitive' } };
+    // nickname은 profile 관계 필드이므로 파서 결과를 보정한다
+    if (where.nickname) {
+      where.profile = { nickname: where.nickname };
+      delete where.nickname;
     }
 
     const users = await client.user.findMany({
@@ -113,17 +115,30 @@ export class UsersPrismaRepository implements UsersRepository {
           select: { nickname: true, avatarUrl: true },
         },
       },
-      orderBy: [{ createdAt: query.order__created_at }, { id: query.order__id }],
+      orderBy,
+      take: take ?? query.take,
       ...(query.cursor__id ? { cursor: { id: query.cursor__id }, skip: 1 } : {}),
-      take: query.take,
     });
 
     const items = users.map(mapUserListItem);
     const count = items.length;
-    const cursor = count > 0 ? { createdAt: items[0].createdAt, id: items[0].id } : null;
-    const next = count === query.take ? { createdAt: items[count - 1].createdAt, id: items[count - 1].id } : null;
+    const cursorMeta = count > 0 ? { createdAt: items[0].createdAt, id: items[0].id } : null;
+    const resolvedTake = take ?? query.take;
+    const lastItem = items[count - 1];
+    const next =
+      count === resolvedTake && lastItem
+        ? buildNextPath('/users', {
+            cursor__created_at: lastItem.createdAt,
+            cursor__id: lastItem.id,
+            take: resolvedTake,
+            order__created_at: query.order__created_at,
+            order__id: query.order__id,
+            where__nickname__contain: query.where__nickname__contain,
+            where__email__contain: query.where__email__contain,
+          })
+        : null;
 
-    return { items, meta: { count, take: query.take, cursor, next } };
+    return { items, meta: { count, take: resolvedTake, cursor: cursorMeta, next } };
   }
 
   async findUserProfileById(userId: string, tx?: Prisma.TransactionClient): Promise<GetUserProfileResult | null> {
@@ -212,5 +227,19 @@ export class UsersPrismaRepository implements UsersRepository {
       throw new Error('업데이트된 유저 프로필을 불러오는 데 실패했습니다.');
     }
     return result;
+  }
+
+  async softDeleteUser(userId: string, tx?: Prisma.TransactionClient): Promise<DeleteUserResult> {
+    const client = tx ?? this.prisma;
+    const user = await client.user.update({
+      where: { id: userId, deletedAt: null },
+      data: { deletedAt: new Date(), status: 'INACTIVE' },
+      select: { id: true, deletedAt: true },
+    });
+
+    return {
+      userId: user.id,
+      deletedAt: user.deletedAt!.toISOString(),
+    };
   }
 }

--- a/backend/src/modules/users/repositoreis/user.repository.ts
+++ b/backend/src/modules/users/repositoreis/user.repository.ts
@@ -29,5 +29,5 @@ export interface UsersRepository {
   findUsers(query: GetUsersQuery, tx?: Prisma.TransactionClient): Promise<GetUsersResult>;
   findUserProfileById(userId: string, tx?: Prisma.TransactionClient): Promise<GetUserProfileResult | null>;
   updateUserProfile(userId: string, data: UpdateUserProfileData, tx?: Prisma.TransactionClient): Promise<GetUserProfileResult>;
-  softDeleteUser(userId: string, tx?: Prisma.TransactionClient): Promise<DeleteUserResult>;
+  softDeleteUser(userId: string, tx?: Prisma.TransactionClient): Promise<DeleteUserResult | null>;
 }

--- a/backend/src/modules/users/repositoreis/user.repository.ts
+++ b/backend/src/modules/users/repositoreis/user.repository.ts
@@ -16,6 +16,11 @@ export type PasswordAuthUser = AuthUser & {
   passwordHash: string | null;
 };
 
+export type DeleteUserResult = {
+  userId: string;
+  deletedAt: string;
+};
+
 export interface UsersRepository {
   findByEmail(email: string, tx?: Prisma.TransactionClient): Promise<AuthUser | null>;
   findAuthUserById(id: string, tx?: Prisma.TransactionClient): Promise<AuthUser | null>;
@@ -24,4 +29,5 @@ export interface UsersRepository {
   findUsers(query: GetUsersQuery, tx?: Prisma.TransactionClient): Promise<GetUsersResult>;
   findUserProfileById(userId: string, tx?: Prisma.TransactionClient): Promise<GetUserProfileResult | null>;
   updateUserProfile(userId: string, data: UpdateUserProfileData, tx?: Prisma.TransactionClient): Promise<GetUserProfileResult>;
+  softDeleteUser(userId: string, tx?: Prisma.TransactionClient): Promise<DeleteUserResult>;
 }

--- a/backend/src/modules/users/types/user-list.type.ts
+++ b/backend/src/modules/users/types/user-list.type.ts
@@ -18,7 +18,7 @@ export interface UserListMeta {
   count: number;
   take: number;
   cursor: UserListCursor | null;
-  next: UserListCursor | null;
+  next: string | null;
 }
 
 export interface GetUsersResult {

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Patch, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, ParseUUIDPipe, Patch, Query, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
@@ -7,6 +7,7 @@ import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api
 import { GetUsersQueryDto } from './dto/get-users-query.dto';
 import { UpdateUserProfileDto } from './dto/update-user-profile.dto';
 import { SelfUserGuard } from './guard/self-user.guard';
+import type { DeleteUserResult } from './repositoreis/user.repository';
 import type { GetUsersResult } from './types/user-list.type';
 import type { GetUserProfileResult } from './types/user-profile.type';
 import { UsersService } from './users.service';
@@ -19,6 +20,7 @@ export class UsersController {
   @Get()
   @ApiOperation({ summary: '유저 목록 조회' })
   @ApiResponse({ status: 200, description: '유저 목록 조회 성공' })
+  @ApiResponse({ status: 400, description: '유효성 검사 실패 (take 범위, order 값, cursor__id UUID 형식)' })
   async getUsers(@Query() query: GetUsersQueryDto): Promise<ApiSuccessResponse<GetUsersResult>> {
     const result = await this.usersService.getUsers(query);
     return createSuccessResponse('유저 목록 조회 성공', result);
@@ -28,10 +30,26 @@ export class UsersController {
   @ApiOperation({ summary: '유저 프로필 조회' })
   @ApiParam({ name: 'userId', description: '유저 ID (UUID)', type: String })
   @ApiResponse({ status: 200, description: '유저 프로필 조회 성공' })
-  @ApiResponse({ status: 404, description: '유저를 찾을 수 없음' })
-  async getUserProfile(@Param('userId') userId: string): Promise<ApiSuccessResponse<GetUserProfileResult>> {
+  @ApiResponse({ status: 400, description: 'userId가 UUID 형식이 아님' })
+  @ApiResponse({ status: 404, description: '존재하지 않는 유저' })
+  async getUserProfile(@Param('userId', ParseUUIDPipe) userId: string): Promise<ApiSuccessResponse<GetUserProfileResult>> {
     const result = await this.usersService.getUserProfile(userId);
     return createSuccessResponse('유저 프로필 조회 성공', result);
+  }
+
+  @Delete(':userId')
+  @UseGuards(AccessTokenGuard, SelfUserGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '회원 탈퇴' })
+  @ApiParam({ name: 'userId', description: '유저 ID (UUID)', type: String })
+  @ApiResponse({ status: 200, description: '회원 탈퇴 성공' })
+  @ApiResponse({ status: 400, description: 'userId가 UUID 형식이 아님' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  @ApiResponse({ status: 403, description: '본인 계정만 탈퇴 가능' })
+  @ApiResponse({ status: 404, description: '존재하지 않는 유저' })
+  async deleteUser(@Param('userId', ParseUUIDPipe) userId: string): Promise<ApiSuccessResponse<DeleteUserResult>> {
+    const result = await this.usersService.deleteUser(userId);
+    return createSuccessResponse('회원 탈퇴가 완료되었습니다.', result);
   }
 
   @Patch(':userId/profiles')

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import type { User } from 'src/generated/prisma';
+import type { Prisma, User } from 'src/generated/prisma';
 
 import type { GetUsersQuery } from './dto/get-users-query.dto';
 import type { UsersRepository } from './repositoreis/user.repository';
@@ -150,6 +150,20 @@ describe('UsersService', () => {
 
     it('유저가 존재하지 않으면 NotFoundException을 던진다', async () => {
       await expect(service.deleteUser('unknown-id')).rejects.toThrow(NotFoundException);
+    });
+
+    it('tx가 전달되면 findAuthUserById와 softDeleteUser에 동일한 tx를 전달한다', async () => {
+      const txClient = {} as Prisma.TransactionClient;
+      const findSpy = jest.spyOn(repositoryStub, 'findAuthUserById');
+      const deleteSpy = jest.spyOn(repositoryStub, 'softDeleteUser');
+
+      await service.deleteUser('user-001', txClient);
+
+      expect(findSpy).toHaveBeenCalledWith('user-001', txClient);
+      expect(deleteSpy).toHaveBeenCalledWith('user-001', txClient);
+
+      findSpy.mockRestore();
+      deleteSpy.mockRestore();
     });
   });
 });

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -25,6 +25,8 @@ const mockListResult: GetUsersResult = {
   meta: { count: 1, take: 20, cursor: { createdAt: '2026-01-01T00:00:00.000Z', id: 'user-001' }, next: null },
 };
 
+const mockDeleteResult = { userId: 'user-001', deletedAt: '2026-06-25T00:00:00.000Z' };
+
 const repositoryStub: UsersRepository = {
   async findByEmail(email) {
     return email === 'test@example.com' ? mockUser : null;
@@ -46,6 +48,10 @@ const repositoryStub: UsersRepository = {
   },
   async updateUserProfile() {
     return mockProfile;
+  },
+  async softDeleteUser(userId) {
+    if (userId !== 'user-001') throw new Error('not found');
+    return mockDeleteResult;
   },
 };
 
@@ -132,6 +138,18 @@ describe('UsersService', () => {
     it('repository 결과를 그대로 반환한다', async () => {
       const result = await service.updateUserProfile('user-001', { profile: { nickname: '새닉네임' } });
       expect(result.user.id).toBe('user-001');
+    });
+  });
+
+  describe('deleteUser', () => {
+    it('유저가 존재하면 탈퇴 결과를 반환한다', async () => {
+      const result = await service.deleteUser('user-001');
+      expect(result.userId).toBe('user-001');
+      expect(result.deletedAt).toBeDefined();
+    });
+
+    it('유저가 존재하지 않으면 NotFoundException을 던진다', async () => {
+      await expect(service.deleteUser('unknown-id')).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -50,8 +50,7 @@ const repositoryStub: UsersRepository = {
     return mockProfile;
   },
   async softDeleteUser(userId) {
-    if (userId !== 'user-001') throw new Error('not found');
-    return mockDeleteResult;
+    return userId === 'user-001' ? mockDeleteResult : null;
   },
 };
 
@@ -152,17 +151,13 @@ describe('UsersService', () => {
       await expect(service.deleteUser('unknown-id')).rejects.toThrow(NotFoundException);
     });
 
-    it('tx가 전달되면 findAuthUserById와 softDeleteUser에 동일한 tx를 전달한다', async () => {
+    it('tx가 전달되면 softDeleteUser에 동일한 tx를 전달한다', async () => {
       const txClient = {} as Prisma.TransactionClient;
-      const findSpy = jest.spyOn(repositoryStub, 'findAuthUserById');
       const deleteSpy = jest.spyOn(repositoryStub, 'softDeleteUser');
 
       await service.deleteUser('user-001', txClient);
 
-      expect(findSpy).toHaveBeenCalledWith('user-001', txClient);
       expect(deleteSpy).toHaveBeenCalledWith('user-001', txClient);
-
-      findSpy.mockRestore();
       deleteSpy.mockRestore();
     });
   });

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -49,10 +49,10 @@ export class UsersService {
   }
 
   async deleteUser(userId: string, tx?: Prisma.TransactionClient) {
-    const user = await this.usersRepository.findAuthUserById(userId, tx);
-    if (!user) {
+    const result = await this.usersRepository.softDeleteUser(userId, tx);
+    if (!result) {
       throw new NotFoundException('존재하지 않는 유저입니다.');
     }
-    return this.usersRepository.softDeleteUser(userId, tx);
+    return result;
   }
 }

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -47,4 +47,12 @@ export class UsersService {
   async updateUserProfile(userId: string, data: UpdateUserProfileData, tx?: Prisma.TransactionClient) {
     return this.usersRepository.updateUserProfile(userId, data, tx);
   }
+
+  async deleteUser(userId: string, tx?: Prisma.TransactionClient) {
+    const user = await this.usersRepository.findAuthUserById(userId, tx);
+    if (!user) {
+      throw new NotFoundException('존재하지 않는 유저입니다.');
+    }
+    return this.usersRepository.softDeleteUser(userId, tx);
+  }
 }


### PR DESCRIPTION
## Summary

- **DTO 유효성 검사 강화**: 이메일 validation message 공통화, 비밀번호 최소 8자 + 특수문자 1개 이상 제약 추가
- **Auth 컨트롤러 응답 형식 통일**: 모든 엔드포인트에 `ApiSuccessResponse` / `createSuccessResponse` 적용 (하네스 규칙 준수)
- **DI 오류 수정**: `AuthModule`이 `UsersModule`을 export하지 않아 `AccessTokenGuard`가 `PlacesModule` 등에서 resolve 실패하던 문제 해소
- **공통 쿼리 파싱 유틸 추가**: `parseToPrismaQuery` — `__` 구분자 기반으로 DTO 키를 Prisma `findMany` 인자로 변환
- **페이지네이션 방식 개선**: `meta.next`를 커서 객체에서 URL 문자열(`buildNextPath`)로 변경 — FE가 그대로 다음 요청 경로로 사용 가능
- **회원탈퇴 API 구현**: `DELETE /users/:userId` — soft delete (`deletedAt` + `status: INACTIVE`)

## Changes

| 범위 | 파일 | 내용 |
| --- | --- | --- |
| common | `email-validation.message.ts` | emailValidationMessage 유틸 신규 추가 |
| common | `query-param.util.ts` | parseToPrismaQuery 추가 |
| auth | `auth.module.ts` | UsersModule export 추가 |
| auth | `auth.controller.ts` | 모든 엔드포인트 createSuccessResponse 적용 |
| auth | `register-email.dto.ts` | 비밀번호 MinLength(8), Matches(특수문자) 추가 |
| auth | `check-email.dto.ts` | emailValidationMessage 적용 |
| users | `update-user-profile.dto.ts` | emailValidationMessage 적용 |
| users | `user.prisma-repository.ts` | parseToPrismaQuery 적용, buildNextPath로 next URL 생성 |
| users | `user-list.type.ts` | `next: string \| null` 로 변경 |
| users | `user.repository.ts` | softDeleteUser 인터페이스 추가 |
| users | `users.service.ts` | deleteUser 추가 |
| users | `users.controller.ts` | DELETE /:userId 엔드포인트 추가, ParseUUIDPipe 적용 |

## Test plan

- [x] `sh ./scripts/verify.sh` — 377 tests 전체 통과 확인
- [x] `POST /auth/register/email` — 비밀번호 7자 또는 특수문자 없으면 400 반환 확인
- [x] `GET /users?where__nickname__contain=준` — 검색 필터 동작 확인
- [x] `GET /users` 응답의 `meta.next`가 URL 문자열인지 확인
- [x] `DELETE /users/:userId` — 본인 토큰으로 탈퇴 성공, 타인 토큰으로 403 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 회원 탈퇴(DELETE) 엔드포인트와 소프트 삭제 기능이 추가되었습니다.
  * 사용자 목록의 다음 페이지 정보가 문자열 URL 형태로 제공됩니다.
* **Bug Fixes**
  * 인증/회원가입 응답이 성공 메시지와 함께 일관된 응답 포맷으로 제공됩니다.
  * 이메일/비밀번호 검증 규칙과 오류 메시지가 더 명확해졌습니다.
  * 사용자 목록 조회의 정렬·필터·커서(페이지네이션) 처리가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->