### PR TITLE
[KAN-68] 프로필 음악 메타데이터 JSONB 저장 및 검색/삭제 API 추가

### DIFF
--- a/backend/docs/backend/api-docs/users.md
+++ b/backend/docs/backend/api-docs/users.md
@@ -103,18 +103,18 @@
     "profile": {
       "nickname": "홍길동",
       "selfDescription": "기타를 사랑합니다.",
-      "avatarUrl": "https://example.com/avatar.jpg",
-      "profileMusic": {
-        "externalTrackId": "12345",
-        "sourceType": "DEEZER",
-        "title": "Blinding Lights",
-        "artistName": "The Weeknd",
-        "albumName": "After Hours",
-        "albumImageUrl": "https://example.com/album.jpg",
-        "durationMs": 200000,
-        "previewUrl": "https://cdns-preview.dzcdn.net/...",
-        "sourceUrl": "https://www.deezer.com/track/12345"
-      }
+      "avatarUrl": "https://example.com/avatar.jpg"
+    },
+    "profileMusic": {
+      "externalTrackId": "12345",
+      "sourceType": "DEEZER",
+      "title": "Blinding Lights",
+      "artistName": "The Weeknd",
+      "albumName": "After Hours",
+      "albumImageUrl": "https://example.com/album.jpg",
+      "durationMs": 200000,
+      "previewUrl": "https://cdns-preview.dzcdn.net/...",
+      "sourceUrl": "https://www.deezer.com/track/12345"
     },
     "skills": [
       {

--- a/backend/docs/backend/api-docs/users.md
+++ b/backend/docs/backend/api-docs/users.md
@@ -1,0 +1,322 @@
+# 유저 API 명세
+
+유저 프로필 조회·수정·탈퇴, 프로필 음악 검색·삭제 도메인을 정리한다.
+
+> ⚠️ 변환 노트: [설계자 보완 2026-06-26]
+> - users.md 신규 생성. 기존 구현(Controller/Service)과 확정된 API 명세(#68, #69)를 기반으로 작성.
+> - #3: 기존 `profile.profileMusicUrl` → `profileMusic: ProfileMusicTrack | null` 로 교체 (스키마 변경 반영)
+> - #5: 기존 `profile.profileMusicUrl` → `profile.profileMusic?: ProfileMusicTrack | null` 로 교체. `null` 전달 시 삭제 안 함.
+> - #68, #69: 사용자 승인된 새 API 명세 추가.
+> - 에러 코드 표준(400/401/403/404) 전체 보완.
+
+## API 목록
+
+| 번호 | 메서드 | 경로 | 설명 |
+|------|--------|------|------|
+| #1 | GET | `/users` | 유저 목록 조회 |
+| #3 | GET | `/users/:userId/profiles` | 유저 프로필 조회 |
+| #5 | PATCH | `/users/:userId/profiles` | 유저 프로필 수정 |
+| #7 | DELETE | `/users/:userId` | 회원 탈퇴 |
+| #68 | GET | `/users/profile-music/search` | 프로필 음악 검색 (Deezer) |
+| #69 | DELETE | `/users/:userId/profile-music` | 프로필 음악 삭제 |
+
+---
+
+## #1 유저 목록 조회
+
+- Method: `GET`
+- Path: `/users`
+- 인증: 없음 (공개)
+
+### Query Parameters
+
+| 이름 | 필수 | 설명 |
+|------|------|------|
+| `take` | N | 가져올 유저 수 (기본값: 20) |
+| `order__created_at` | N | 생성일 정렬 (`asc` / `desc`, 기본값: `desc`) |
+| `order__id` | N | ID 정렬 (`asc` / `desc`, 기본값: `desc`) |
+| `cursor__created_at` | N | 커서 기반 페이지네이션 — 마지막 아이템 생성일 |
+| `cursor__id` | N | 커서 기반 페이지네이션 — 마지막 아이템 ID (UUID) |
+| `where__nickname__contain` | N | 닉네임 부분 검색 |
+| `where__email__contain` | N | 이메일 부분 검색 |
+
+### Response 200
+
+```json
+{
+  "success": true,
+  "message": "유저 목록 조회 성공",
+  "data": {
+    "items": [
+      {
+        "id": "uuid",
+        "email": "user@example.com",
+        "nickname": "홍길동",
+        "status": "ACTIVE",
+        "avatarUrl": null,
+        "createdAt": "2026-01-01T00:00:00.000Z"
+      }
+    ],
+    "meta": {
+      "count": 1,
+      "take": 20,
+      "cursor": { "createdAt": "2026-01-01T00:00:00.000Z", "id": "uuid" },
+      "next": null
+    }
+  }
+}
+```
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 400 | `take` 범위 오류, `order` 값 오류, `cursor__id` UUID 형식 오류 |
+
+---
+
+## #3 유저 프로필 조회
+
+- Method: `GET`
+- Path: `/users/:userId/profiles`
+- 인증: 없음 (공개)
+
+### Path Parameters
+
+| 이름 | 설명 |
+|------|------|
+| `userId` | 유저 ID (UUID) |
+
+### Response 200
+
+```json
+{
+  "success": true,
+  "message": "유저 프로필 조회 성공",
+  "data": {
+    "user": {
+      "id": "uuid",
+      "email": "user@example.com",
+      "status": "ACTIVE",
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    "profile": {
+      "nickname": "홍길동",
+      "selfDescription": "기타를 사랑합니다.",
+      "avatarUrl": "https://example.com/avatar.jpg",
+      "profileMusic": {
+        "externalTrackId": "12345",
+        "sourceType": "DEEZER",
+        "title": "Blinding Lights",
+        "artistName": "The Weeknd",
+        "albumName": "After Hours",
+        "albumImageUrl": "https://example.com/album.jpg",
+        "durationMs": 200000,
+        "previewUrl": "https://cdns-preview.dzcdn.net/...",
+        "sourceUrl": "https://www.deezer.com/track/12345"
+      }
+    },
+    "skills": [
+      {
+        "skillTypeId": "uuid",
+        "skillName": "기타",
+        "level": "INTERMEDIATE",
+        "isPrimary": true
+      }
+    ],
+    "favoriteGenres": [
+      {
+        "genreId": "uuid",
+        "name": "록"
+      }
+    ]
+  }
+}
+```
+
+> 참고: `profile`이 없으면 `null`. `profileMusic`이 없으면 `null`.
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 400 | `userId`가 UUID 형식이 아님 |
+| 404 | 존재하지 않는 유저 |
+
+---
+
+## #5 유저 프로필 수정
+
+- Method: `PATCH`
+- Path: `/users/:userId/profiles`
+- 인증: AccessToken + SelfUser
+
+### Path Parameters
+
+| 이름 | 설명 |
+|------|------|
+| `userId` | 유저 ID (UUID) |
+
+### Request Body
+
+```json
+{
+  "profile": {
+    "nickname": "새닉네임",
+    "selfDescription": "새 소개글",
+    "avatarUrl": "https://example.com/avatar.jpg",
+    "profileMusic": {
+      "externalTrackId": "12345",
+      "sourceType": "DEEZER",
+      "title": "Blinding Lights",
+      "artistName": "The Weeknd",
+      "albumName": "After Hours",
+      "albumImageUrl": "https://example.com/album.jpg",
+      "durationMs": 200000,
+      "previewUrl": "https://cdns-preview.dzcdn.net/...",
+      "sourceUrl": "https://www.deezer.com/track/12345"
+    }
+  },
+  "personalInfo": {
+    "email": "new@example.com"
+  },
+  "skills": [
+    {
+      "skillTypeId": "uuid",
+      "level": "INTERMEDIATE",
+      "isPrimary": true
+    }
+  ],
+  "favoriteGenres": ["uuid"]
+}
+```
+
+> 참고: `profile.profileMusic`은 선택 필드. 전달하면 upsert, 미전달 시 변경 없음. 삭제는 #69 전용. `profileMusic: null` 전달은 변경 없음(삭제 아님).
+
+### Response 200
+
+`#3`과 동일한 구조의 `GetUserProfileResult`.
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 400 | 잘못된 입력값 |
+| 401 | 인증 실패 |
+| 403 | 본인 프로필만 수정 가능 |
+| 404 | 존재하지 않는 유저 |
+
+---
+
+## #7 회원 탈퇴
+
+- Method: `DELETE`
+- Path: `/users/:userId`
+- 인증: AccessToken + SelfUser
+
+### Path Parameters
+
+| 이름 | 설명 |
+|------|------|
+| `userId` | 유저 ID (UUID) |
+
+### Response 200
+
+```json
+{
+  "success": true,
+  "message": "회원 탈퇴가 완료되었습니다.",
+  "data": {
+    "userId": "uuid",
+    "deletedAt": "2026-06-26T00:00:00.000Z"
+  }
+}
+```
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 400 | `userId`가 UUID 형식이 아님 |
+| 401 | 인증 실패 |
+| 403 | 본인 계정만 탈퇴 가능 |
+| 404 | 존재하지 않는 유저 |
+
+---
+
+## #68 프로필 음악 검색
+
+- Method: `GET`
+- Path: `/users/profile-music/search`
+- 인증: 없음 (공개)
+
+### Query Parameters
+
+| 이름 | 필수 | 설명 |
+|------|------|------|
+| `q` | Y | 검색어 (곡명, 아티스트명 등) |
+
+### Response 200
+
+```json
+{
+  "success": true,
+  "message": "프로필 음악 검색 성공",
+  "data": {
+    "items": [
+      {
+        "externalTrackId": "12345",
+        "sourceType": "DEEZER",
+        "title": "Blinding Lights",
+        "artistName": "The Weeknd",
+        "albumName": "After Hours",
+        "albumImageUrl": "https://example.com/album.jpg",
+        "durationMs": 200000,
+        "previewUrl": "https://cdns-preview.dzcdn.net/...",
+        "sourceUrl": "https://www.deezer.com/track/12345"
+      }
+    ]
+  }
+}
+```
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 400 | `q` 파라미터 누락 |
+
+---
+
+## #69 프로필 음악 삭제
+
+- Method: `DELETE`
+- Path: `/users/:userId/profile-music`
+- 인증: AccessToken + SelfUser
+
+### Path Parameters
+
+| 이름 | 설명 |
+|------|------|
+| `userId` | 유저 ID (UUID) |
+
+### Response 200
+
+```json
+{
+  "success": true,
+  "message": "프로필 음악이 삭제되었습니다.",
+  "data": {
+    "userId": "uuid",
+    "deletedAt": "2026-06-26T00:00:00.000Z"
+  }
+}
+```
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 401 | 인증 실패 |
+| 403 | 본인 프로필 음악만 삭제 가능 |
+| 404 | 프로필 음악이 존재하지 않음 |

--- a/backend/docs/backend/designs/users/profile-music-jsonb.md
+++ b/backend/docs/backend/designs/users/profile-music-jsonb.md
@@ -1,0 +1,527 @@
+# ProfileMusic 메타데이터 저장/조회 설계
+
+## API 번호
+
+- #68 `GET /users/profile-music/search` — 신규 (기존 최대 #7 기준, Notion 번호 그대로 적용)
+- #69 `DELETE /users/:userId/profile-music` — 신규
+- #3 `GET /users/:userId/profiles` — 기존 업데이트 (`profileMusicUrl` → `profileMusic`)
+- #5 `PATCH /users/:userId/profiles` — 기존 업데이트 (`profileMusicUrl` → `profileMusic` upsert)
+
+명세 위치: `docs/backend/api-docs/users.md`
+
+---
+
+## 작업 범위
+
+### 스키마 변경 (prisma/schema.prisma)
+
+```
+수정: prisma/schema.prisma
+  - UserProfile.profileMusicUrl 필드 제거
+  - User 모델에 `profileMusic ProfileMusic?` 관계 추가
+  - ProfileMusic 모델 신규 추가
+```
+
+### 신규 파일
+
+```
+신규: src/modules/users/repositories/profile-music.repository.ts
+      src/modules/users/repositories/profile-music.prisma-repository.ts
+      src/modules/users/dto/search-profile-music-query.dto.ts
+      src/modules/users/dto/profile-music-track.dto.ts
+      src/modules/users/types/profile-music.type.ts
+```
+
+### 수정 파일
+
+```
+수정: src/modules/users/types/user-profile.type.ts
+        UserProfileDetail.profileMusicUrl 제거
+        UserProfileDetail에 profileMusic: ProfileMusicTrack | null 추가
+
+수정: src/modules/users/dto/update-user-profile.dto.ts
+        UpdateProfileDto.profileMusicUrl 제거
+        UpdateProfileDto에 profileMusic?: ProfileMusicTrackDto | null 추가
+
+수정: src/modules/users/repositoreis/user.repository.ts
+        (기존 오타 경로 그대로 유지)
+        UpdateUserProfileData 타입에 profile.profileMusic 반영됨 (DTO 변경으로 연동)
+
+수정: src/modules/users/repositoreis/user.prisma-repository.ts
+        findUserProfileById — profileMusic 관계 include 추가, 응답 매핑 수정
+        updateUserProfile — profileMusic upsert 로직 추가
+
+수정: src/modules/users/users.service.ts
+        searchProfileMusic 메서드 추가
+        deleteProfileMusic 메서드 추가
+        DeezerTrackClient 주입 추가
+
+수정: src/modules/users/users.controller.ts
+        GET /users/profile-music/search 핸들러 추가
+        DELETE /users/:userId/profile-music 핸들러 추가
+
+수정: src/modules/users/users.module.ts
+        ProfileMusicPrismaRepository provider 등록
+        PROFILE_MUSIC_REPOSITORY 심볼 등록
+        DeezerTrackClient provider 등록
+        SongsModule import 또는 DeezerTrackClient 직접 등록
+
+수정: src/modules/users/users.service.spec.ts
+        searchProfileMusic / deleteProfileMusic 테스트 추가
+        mockProfile profileMusicUrl → profileMusic 교체
+```
+
+---
+
+## 스키마 설계
+
+### 추가할 ProfileMusic 모델
+
+```prisma
+model ProfileMusic {
+  id        String   @id @default(uuid()) @db.Uuid
+  userId    String   @unique @map("user_id") @db.Uuid
+  trackData Json     @map("track_data") @db.JsonB
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("profile_music")
+}
+```
+
+### User 모델 변경
+
+```prisma
+// 추가
+profileMusic ProfileMusic?
+```
+
+### UserProfile 모델 변경
+
+```prisma
+// 제거
+profileMusicUrl String? @map("profile_music_url")
+```
+
+---
+
+## 타입 정의
+
+### ProfileMusicTrack (types/profile-music.type.ts)
+
+```typescript
+/** 프로필 음악 트랙 데이터 구조 — JSONB trackData 컬럼에 저장되는 형태와 동일 */
+export interface ProfileMusicTrack {
+  externalTrackId: string;
+  sourceType: 'DEEZER';
+  title: string;
+  artistName: string;
+  albumName: string;
+  albumImageUrl: string | null;
+  durationMs: number;
+  previewUrl: string | null;
+  sourceUrl: string;
+}
+
+/** #69 삭제 응답 */
+export interface DeleteProfileMusicResult {
+  userId: string;
+  deletedAt: string;
+}
+```
+
+### UserProfileDetail 변경 (types/user-profile.type.ts)
+
+```typescript
+export interface UserProfileDetail {
+  nickname: string;
+  selfDescription: string | null;
+  // profileMusicUrl 제거
+  avatarUrl: string | null;
+  profileMusic: ProfileMusicTrack | null;  // 추가
+}
+```
+
+---
+
+## Repository 인터페이스
+
+### 신규: PROFILE_MUSIC_REPOSITORY (repositories/profile-music.repository.ts)
+
+```typescript
+export const PROFILE_MUSIC_REPOSITORY = Symbol('PROFILE_MUSIC_REPOSITORY');
+
+export interface ProfileMusicRepository {
+  /**
+   * userId로 ProfileMusic 레코드를 조회한다.
+   * 존재하지 않으면 null을 반환한다.
+   */
+  findByUserId(userId: string, tx?: Prisma.TransactionClient): Promise<ProfileMusicTrack | null>;
+
+  /**
+   * ProfileMusic을 upsert한다.
+   * userId 기준으로 이미 존재하면 trackData를 업데이트하고,
+   * 없으면 신규 생성한다.
+   */
+  upsertByUserId(userId: string, trackData: ProfileMusicTrack, tx?: Prisma.TransactionClient): Promise<ProfileMusicTrack>;
+
+  /**
+   * userId로 ProfileMusic을 삭제하고 삭제 시각을 반환한다.
+   * 레코드가 없으면 null을 반환한다.
+   */
+  deleteByUserId(userId: string, tx?: Prisma.TransactionClient): Promise<DeleteProfileMusicResult | null>;
+}
+```
+
+### 기존 UsersRepository 변경 없음
+
+`findUserProfileById`와 `updateUserProfile`의 시그니처는 변경 없다. 내부 구현(Prisma 쿼리)만 바뀐다.
+
+- `findUserProfileById`: `include: { profileMusic: true }` 추가 후 `mapProfileMusic` 헬퍼로 변환
+- `updateUserProfile`: `data.profile.profileMusic`이 존재하면 `PROFILE_MUSIC_REPOSITORY`의 `upsertByUserId` 호출
+
+단, `updateUserProfile`이 `ProfileMusicRepository`를 직접 사용하면 Repository → Repository 의존이 생긴다. 이 경우 upsert 로직을 `UsersPrismaRepository` 내에서 `tx`를 통해 직접 Prisma 쿼리로 처리하는 방식을 채택한다(아래 "Service 비즈니스 규칙" 참고).
+
+---
+
+## DTO 정의
+
+### ProfileMusicTrackDto (dto/profile-music-track.dto.ts)
+
+```typescript
+export class ProfileMusicTrackDto {
+  @ApiProperty({ description: '외부 트랙 ID', example: '12345' })
+  @IsString({ message: stringValidationMessage })
+  externalTrackId!: string;
+
+  @ApiProperty({ description: '소스 타입', example: 'DEEZER' })
+  @IsIn(['DEEZER'])
+  sourceType!: 'DEEZER';
+
+  @ApiProperty({ description: '곡 제목', example: 'Blinding Lights' })
+  @IsString({ message: stringValidationMessage })
+  title!: string;
+
+  @ApiProperty({ description: '아티스트명', example: 'The Weeknd' })
+  @IsString({ message: stringValidationMessage })
+  artistName!: string;
+
+  @ApiProperty({ description: '앨범명', example: 'After Hours' })
+  @IsString({ message: stringValidationMessage })
+  albumName!: string;
+
+  @ApiPropertyOptional({ description: '앨범 이미지 URL', example: 'https://example.com/album.jpg' })
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  albumImageUrl?: string | null;
+
+  @ApiProperty({ description: '재생 시간 (밀리초)', example: 200000 })
+  @IsInt()
+  durationMs!: number;
+
+  @ApiPropertyOptional({ description: '미리 듣기 URL', example: 'https://cdns-preview.dzcdn.net/...' })
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  previewUrl?: string | null;
+
+  @ApiProperty({ description: '소스 URL', example: 'https://www.deezer.com/track/12345' })
+  @IsString({ message: stringValidationMessage })
+  sourceUrl!: string;
+}
+```
+
+### SearchProfileMusicQueryDto (dto/search-profile-music-query.dto.ts)
+
+```typescript
+export class SearchProfileMusicQueryDto {
+  @ApiProperty({ description: '검색어 (곡명, 아티스트명)', example: 'Blinding Lights' })
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty({ message: '검색어를 입력해 주세요.' })
+  q!: string;
+}
+```
+
+### UpdateProfileDto 변경 (dto/update-user-profile.dto.ts)
+
+```typescript
+class UpdateProfileDto {
+  // 기존 nickname, selfDescription, avatarUrl 유지
+
+  // 제거:
+  // profileMusicUrl?: string;
+
+  // 추가:
+  @ApiPropertyOptional({ description: '프로필 음악 정보. 전달 시 upsert, 미전달 시 변경 없음. null 전달 시에도 변경 없음.' })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ProfileMusicTrackDto)
+  profileMusic?: ProfileMusicTrackDto | null;
+}
+```
+
+---
+
+## Service 비즈니스 규칙
+
+### searchProfileMusic(query: string, tx?: Prisma.TransactionClient): Promise<{ items: ProfileMusicTrack[] }>
+
+```
+1. DeezerTrackClient.searchTracks(query) 호출
+2. 결과를 parseDeezerTrackToProfileMusicTrack 헬퍼(또는 인라인 매핑)로 변환
+   - SongPreview.releaseDate 필드는 ProfileMusicTrack에 없으므로 제외
+   - sourceType은 'DEEZER'로 고정
+3. { items: ProfileMusicTrack[] } 반환
+
+예외: Deezer API 장애 → DeezerTrackClient 내부에서 BadGatewayException 발생 (Service는 별도 처리 없음)
+```
+
+> 참고: `parseDeezerTrackToSongPreview` 파서(songs 모듈)와 로직이 거의 동일하지만 반환 타입이 다르다. `releaseDate`가 `ProfileMusicTrack`에 없으므로 공유 파서를 억지로 재사용하지 않고 별도 변환 함수를 UsersService 내 private 메서드로 정의한다.
+
+### deleteProfileMusic(userId: string, tx?: Prisma.TransactionClient): Promise<DeleteProfileMusicResult>
+
+```
+1. profileMusicRepository.deleteByUserId(userId, tx) 호출
+2. 반환값이 null → NotFoundException('프로필 음악이 존재하지 않습니다.')
+3. 결과 반환
+```
+
+### updateUserProfile 변경 사항
+
+기존 `updateUserProfile`에서 `data.profile.profileMusic` 처리를 추가한다.
+
+```
+기존 흐름에서 profile 업데이트 단계:
+  - userProfile.update()에 profileMusicUrl 포함 → 제거
+  - data.profile.profileMusic이 truthy(null이 아니고 undefined가 아님)이면:
+      client.profileMusic.upsert({
+        where: { userId },
+        create: { userId, trackData: data.profile.profileMusic },
+        update: { trackData: data.profile.profileMusic },
+      })
+
+profileMusic: null 또는 undefined → 아무 처리 없음
+```
+
+Prisma upsert를 `UsersPrismaRepository.updateUserProfile` 내부에서 직접 처리한다(tx 인자 재사용). `ProfileMusicRepository`는 삭제(deleteByUserId)와 독립 조회에만 사용한다.
+
+### getUserProfile 변경 사항
+
+`findUserProfileById` 내부에서 `profileMusic` 관계를 include한 뒤 응답 매핑에 포함. Service 로직 변경 없음.
+
+---
+
+## Controller 메서드 설계
+
+### GET /users/profile-music/search (#68)
+
+```typescript
+@Get('profile-music/search')
+@ApiOperation({ summary: '프로필 음악 검색' })
+@ApiResponse({ status: 200, description: '프로필 음악 검색 성공' })
+@ApiResponse({ status: 400, description: '검색어(q) 누락' })
+async searchProfileMusic(
+  @Query() query: SearchProfileMusicQueryDto,
+): Promise<ApiSuccessResponse<{ items: ProfileMusicTrack[] }>>
+```
+
+> 주의: 경로가 `/users/profile-music/search`이고 `:userId` 파라미터 라우트보다 위에 선언되어야 NestJS 라우터가 `profile-music`을 userId로 오인하지 않는다. NestJS는 선언 순서대로 매칭하므로 Controller 상단에 배치한다.
+
+### DELETE /users/:userId/profile-music (#69)
+
+```typescript
+@Delete(':userId/profile-music')
+@UseGuards(AccessTokenGuard, SelfUserGuard)
+@ApiBearerAuth('access-token')
+@ApiOperation({ summary: '프로필 음악 삭제' })
+@ApiParam({ name: 'userId', description: '유저 ID (UUID)', type: String })
+@ApiResponse({ status: 200, description: '프로필 음악 삭제 성공' })
+@ApiResponse({ status: 401, description: '인증 실패' })
+@ApiResponse({ status: 403, description: '본인 프로필 음악만 삭제 가능' })
+@ApiResponse({ status: 404, description: '프로필 음악이 존재하지 않음' })
+async deleteProfileMusic(
+  @Param('userId', ParseUUIDPipe) userId: string,
+): Promise<ApiSuccessResponse<DeleteProfileMusicResult>>
+```
+
+---
+
+## ProfileMusicPrismaRepository 구현 설계
+
+### findByUserId
+
+```typescript
+const record = await client.profileMusic.findUnique({ where: { userId } });
+if (!record) return null;
+return record.trackData as ProfileMusicTrack;
+```
+
+### upsertByUserId
+
+```typescript
+const record = await client.profileMusic.upsert({
+  where: { userId },
+  create: { userId, trackData: trackData as Prisma.InputJsonValue },
+  update: { trackData: trackData as Prisma.InputJsonValue },
+});
+return record.trackData as ProfileMusicTrack;
+```
+
+### deleteByUserId
+
+```typescript
+try {
+  await client.profileMusic.delete({ where: { userId } });
+  return { userId, deletedAt: new Date().toISOString() };
+} catch (e) {
+  if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
+    return null;
+  }
+  throw e;
+}
+```
+
+---
+
+## 트랜잭션 경계
+
+| 메서드 | tx? 이유 |
+|--------|----------|
+| `UsersService.searchProfileMusic` | DB 접근 없음. tx 불필요하나 시그니처 통일을 위해 tx? 포함 |
+| `UsersService.deleteProfileMusic` | 단일 delete이므로 자체 트랜잭션 불필요. 외부 tx 전달만 지원 |
+| `UsersService.updateUserProfile` | 기존 메서드 — 내부에서 `prisma.$transaction` 사용. profileMusic upsert를 동일 tx 안에서 처리 |
+| `ProfileMusicPrismaRepository.*` | 모든 메서드가 `tx?` 인자 수용 |
+
+`updateUserProfile` 트랜잭션 처리 패턴:
+
+```typescript
+const run = async (client: Prisma.TransactionClient) => {
+  // 기존 profile/skills/genres 처리
+  // + profileMusic upsert (data.profile.profileMusic 있을 때만)
+};
+return tx ? run(tx) : this.prisma.$transaction(run);
+```
+
+---
+
+## 모듈 변경 (users.module.ts)
+
+```typescript
+import { DeezerTrackClient } from '../songs/deezer-track.client';
+import { ProfileMusicPrismaRepository } from './repositories/profile-music.prisma-repository';
+import { PROFILE_MUSIC_REPOSITORY } from './repositories/profile-music.repository';
+
+@Module({
+  providers: [
+    // 기존 유지
+    UsersService,
+    AccessTokenGuard,
+    SelfUserGuard,
+    { provide: USERS_REPOSITORY, useClass: UsersPrismaRepository },
+    // 추가
+    DeezerTrackClient,
+    ProfileMusicPrismaRepository,
+    { provide: PROFILE_MUSIC_REPOSITORY, useClass: ProfileMusicPrismaRepository },
+  ],
+  // ...
+})
+```
+
+> `DeezerTrackClient`는 SongsModule에 등록되어 있지만 exports되지 않는다. UsersModule에서 직접 providers에 추가한다.
+
+---
+
+## UsersService 의존성 변경
+
+```typescript
+@Injectable()
+export class UsersService {
+  constructor(
+    @Inject(USERS_REPOSITORY)
+    private readonly usersRepository: UsersRepository,
+    @Inject(PROFILE_MUSIC_REPOSITORY)
+    private readonly profileMusicRepository: ProfileMusicRepository,
+    @Inject(DeezerTrackClient)
+    private readonly deezerTrackClient: DeezerTrackClient,
+    // prisma는 tx 진입점으로 직접 사용하지 않음 (updateUserProfile은 usersRepository 내부에서 처리)
+  ) {}
+}
+```
+
+> `updateUserProfile` 내부의 profileMusic upsert는 `UsersPrismaRepository`가 prisma client를 통해 직접 처리한다. Service는 Repository 인터페이스에만 의존한다는 원칙을 유지하기 위해, UsersPrismaRepository에 profileMusic upsert를 위임한다. 따라서 UsersService에는 PrismaService를 주입하지 않는다.
+
+---
+
+## 테스트 계획
+
+### users.service.spec.ts — 신규 테스트 케이스
+
+repositoryStub에 `profileMusicRepository` stub 추가:
+
+```typescript
+const profileMusicRepositoryStub: ProfileMusicRepository = {
+  async findByUserId(userId) { return userId === 'user-001' ? mockProfileMusicTrack : null; },
+  async upsertByUserId(_userId, trackData) { return trackData; },
+  async deleteByUserId(userId) { return userId === 'user-001' ? { userId, deletedAt: '2026-06-26T00:00:00.000Z' } : null; },
+};
+```
+
+DeezerTrackClient stub:
+
+```typescript
+const deezerTrackClientStub = {
+  async searchTracks(_query: string) { return [mockDeezerTrackApiResponse]; },
+};
+```
+
+| 메서드 | 케이스 | 검증 |
+|--------|--------|------|
+| `searchProfileMusic` | happy path | `{ items: [...] }` 반환, items 길이 ≥ 1 |
+| `searchProfileMusic` | Deezer API 실패 | DeezerTrackClient가 BadGatewayException throw → Service도 그대로 전파 |
+| `searchProfileMusic` | tx 전달 | `deezerTrackClient.searchTracks`에 tx 영향 없음 (외부 API) |
+| `deleteProfileMusic` | happy path | `{ userId, deletedAt }` 반환 |
+| `deleteProfileMusic` | 프로필 음악 없음 | `NotFoundException` |
+| `deleteProfileMusic` | tx 전달 | `profileMusicRepository.deleteByUserId`에 동일 tx 전달 |
+
+### mockProfile 수정
+
+```typescript
+// 기존
+profile: { nickname: 'testuser', selfDescription: null, profileMusicUrl: null, avatarUrl: null }
+
+// 변경
+profile: { nickname: 'testuser', selfDescription: null, avatarUrl: null, profileMusic: null }
+```
+
+### updateUserProfile 기존 테스트 영향 없음
+
+`updateUserProfile` stub 반환값(`mockProfile`)이 변경되므로 기존 테스트 통과 확인 필요. stub 값만 업데이트.
+
+---
+
+## 설계 품질 기준 체크리스트
+
+- [x] Service 메서드마다 예외 조건이 명시되었는가?
+  - `searchProfileMusic`: BadGatewayException (Deezer 장애, DeezerTrackClient 내부)
+  - `deleteProfileMusic`: NotFoundException (프로필 음악 없음)
+- [x] Repository 메서드가 인터페이스에 선언되었는가?
+  - `ProfileMusicRepository`: findByUserId / upsertByUserId / deleteByUserId
+- [x] 트랜잭션 경계가 명확한가?
+  - updateUserProfile: prisma.$transaction 내 profileMusic upsert 포함
+  - deleteProfileMusic: 외부 tx 전달만 지원
+- [x] 테스트 케이스가 happy path + NotFoundException + BadGatewayException + tx 일관성 + 외부 tx를 포함하는가?
+- [x] Prisma 모델과 설계가 일치하는가?
+  - ProfileMusic 모델 구조 = 확정 스키마와 동일
+  - UserProfile.profileMusicUrl 제거 반영
+- [x] DTO 필드에 `@ApiProperty`가 포함되었는가?
+  - ProfileMusicTrackDto, SearchProfileMusicQueryDto, UpdateProfileDto 모두 포함
+- [x] Controller 메서드에 `@ApiOperation`, `@ApiResponse` 데코레이터가 포함되었는가?
+  - #68, #69 핸들러 모두 포함
+- [x] 작업 대상 API의 `#N` 번호가 명시되었는가?
+  - #68, #69, #3(업데이트), #5(업데이트)
+
+---
+
+## 미결 사항
+
+없음. 확정된 API 명세와 스키마를 기반으로 모든 항목이 결정되었다.

--- a/backend/docs/backend/designs/users/profile-music-jsonb.md
+++ b/backend/docs/backend/designs/users/profile-music-jsonb.md
@@ -15,7 +15,7 @@
 
 ### 스키마 변경 (prisma/schema.prisma)
 
-```
+```text
 수정: prisma/schema.prisma
   - UserProfile.profileMusicUrl 필드 제거
   - User 모델에 `profileMusic ProfileMusic?` 관계 추가
@@ -24,7 +24,7 @@
 
 ### 신규 파일
 
-```
+```text
 신규: src/modules/users/repositories/profile-music.repository.ts
       src/modules/users/repositories/profile-music.prisma-repository.ts
       src/modules/users/dto/search-profile-music-query.dto.ts
@@ -34,7 +34,7 @@
 
 ### 수정 파일
 
-```
+```text
 수정: src/modules/users/types/user-profile.type.ts
         UserProfileDetail.profileMusicUrl 제거
         UserProfileDetail에 profileMusic: ProfileMusicTrack | null 추가
@@ -266,7 +266,7 @@ class UpdateProfileDto {
 
 ### searchProfileMusic(query: string, tx?: Prisma.TransactionClient): Promise<{ items: ProfileMusicTrack[] }>
 
-```
+```text
 1. DeezerTrackClient.searchTracks(query) 호출
 2. 결과를 parseDeezerTrackToProfileMusicTrack 헬퍼(또는 인라인 매핑)로 변환
    - SongPreview.releaseDate 필드는 ProfileMusicTrack에 없으므로 제외
@@ -280,7 +280,7 @@ class UpdateProfileDto {
 
 ### deleteProfileMusic(userId: string, tx?: Prisma.TransactionClient): Promise<DeleteProfileMusicResult>
 
-```
+```text
 1. profileMusicRepository.deleteByUserId(userId, tx) 호출
 2. 반환값이 null → NotFoundException('프로필 음악이 존재하지 않습니다.')
 3. 결과 반환
@@ -290,7 +290,7 @@ class UpdateProfileDto {
 
 기존 `updateUserProfile`에서 `data.profile.profileMusic` 처리를 추가한다.
 
-```
+```text
 기존 흐름에서 profile 업데이트 단계:
   - userProfile.update()에 profileMusicUrl 포함 → 제거
   - data.profile.profileMusic이 truthy(null이 아니고 undefined가 아님)이면:

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -25,6 +25,7 @@ model User {
   favoriteGenres      FavoriteGenre[]
   notifications       Notification[]
   profile             UserProfile?
+  profileMusic        ProfileMusic?
   userSkills          UserSkill[]
 
   @@map("users")
@@ -52,12 +53,22 @@ model UserProfile {
   userId          String    @id @map("user_id") @db.Uuid
   nickname        String    @db.VarChar(255)
   selfDescription String?   @map("self_description")
-  profileMusicUrl String?   @map("profile_music_url")
   avatarUrl       String?   @map("avatar_url")
   updatedAt       DateTime? @map("updated_at") @db.Timestamptz(6)
   user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("user_profiles")
+}
+
+model ProfileMusic {
+  id        String   @id @default(uuid()) @db.Uuid
+  userId    String   @unique @map("user_id") @db.Uuid
+  trackData Json     @map("track_data") @db.JsonB
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("profile_music")
 }
 
 model Notification {

--- a/backend/src/modules/songs/songs.controller.ts
+++ b/backend/src/modules/songs/songs.controller.ts
@@ -7,7 +7,6 @@ import type { AuthUser } from '../users/repositoreis/user.repository';
 
 import { CreateSongBodyDto } from './dto/create-song.dto';
 import { GetBandSongsQueryDto } from './dto/get-band-songs-query.dto';
-import { SearchDeezerTrackPreviewsQueryDto } from './dto/search-deezer-track-previews-query.dto';
 import { UpdateSongBodyDto } from './dto/update-song.dto';
 import type { CreateSongResult } from './types/create-song-result.type';
 import type { DeleteSongResult } from './types/delete-song-result.type';
@@ -108,15 +107,5 @@ export class SongsController {
     const songPreview = await this.songsService.previewSpotifyTrack(trackId);
 
     return createSuccessResponse('Spotify 곡 미리보기 조회 성공', songPreview);
-  }
-
-  @Get('songs/deezer/tracks/search')
-  @ApiOperation({ summary: 'Deezer 곡 검색' })
-  @ApiResponse({ status: 200, description: 'Deezer 곡 검색 성공' })
-  @ApiResponse({ status: 400, description: '잘못된 요청' })
-  async searchDeezerTrackPreviews(@Query() query: SearchDeezerTrackPreviewsQueryDto): Promise<ApiSuccessResponse<SongPreview[]>> {
-    const songPreviews = await this.songsService.searchDeezerTrackPreviews(query.query);
-
-    return createSuccessResponse('Deezer 곡 미리보기 목록 조회 성공', songPreviews);
   }
 }

--- a/backend/src/modules/songs/songs.module.ts
+++ b/backend/src/modules/songs/songs.module.ts
@@ -7,7 +7,6 @@ import { UsersModule } from '../users/users.module';
 
 import { SongsPrismaRepository } from './repositories/songs.prisma-repository';
 import { SONGS_REPOSITORY } from './repositories/songs.repository';
-import { DeezerTrackClient } from './deezer-track.client';
 import { SongsController } from './songs.controller';
 import { SongsService } from './songs.service';
 import { SpotifyTrackClient } from './spotify-track.client';
@@ -19,7 +18,6 @@ import { SpotifyTrackClient } from './spotify-track.client';
     AccessTokenGuard,
     SongsService,
     SpotifyTrackClient,
-    DeezerTrackClient,
     SongsPrismaRepository,
     {
       provide: SONGS_REPOSITORY,

--- a/backend/src/modules/songs/songs.service.spec.ts
+++ b/backend/src/modules/songs/songs.service.spec.ts
@@ -4,7 +4,6 @@ import type { PrismaService } from '../../database/prisma';
 import type { SkillsService } from '../skills/skills.service';
 
 import type { SongsRepository } from './repositories/songs.repository';
-import type { DeezerTrackSearcher } from './deezer-track.client';
 import { SongsService } from './songs.service';
 import type { SpotifyTrackReader } from './spotify-track.client';
 
@@ -28,14 +27,11 @@ describe('SongsService', () => {
     const spotifyTrackReader: jest.Mocked<SpotifyTrackReader> = {
       findTrack: jest.fn(),
     };
-    const deezerTrackSearcher: jest.Mocked<DeezerTrackSearcher> = {
-      searchTracks: jest.fn(),
-    };
     const skillsService: jest.Mocked<SkillsService> = {
       findExistingSkillTypeIds: jest.fn(),
     } as unknown as jest.Mocked<SkillsService>;
 
-    const service = new SongsService(repository, prisma, skillsService, spotifyTrackReader, deezerTrackSearcher);
+    const service = new SongsService(repository, prisma, skillsService, spotifyTrackReader);
 
     return {
       service,
@@ -44,7 +40,6 @@ describe('SongsService', () => {
       transactionClient,
       skillsService,
       spotifyTrackReader,
-      deezerTrackSearcher,
     };
   };
 
@@ -81,44 +76,6 @@ describe('SongsService', () => {
       albumName: 'Cut To The Feeling',
       sourceUrl: 'https://open.spotify.com/track/11dFghVXANMlKmJXsNCbNl',
       sourceType: 'SPOTIFY',
-    });
-  });
-
-  it('Deezer 곡 미리보기 서비스는 Deezer track 검색 결과를 목록으로 변환한다', async () => {
-    const { service, deezerTrackSearcher } = createService();
-
-    deezerTrackSearcher.searchTracks.mockResolvedValue([
-      {
-        id: 3135556,
-        title: 'Harder, Better, Faster, Stronger',
-        duration: 224,
-        link: 'https://www.deezer.com/track/3135556',
-        preview: 'https://cdns-preview.dzcdn.net/stream/demo.mp3',
-        artist: {
-          name: 'Daft Punk',
-        },
-        album: {
-          title: 'Discovery',
-          cover: 'https://api.deezer.com/album/302127/image',
-          cover_medium: 'https://e-cdns-images.dzcdn.net/images/cover/medium.jpg',
-          cover_big: 'https://e-cdns-images.dzcdn.net/images/cover/big.jpg',
-          cover_xl: 'https://e-cdns-images.dzcdn.net/images/cover/xl.jpg',
-        },
-      },
-    ]);
-
-    const result = await service.searchDeezerTrackPreviews('Daft Punk Harder Better Faster Stronger');
-
-    expect(deezerTrackSearcher.searchTracks).toHaveBeenCalledWith('Daft Punk Harder Better Faster Stronger');
-    expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({
-      externalTrackId: '3135556',
-      title: 'Harder, Better, Faster, Stronger',
-      artistName: 'Daft Punk',
-      albumName: 'Discovery',
-      durationMs: 224000,
-      sourceUrl: 'https://www.deezer.com/track/3135556',
-      sourceType: 'DEEZER',
     });
   });
 

--- a/backend/src/modules/songs/songs.service.ts
+++ b/backend/src/modules/songs/songs.service.ts
@@ -13,8 +13,6 @@ import type { DeleteSongResult } from './types/delete-song-result.type';
 import type { GetBandSongsResult } from './types/song-list.type';
 import type { SongPreview } from './types/song-preview.type';
 import type { UpdateSongResult } from './types/update-song-result.type';
-import { DeezerTrackClient, type DeezerTrackSearcher } from './deezer-track.client';
-import { parseDeezerTrackToSongPreview } from './deezer-track.parser';
 import { SpotifyTrackClient, type SpotifyTrackReader } from './spotify-track.client';
 import { parseSpotifyTrackToSongPreview } from './spotify-track.parser';
 
@@ -27,8 +25,6 @@ export class SongsService {
     private readonly skillsService: SkillsService,
     @Inject(SpotifyTrackClient)
     private readonly spotifyTrackReader: SpotifyTrackReader,
-    @Inject(DeezerTrackClient)
-    private readonly deezerTrackSearcher: DeezerTrackSearcher,
   ) {}
 
   /**
@@ -41,18 +37,6 @@ export class SongsService {
     const spotifyTrack = await this.spotifyTrackReader.findTrack(trackId);
 
     return parseSpotifyTrackToSongPreview(spotifyTrack);
-  }
-
-  /**
-   * Deezer track 검색 결과를 곡 등록 미리보기 데이터 목록으로 변환한다.
-   *
-   * @param {string} query - 곡명과 아티스트명을 포함한 검색어
-   * @returns {Promise<SongPreview[]>} 곡 등록 미리보기 데이터 목록
-   */
-  async searchDeezerTrackPreviews(query: string): Promise<SongPreview[]> {
-    const deezerTracks = await this.deezerTrackSearcher.searchTracks(query);
-
-    return deezerTracks.map(deezerTrack => parseDeezerTrackToSongPreview(deezerTrack));
   }
 
   /**

--- a/backend/src/modules/users/dto/profile-music-track.dto.ts
+++ b/backend/src/modules/users/dto/profile-music-track.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsInt, IsOptional, IsString } from 'class-validator';
+import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
+
+import type { ProfileMusicTrack } from '../types/profile-music.type';
+
+export class ProfileMusicTrackDto implements ProfileMusicTrack {
+  @ApiProperty({ description: '외부 트랙 ID', example: '12345' })
+  @IsString({ message: stringValidationMessage })
+  externalTrackId!: string;
+
+  @ApiProperty({ description: '소스 타입', example: 'DEEZER' })
+  @IsIn(['DEEZER'])
+  sourceType!: 'DEEZER';
+
+  @ApiProperty({ description: '곡 제목', example: 'Blinding Lights' })
+  @IsString({ message: stringValidationMessage })
+  title!: string;
+
+  @ApiProperty({ description: '아티스트명', example: 'The Weeknd' })
+  @IsString({ message: stringValidationMessage })
+  artistName!: string;
+
+  @ApiProperty({ description: '앨범명', example: 'After Hours' })
+  @IsString({ message: stringValidationMessage })
+  albumName!: string;
+
+  @ApiPropertyOptional({ description: '앨범 이미지 URL', example: 'https://example.com/album.jpg', nullable: true })
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  albumImageUrl!: string | null;
+
+  @ApiProperty({ description: '재생 시간 (밀리초)', example: 200000 })
+  @IsInt()
+  durationMs!: number;
+
+  @ApiPropertyOptional({ description: '미리 듣기 URL', example: 'https://cdns-preview.dzcdn.net/...', nullable: true })
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  previewUrl!: string | null;
+
+  @ApiProperty({ description: '소스 URL', example: 'https://www.deezer.com/track/12345' })
+  @IsString({ message: stringValidationMessage })
+  sourceUrl!: string;
+}

--- a/backend/src/modules/users/dto/profile-music-track.dto.ts
+++ b/backend/src/modules/users/dto/profile-music-track.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsIn, IsInt, IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsInt, IsString, ValidateIf } from 'class-validator';
 import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
 
 import type { ProfileMusicTrack } from '../types/profile-music.type';
@@ -25,8 +25,8 @@ export class ProfileMusicTrackDto implements ProfileMusicTrack {
   @IsString({ message: stringValidationMessage })
   albumName!: string;
 
-  @ApiPropertyOptional({ description: '앨범 이미지 URL', example: 'https://example.com/album.jpg', nullable: true })
-  @IsOptional()
+  @ApiProperty({ description: '앨범 이미지 URL', example: 'https://example.com/album.jpg', nullable: true })
+  @ValidateIf(o => o.albumImageUrl !== null)
   @IsString({ message: stringValidationMessage })
   albumImageUrl!: string | null;
 
@@ -34,8 +34,8 @@ export class ProfileMusicTrackDto implements ProfileMusicTrack {
   @IsInt()
   durationMs!: number;
 
-  @ApiPropertyOptional({ description: '미리 듣기 URL', example: 'https://cdns-preview.dzcdn.net/...', nullable: true })
-  @IsOptional()
+  @ApiProperty({ description: '미리 듣기 URL', example: 'https://cdns-preview.dzcdn.net/...', nullable: true })
+  @ValidateIf(o => o.previewUrl !== null)
   @IsString({ message: stringValidationMessage })
   previewUrl!: string | null;
 

--- a/backend/src/modules/users/dto/search-profile-music-query.dto.ts
+++ b/backend/src/modules/users/dto/search-profile-music-query.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+import { notemptyValidationMessage } from 'src/common/validation-message/notempty-validation.message';
+import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
+
+export class SearchProfileMusicQueryDto {
+  @ApiProperty({ description: '검색어 (곡명, 아티스트명)', example: 'Blinding Lights' })
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty({ message: notemptyValidationMessage })
+  q!: string;
+}

--- a/backend/src/modules/users/dto/search-profile-music-query.dto.ts
+++ b/backend/src/modules/users/dto/search-profile-music-query.dto.ts
@@ -1,10 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import { IsNotEmpty, IsString } from 'class-validator';
 import { notemptyValidationMessage } from 'src/common/validation-message/notempty-validation.message';
 import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
 
 export class SearchProfileMusicQueryDto {
   @ApiProperty({ description: '검색어 (곡명, 아티스트명)', example: 'Blinding Lights' })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString({ message: stringValidationMessage })
   @IsNotEmpty({ message: notemptyValidationMessage })
   q!: string;

--- a/backend/src/modules/users/dto/update-user-profile.dto.ts
+++ b/backend/src/modules/users/dto/update-user-profile.dto.ts
@@ -20,7 +20,7 @@ class UpdateProfileDto {
   @IsString({ message: stringValidationMessage })
   selfDescription?: string;
 
-  @ApiPropertyOptional({ description: '프로필 음악 정보. 전달 시 upsert, 미전달/null 시 변경 없음.', type: ProfileMusicTrackDto })
+  @ApiPropertyOptional({ description: '프로필 음악 정보. 전달 시 upsert, 미전달/null 시 변경 없음.', type: ProfileMusicTrackDto, nullable: true })
   @IsOptional()
   @ValidateNested()
   @Type(() => ProfileMusicTrackDto)

--- a/backend/src/modules/users/dto/update-user-profile.dto.ts
+++ b/backend/src/modules/users/dto/update-user-profile.dto.ts
@@ -7,6 +7,8 @@ import { stringValidationMessage } from 'src/common/validation-message/string-va
 import { uuidValidationMessage } from 'src/common/validation-message/uuid-validation.message';
 import { SkillLevelType } from 'src/generated/prisma';
 
+import { ProfileMusicTrackDto } from './profile-music-track.dto';
+
 class UpdateProfileDto {
   @ApiPropertyOptional({ description: '닉네임', example: '홍길동' })
   @IsOptional()
@@ -18,10 +20,11 @@ class UpdateProfileDto {
   @IsString({ message: stringValidationMessage })
   selfDescription?: string;
 
-  @ApiPropertyOptional({ description: '프로필 음악 URL', example: 'https://example.com/music.mp3' })
+  @ApiPropertyOptional({ description: '프로필 음악 정보. 전달 시 upsert, 미전달/null 시 변경 없음.', type: ProfileMusicTrackDto })
   @IsOptional()
-  @IsString({ message: stringValidationMessage })
-  profileMusicUrl?: string;
+  @ValidateNested()
+  @Type(() => ProfileMusicTrackDto)
+  profileMusic?: ProfileMusicTrackDto | null;
 
   @ApiPropertyOptional({ description: '프로필 이미지 URL', example: 'https://example.com/avatar.jpg' })
   @IsOptional()

--- a/backend/src/modules/users/repositoreis/profile-music.prisma-repository.ts
+++ b/backend/src/modules/users/repositoreis/profile-music.prisma-repository.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/database/prisma/prisma.service';
+import { Prisma } from 'src/generated/prisma';
+
+import type { DeleteProfileMusicResult, ProfileMusicTrack } from '../types/profile-music.type';
+
+import type { ProfileMusicRepository } from './profile-music.repository';
+
+@Injectable()
+export class ProfileMusicPrismaRepository implements ProfileMusicRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findByUserId(userId: string, tx?: Prisma.TransactionClient): Promise<ProfileMusicTrack | null> {
+    const client = tx ?? this.prisma;
+    const record = await client.profileMusic.findUnique({ where: { userId } });
+    if (!record) return null;
+    return record.trackData as unknown as ProfileMusicTrack;
+  }
+
+  async upsertByUserId(userId: string, trackData: ProfileMusicTrack, tx?: Prisma.TransactionClient): Promise<ProfileMusicTrack> {
+    const client = tx ?? this.prisma;
+    const record = await client.profileMusic.upsert({
+      where: { userId },
+      create: { userId, trackData: trackData as unknown as Prisma.InputJsonValue },
+      update: { trackData: trackData as unknown as Prisma.InputJsonValue },
+    });
+    return record.trackData as unknown as ProfileMusicTrack;
+  }
+
+  async deleteByUserId(userId: string, tx?: Prisma.TransactionClient): Promise<DeleteProfileMusicResult | null> {
+    const client = tx ?? this.prisma;
+    try {
+      await client.profileMusic.delete({ where: { userId } });
+      return { userId, deletedAt: new Date().toISOString() };
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
+        return null;
+      }
+      throw e;
+    }
+  }
+}

--- a/backend/src/modules/users/repositoreis/profile-music.repository.ts
+++ b/backend/src/modules/users/repositoreis/profile-music.repository.ts
@@ -1,0 +1,25 @@
+import type { Prisma } from 'src/generated/prisma';
+
+import type { DeleteProfileMusicResult, ProfileMusicTrack } from '../types/profile-music.type';
+
+export const PROFILE_MUSIC_REPOSITORY = Symbol('PROFILE_MUSIC_REPOSITORY');
+
+export interface ProfileMusicRepository {
+  /**
+   * userId로 ProfileMusic 레코드를 조회한다.
+   * 존재하지 않으면 null을 반환한다.
+   */
+  findByUserId(userId: string, tx?: Prisma.TransactionClient): Promise<ProfileMusicTrack | null>;
+
+  /**
+   * ProfileMusic을 upsert한다.
+   * userId 기준으로 이미 존재하면 trackData를 업데이트하고, 없으면 신규 생성한다.
+   */
+  upsertByUserId(userId: string, trackData: ProfileMusicTrack, tx?: Prisma.TransactionClient): Promise<ProfileMusicTrack>;
+
+  /**
+   * userId로 ProfileMusic을 삭제하고 삭제 결과를 반환한다.
+   * 레코드가 없으면 null을 반환한다.
+   */
+  deleteByUserId(userId: string, tx?: Prisma.TransactionClient): Promise<DeleteProfileMusicResult | null>;
+}

--- a/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
+++ b/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
@@ -1,3 +1,4 @@
+import { NotFoundException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { PrismaService } from 'src/database/prisma/prisma.service';
 import { Prisma } from 'src/generated/prisma';
@@ -315,7 +316,7 @@ describe('UsersPrismaRepository', () => {
       expect(mockPrisma.favoriteGenre.createMany).toHaveBeenCalledWith({ data: [{ userId: 'user-001', genreId: 'genre-002' }] });
     });
 
-    it('profile.profileMusic이 있으면 profileMusic.upsert를 호출한다', async () => {
+    it('profile.profileMusic이 있으면 create/update trackData 페이로드를 포함해 profileMusic.upsert를 호출한다', async () => {
       mockPrisma.profileMusic.upsert.mockResolvedValue({});
       const trackData = {
         externalTrackId: '12345',
@@ -329,7 +330,64 @@ describe('UsersPrismaRepository', () => {
         sourceUrl: 'https://www.deezer.com/track/12345',
       };
       await repository.updateUserProfile('user-001', { profile: { profileMusic: trackData } });
-      expect(mockPrisma.profileMusic.upsert).toHaveBeenCalledWith(expect.objectContaining({ where: { userId: 'user-001' } }));
+      expect(mockPrisma.profileMusic.upsert).toHaveBeenCalledWith({
+        where: { userId: 'user-001' },
+        create: { userId: 'user-001', trackData },
+        update: { trackData },
+      });
+    });
+
+    it('profile.profileMusic이 null이면 profileMusic.upsert를 호출하지 않는다', async () => {
+      await repository.updateUserProfile('user-001', { profile: { profileMusic: null } });
+      expect(mockPrisma.profileMusic.upsert).not.toHaveBeenCalled();
+    });
+
+    it('profile.profileMusic이 없으면 profileMusic.upsert를 호출하지 않는다', async () => {
+      await repository.updateUserProfile('user-001', { profile: { nickname: '새닉네임' } });
+      expect(mockPrisma.profileMusic.upsert).not.toHaveBeenCalled();
+    });
+
+    it('profileMusic.upsert가 P2003을 던지면 NotFoundException으로 변환한다', async () => {
+      const p2003 = new Prisma.PrismaClientKnownRequestError('Foreign key constraint failed', { code: 'P2003', clientVersion: '0' });
+      mockPrisma.profileMusic.upsert.mockRejectedValue(p2003);
+      const trackData = {
+        externalTrackId: '12345',
+        sourceType: 'DEEZER' as const,
+        title: 'Blinding Lights',
+        artistName: 'The Weeknd',
+        albumName: 'After Hours',
+        albumImageUrl: null,
+        durationMs: 200000,
+        previewUrl: null,
+        sourceUrl: 'https://www.deezer.com/track/12345',
+      };
+      await expect(repository.updateUserProfile('user-001', { profile: { profileMusic: trackData } })).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('tx가 전달되면 tx 클라이언트로 profileMusic.upsert를 호출한다', async () => {
+      const txClient = {
+        userProfile: { update: jest.fn().mockResolvedValue({}) },
+        profileMusic: { upsert: jest.fn().mockResolvedValue({}) },
+        user: { findUnique: jest.fn().mockResolvedValue(userRecord) },
+      };
+      const trackData = {
+        externalTrackId: '999',
+        sourceType: 'DEEZER' as const,
+        title: 'Test',
+        artistName: 'Artist',
+        albumName: 'Album',
+        albumImageUrl: null,
+        durationMs: 100000,
+        previewUrl: null,
+        sourceUrl: 'https://www.deezer.com/track/999',
+      };
+      await repository.updateUserProfile('user-001', { profile: { profileMusic: trackData } }, txClient as unknown as Prisma.TransactionClient);
+      expect(txClient.profileMusic.upsert).toHaveBeenCalledWith({
+        where: { userId: 'user-001' },
+        create: { userId: 'user-001', trackData },
+        update: { trackData },
+      });
+      expect(mockPrisma.profileMusic.upsert).not.toHaveBeenCalled();
     });
 
     it('모든 변경 후 최신 프로필을 반환한다', async () => {

--- a/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
+++ b/backend/src/modules/users/repositoreis/user.prisma-repository.spec.ts
@@ -9,6 +9,7 @@ import { UsersPrismaRepository } from './user.prisma-repository';
 const mockPrisma = {
   user: { findUnique: jest.fn(), findFirst: jest.fn(), findMany: jest.fn(), create: jest.fn(), update: jest.fn() },
   userProfile: { create: jest.fn(), update: jest.fn() },
+  profileMusic: { findUnique: jest.fn(), upsert: jest.fn(), delete: jest.fn() },
   userSkill: { deleteMany: jest.fn(), createMany: jest.fn() },
   favoriteGenre: { deleteMany: jest.fn(), createMany: jest.fn() },
   $transaction: jest.fn().mockImplementation(fn => fn(mockPrisma)),
@@ -21,7 +22,8 @@ const userRecord = {
   email: 'test@example.com',
   status: 'ACTIVE',
   createdAt: new Date('2026-01-01T00:00:00.000Z'),
-  profile: { nickname: 'testuser', selfDescription: '안녕', profileMusicUrl: null, avatarUrl: null },
+  profile: { nickname: 'testuser', selfDescription: '안녕', avatarUrl: null },
+  profileMusic: null,
   userSkills: [{ skillTypeId: 'skill-001', skillLevel: 'ADVANCED', isPrimary: true, skillType: { name: 'GUITAR' } }],
   favoriteGenres: [{ genreId: 'genre-001', genre: { name: 'ROCK' } }],
 };
@@ -311,6 +313,23 @@ describe('UsersPrismaRepository', () => {
       await repository.updateUserProfile('user-001', { favoriteGenres: ['genre-002'] });
       expect(mockPrisma.favoriteGenre.deleteMany).toHaveBeenCalledWith({ where: { userId: 'user-001' } });
       expect(mockPrisma.favoriteGenre.createMany).toHaveBeenCalledWith({ data: [{ userId: 'user-001', genreId: 'genre-002' }] });
+    });
+
+    it('profile.profileMusic이 있으면 profileMusic.upsert를 호출한다', async () => {
+      mockPrisma.profileMusic.upsert.mockResolvedValue({});
+      const trackData = {
+        externalTrackId: '12345',
+        sourceType: 'DEEZER' as const,
+        title: 'Blinding Lights',
+        artistName: 'The Weeknd',
+        albumName: 'After Hours',
+        albumImageUrl: null,
+        durationMs: 200000,
+        previewUrl: null,
+        sourceUrl: 'https://www.deezer.com/track/12345',
+      };
+      await repository.updateUserProfile('user-001', { profile: { profileMusic: trackData } });
+      expect(mockPrisma.profileMusic.upsert).toHaveBeenCalledWith(expect.objectContaining({ where: { userId: 'user-001' } }));
     });
 
     it('모든 변경 후 최신 프로필을 반환한다', async () => {

--- a/backend/src/modules/users/repositoreis/user.prisma-repository.ts
+++ b/backend/src/modules/users/repositoreis/user.prisma-repository.ts
@@ -6,6 +6,7 @@ import { Prisma, type User } from 'src/generated/prisma';
 
 import type { GetUsersQuery } from '../dto/get-users-query.dto';
 import type { UpdateUserProfileData } from '../dto/update-user-profile.dto';
+import type { ProfileMusicTrack } from '../types/profile-music.type';
 import type { GetUsersResult, UserListItem } from '../types/user-list.type';
 import type { GetUserProfileResult } from '../types/user-profile.type';
 import { generateRandomNickname } from '../util/nickname_maker';
@@ -157,6 +158,7 @@ export class UsersPrismaRepository implements UsersRepository {
       where: { id: userId, deletedAt: null },
       include: {
         profile: true,
+        profileMusic: true,
         userSkills: {
           include: { skillType: true },
         },
@@ -179,10 +181,10 @@ export class UsersPrismaRepository implements UsersRepository {
         ? {
             nickname: user.profile.nickname,
             selfDescription: user.profile.selfDescription,
-            profileMusicUrl: user.profile.profileMusicUrl,
             avatarUrl: user.profile.avatarUrl,
           }
         : null,
+      profileMusic: user.profileMusic ? (user.profileMusic.trackData as unknown as ProfileMusicTrack) : null,
       skills: user.userSkills.map(s => ({
         skillTypeId: s.skillTypeId,
         skillName: s.skillType.name,
@@ -199,7 +201,17 @@ export class UsersPrismaRepository implements UsersRepository {
   async updateUserProfile(userId: string, data: UpdateUserProfileData, tx?: Prisma.TransactionClient): Promise<GetUserProfileResult> {
     const run = async (client: Prisma.TransactionClient) => {
       if (data.profile) {
-        await client.userProfile.update({ where: { userId }, data: data.profile });
+        const { profileMusic, ...profileFields } = data.profile;
+        if (Object.keys(profileFields).length > 0) {
+          await client.userProfile.update({ where: { userId }, data: profileFields });
+        }
+        if (profileMusic) {
+          await client.profileMusic.upsert({
+            where: { userId },
+            create: { userId, trackData: profileMusic as unknown as Prisma.InputJsonValue },
+            update: { trackData: profileMusic as unknown as Prisma.InputJsonValue },
+          });
+        }
       }
 
       if (data.personalInfo?.email) {

--- a/backend/src/modules/users/repositoreis/user.prisma-repository.ts
+++ b/backend/src/modules/users/repositoreis/user.prisma-repository.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { parseToPrismaQuery } from 'src/common/query';
 import { buildNextPath } from 'src/common/url';
 import { PrismaService } from 'src/database/prisma/prisma.service';
@@ -206,11 +206,18 @@ export class UsersPrismaRepository implements UsersRepository {
           await client.userProfile.update({ where: { userId }, data: profileFields });
         }
         if (profileMusic) {
-          await client.profileMusic.upsert({
-            where: { userId },
-            create: { userId, trackData: profileMusic as unknown as Prisma.InputJsonValue },
-            update: { trackData: profileMusic as unknown as Prisma.InputJsonValue },
-          });
+          try {
+            await client.profileMusic.upsert({
+              where: { userId },
+              create: { userId, trackData: profileMusic as unknown as Prisma.InputJsonValue },
+              update: { trackData: profileMusic as unknown as Prisma.InputJsonValue },
+            });
+          } catch (e) {
+            if (e instanceof Prisma.PrismaClientKnownRequestError && (e.code === 'P2003' || e.code === 'P2025')) {
+              throw new NotFoundException('존재하지 않는 유저입니다.');
+            }
+            throw e;
+          }
         }
       }
 

--- a/backend/src/modules/users/types/profile-music.type.ts
+++ b/backend/src/modules/users/types/profile-music.type.ts
@@ -1,0 +1,18 @@
+/** JSONB trackData 컬럼에 저장되는 프로필 음악 트랙 데이터 */
+export interface ProfileMusicTrack {
+  externalTrackId: string;
+  sourceType: 'DEEZER';
+  title: string;
+  artistName: string;
+  albumName: string;
+  albumImageUrl: string | null;
+  durationMs: number;
+  previewUrl: string | null;
+  sourceUrl: string;
+}
+
+/** #69 DELETE /users/:userId/profile-music 응답 */
+export interface DeleteProfileMusicResult {
+  userId: string;
+  deletedAt: string;
+}

--- a/backend/src/modules/users/types/user-profile.type.ts
+++ b/backend/src/modules/users/types/user-profile.type.ts
@@ -1,5 +1,7 @@
 import type { SkillLevelType, UserStatus } from 'src/generated/prisma';
 
+import type { ProfileMusicTrack } from './profile-music.type';
+
 export interface UserProfileUserDetail {
   id: string;
   email: string | null;
@@ -10,9 +12,10 @@ export interface UserProfileUserDetail {
 export interface UserProfileDetail {
   nickname: string;
   selfDescription: string | null;
-  profileMusicUrl: string | null;
   avatarUrl: string | null;
 }
+
+export type { ProfileMusicTrack };
 
 export interface UserSkillDetail {
   skillTypeId: string;
@@ -29,6 +32,7 @@ export interface UserFavoriteGenreDetail {
 export interface GetUserProfileResult {
   user: UserProfileUserDetail;
   profile: UserProfileDetail | null;
+  profileMusic: ProfileMusicTrack | null;
   skills: UserSkillDetail[];
   favoriteGenres: UserFavoriteGenreDetail[];
 }

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -5,9 +5,11 @@ import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
 
 import { GetUsersQueryDto } from './dto/get-users-query.dto';
+import { SearchProfileMusicQueryDto } from './dto/search-profile-music-query.dto';
 import { UpdateUserProfileDto } from './dto/update-user-profile.dto';
 import { SelfUserGuard } from './guard/self-user.guard';
 import type { DeleteUserResult } from './repositoreis/user.repository';
+import type { DeleteProfileMusicResult, ProfileMusicTrack } from './types/profile-music.type';
 import type { GetUsersResult } from './types/user-list.type';
 import type { GetUserProfileResult } from './types/user-profile.type';
 import { UsersService } from './users.service';
@@ -24,6 +26,16 @@ export class UsersController {
   async getUsers(@Query() query: GetUsersQueryDto): Promise<ApiSuccessResponse<GetUsersResult>> {
     const result = await this.usersService.getUsers(query);
     return createSuccessResponse('유저 목록 조회 성공', result);
+  }
+
+  // profile-music/search는 :userId 라우트보다 위에 선언해야 NestJS가 profile-music을 userId로 오인하지 않는다
+  @Get('profile-music/search')
+  @ApiOperation({ summary: '프로필 음악 검색 (#68)' })
+  @ApiResponse({ status: 200, description: '프로필 음악 검색 성공' })
+  @ApiResponse({ status: 400, description: '검색어(q) 누락' })
+  async searchProfileMusic(@Query() query: SearchProfileMusicQueryDto): Promise<ApiSuccessResponse<{ items: ProfileMusicTrack[] }>> {
+    const result = await this.usersService.searchProfileMusic(query.q);
+    return createSuccessResponse('프로필 음악 검색 성공', result);
   }
 
   @Get(':userId/profiles')
@@ -50,6 +62,20 @@ export class UsersController {
   async deleteUser(@Param('userId', ParseUUIDPipe) userId: string): Promise<ApiSuccessResponse<DeleteUserResult>> {
     const result = await this.usersService.deleteUser(userId);
     return createSuccessResponse('회원 탈퇴가 완료되었습니다.', result);
+  }
+
+  @Delete(':userId/profile-music')
+  @UseGuards(AccessTokenGuard, SelfUserGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '프로필 음악 삭제 (#69)' })
+  @ApiParam({ name: 'userId', description: '유저 ID (UUID)', type: String })
+  @ApiResponse({ status: 200, description: '프로필 음악 삭제 성공' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  @ApiResponse({ status: 403, description: '본인 프로필 음악만 삭제 가능' })
+  @ApiResponse({ status: 404, description: '프로필 음악이 존재하지 않음' })
+  async deleteProfileMusic(@Param('userId', ParseUUIDPipe) userId: string): Promise<ApiSuccessResponse<DeleteProfileMusicResult>> {
+    const result = await this.usersService.deleteProfileMusic(userId);
+    return createSuccessResponse('프로필 음악 삭제 성공', result);
   }
 
   @Patch(':userId/profiles')

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -70,6 +70,7 @@ export class UsersController {
   @ApiOperation({ summary: '프로필 음악 삭제 (#69)' })
   @ApiParam({ name: 'userId', description: '유저 ID (UUID)', type: String })
   @ApiResponse({ status: 200, description: '프로필 음악 삭제 성공' })
+  @ApiResponse({ status: 400, description: 'userId가 UUID 형식이 아님' })
   @ApiResponse({ status: 401, description: '인증 실패' })
   @ApiResponse({ status: 403, description: '본인 프로필 음악만 삭제 가능' })
   @ApiResponse({ status: 404, description: '프로필 음악이 존재하지 않음' })

--- a/backend/src/modules/users/users.module.ts
+++ b/backend/src/modules/users/users.module.ts
@@ -1,10 +1,13 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { AuthModule } from 'src/auth/auth.module';
+import { DeezerTrackClient } from 'src/modules/songs/deezer-track.client';
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 
 import { SelfUserGuard } from './guard/self-user.guard';
+import { ProfileMusicPrismaRepository } from './repositoreis/profile-music.prisma-repository';
+import { PROFILE_MUSIC_REPOSITORY } from './repositoreis/profile-music.repository';
 import { UsersPrismaRepository } from './repositoreis/user.prisma-repository';
 import { USERS_REPOSITORY } from './repositoreis/user.repository';
 import { UsersController } from './users.controller';
@@ -17,10 +20,9 @@ import { UsersService } from './users.service';
     UsersService,
     AccessTokenGuard,
     SelfUserGuard,
-    {
-      provide: USERS_REPOSITORY,
-      useClass: UsersPrismaRepository,
-    },
+    DeezerTrackClient,
+    { provide: USERS_REPOSITORY, useClass: UsersPrismaRepository },
+    { provide: PROFILE_MUSIC_REPOSITORY, useClass: ProfileMusicPrismaRepository },
   ],
   exports: [UsersService],
 })

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -1,19 +1,36 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import type { Prisma, User } from 'src/generated/prisma';
+import { DeezerTrackClient } from 'src/modules/songs/deezer-track.client';
+import type { DeezerTrackApiResponse } from 'src/modules/songs/types/deezer-track-api-response.type';
 
 import type { GetUsersQuery } from './dto/get-users-query.dto';
+import { PROFILE_MUSIC_REPOSITORY, type ProfileMusicRepository } from './repositoreis/profile-music.repository';
 import type { UsersRepository } from './repositoreis/user.repository';
 import { USERS_REPOSITORY } from './repositoreis/user.repository';
+import type { DeleteProfileMusicResult, ProfileMusicTrack } from './types/profile-music.type';
 import type { GetUsersResult } from './types/user-list.type';
 import type { GetUserProfileResult } from './types/user-profile.type';
 import { UsersService } from './users.service';
 
 const mockUser = { id: 'user-001', email: 'test@example.com' };
 
+const mockProfileMusic: ProfileMusicTrack = {
+  externalTrackId: '12345',
+  sourceType: 'DEEZER',
+  title: 'Blinding Lights',
+  artistName: 'The Weeknd',
+  albumName: 'After Hours',
+  albumImageUrl: null,
+  durationMs: 200000,
+  previewUrl: null,
+  sourceUrl: 'https://www.deezer.com/track/12345',
+};
+
 const mockProfile: GetUserProfileResult = {
   user: { id: 'user-001', email: 'test@example.com', status: 'ACTIVE', createdAt: '2026-01-01T00:00:00.000Z' },
-  profile: { nickname: 'testuser', selfDescription: null, profileMusicUrl: null, avatarUrl: null },
+  profile: { nickname: 'testuser', selfDescription: null, avatarUrl: null },
+  profileMusic: null,
   skills: [],
   favoriteGenres: [],
 };
@@ -26,6 +43,17 @@ const mockListResult: GetUsersResult = {
 };
 
 const mockDeleteResult = { userId: 'user-001', deletedAt: '2026-06-25T00:00:00.000Z' };
+const mockDeleteProfileMusicResult: DeleteProfileMusicResult = { userId: 'user-001', deletedAt: '2026-06-26T00:00:00.000Z' };
+
+const mockDeezerTrack: DeezerTrackApiResponse = {
+  id: 12345,
+  title: 'Blinding Lights',
+  duration: 200,
+  link: 'https://www.deezer.com/track/12345',
+  preview: null,
+  artist: { name: 'The Weeknd' },
+  album: { title: 'After Hours', cover: '', cover_medium: '', cover_big: '', cover_xl: '' },
+};
 
 const repositoryStub: UsersRepository = {
   async findByEmail(email) {
@@ -54,12 +82,35 @@ const repositoryStub: UsersRepository = {
   },
 };
 
+const profileMusicRepositoryStub: ProfileMusicRepository = {
+  async findByUserId(userId) {
+    return userId === 'user-001' ? mockProfileMusic : null;
+  },
+  async upsertByUserId(_userId, trackData) {
+    return trackData;
+  },
+  async deleteByUserId(userId) {
+    return userId === 'user-001' ? mockDeleteProfileMusicResult : null;
+  },
+};
+
+const deezerTrackClientStub = {
+  async searchTracks(_query: string): Promise<DeezerTrackApiResponse[]> {
+    return [mockDeezerTrack];
+  },
+};
+
 describe('UsersService', () => {
   let service: UsersService;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      providers: [UsersService, { provide: USERS_REPOSITORY, useValue: repositoryStub }],
+      providers: [
+        UsersService,
+        { provide: USERS_REPOSITORY, useValue: repositoryStub },
+        { provide: PROFILE_MUSIC_REPOSITORY, useValue: profileMusicRepositoryStub },
+        { provide: DeezerTrackClient, useValue: deezerTrackClientStub },
+      ],
     }).compile();
 
     service = module.get(UsersService);
@@ -156,6 +207,42 @@ describe('UsersService', () => {
       const deleteSpy = jest.spyOn(repositoryStub, 'softDeleteUser');
 
       await service.deleteUser('user-001', txClient);
+
+      expect(deleteSpy).toHaveBeenCalledWith('user-001', txClient);
+      deleteSpy.mockRestore();
+    });
+  });
+
+  describe('searchProfileMusic', () => {
+    it('Deezer 검색 결과를 ProfileMusicTrack 목록으로 반환한다', async () => {
+      const result = await service.searchProfileMusic('Blinding Lights');
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].externalTrackId).toBe('12345');
+      expect(result.items[0].sourceType).toBe('DEEZER');
+    });
+
+    it('Deezer API 실패 시 에러가 그대로 전파된다', async () => {
+      jest.spyOn(deezerTrackClientStub, 'searchTracks').mockRejectedValueOnce(new Error('Deezer 장애'));
+      await expect(service.searchProfileMusic('query')).rejects.toThrow('Deezer 장애');
+    });
+  });
+
+  describe('deleteProfileMusic', () => {
+    it('프로필 음악이 존재하면 삭제 결과를 반환한다', async () => {
+      const result = await service.deleteProfileMusic('user-001');
+      expect(result.userId).toBe('user-001');
+      expect(result.deletedAt).toBeDefined();
+    });
+
+    it('프로필 음악이 없으면 NotFoundException을 던진다', async () => {
+      await expect(service.deleteProfileMusic('unknown-id')).rejects.toThrow(NotFoundException);
+    });
+
+    it('tx가 전달되면 deleteByUserId에 동일한 tx를 전달한다', async () => {
+      const txClient = {} as Prisma.TransactionClient;
+      const deleteSpy = jest.spyOn(profileMusicRepositoryStub, 'deleteByUserId');
+
+      await service.deleteProfileMusic('user-001', txClient);
 
       expect(deleteSpy).toHaveBeenCalledWith('user-001', txClient);
       deleteSpy.mockRestore();

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -1,13 +1,11 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { Test } from '@nestjs/testing';
 import type { Prisma, User } from 'src/generated/prisma';
-import { DeezerTrackClient } from 'src/modules/songs/deezer-track.client';
+import type { DeezerTrackClient } from 'src/modules/songs/deezer-track.client';
 import type { DeezerTrackApiResponse } from 'src/modules/songs/types/deezer-track-api-response.type';
 
 import type { GetUsersQuery } from './dto/get-users-query.dto';
-import { PROFILE_MUSIC_REPOSITORY, type ProfileMusicRepository } from './repositoreis/profile-music.repository';
+import type { ProfileMusicRepository } from './repositoreis/profile-music.repository';
 import type { UsersRepository } from './repositoreis/user.repository';
-import { USERS_REPOSITORY } from './repositoreis/user.repository';
 import type { DeleteProfileMusicResult, ProfileMusicTrack } from './types/profile-music.type';
 import type { GetUsersResult } from './types/user-list.type';
 import type { GetUserProfileResult } from './types/user-profile.type';
@@ -103,17 +101,8 @@ const deezerTrackClientStub = {
 describe('UsersService', () => {
   let service: UsersService;
 
-  beforeEach(async () => {
-    const module = await Test.createTestingModule({
-      providers: [
-        UsersService,
-        { provide: USERS_REPOSITORY, useValue: repositoryStub },
-        { provide: PROFILE_MUSIC_REPOSITORY, useValue: profileMusicRepositoryStub },
-        { provide: DeezerTrackClient, useValue: deezerTrackClientStub },
-      ],
-    }).compile();
-
-    service = module.get(UsersService);
+  beforeEach(() => {
+    service = new UsersService(repositoryStub, profileMusicRepositoryStub, deezerTrackClientStub as unknown as DeezerTrackClient);
   });
 
   describe('getUserByEmail', () => {

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -1,15 +1,37 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma } from 'src/generated/prisma';
+import { DeezerTrackClient } from 'src/modules/songs/deezer-track.client';
+import type { DeezerTrackApiResponse } from 'src/modules/songs/types/deezer-track-api-response.type';
 
 import type { GetUsersQuery } from './dto/get-users-query.dto';
 import type { UpdateUserProfileData } from './dto/update-user-profile.dto';
+import { PROFILE_MUSIC_REPOSITORY, ProfileMusicRepository } from './repositoreis/profile-music.repository';
 import { USERS_REPOSITORY, UsersRepository } from './repositoreis/user.repository';
+import type { DeleteProfileMusicResult, ProfileMusicTrack } from './types/profile-music.type';
+
+function toDeezerProfileMusicTrack(track: DeezerTrackApiResponse): ProfileMusicTrack {
+  return {
+    externalTrackId: String(track.id),
+    sourceType: 'DEEZER',
+    title: track.title,
+    artistName: track.artist.name,
+    albumName: track.album.title,
+    albumImageUrl: track.album.cover_xl || track.album.cover_big || track.album.cover_medium || track.album.cover || null,
+    durationMs: track.duration * 1000,
+    previewUrl: track.preview,
+    sourceUrl: track.link,
+  };
+}
 
 @Injectable()
 export class UsersService {
   constructor(
     @Inject(USERS_REPOSITORY)
     private readonly usersRepository: UsersRepository,
+    @Inject(PROFILE_MUSIC_REPOSITORY)
+    private readonly profileMusicRepository: ProfileMusicRepository,
+    @Inject(DeezerTrackClient)
+    private readonly deezerTrackClient: DeezerTrackClient,
   ) {}
 
   async getUserByEmail(email: string, tx?: Prisma.TransactionClient) {
@@ -52,6 +74,26 @@ export class UsersService {
     const result = await this.usersRepository.softDeleteUser(userId, tx);
     if (!result) {
       throw new NotFoundException('존재하지 않는 유저입니다.');
+    }
+    return result;
+  }
+
+  /**
+   * Deezer에서 트랙을 검색하여 프로필 음악 후보 목록을 반환한다.
+   */
+  async searchProfileMusic(query: string): Promise<{ items: ProfileMusicTrack[] }> {
+    const tracks = await this.deezerTrackClient.searchTracks(query);
+    return { items: tracks.map(toDeezerProfileMusicTrack) };
+  }
+
+  /**
+   * 유저의 프로필 음악을 삭제한다.
+   * 존재하지 않으면 NotFoundException을 던진다.
+   */
+  async deleteProfileMusic(userId: string, tx?: Prisma.TransactionClient): Promise<DeleteProfileMusicResult> {
+    const result = await this.profileMusicRepository.deleteByUserId(userId, tx);
+    if (!result) {
+      throw new NotFoundException('프로필 음악이 존재하지 않습니다.');
     }
     return result;
   }


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 30~40분

<br/>

## 📌 작업 요약

`UserProfile.profileMusicUrl`을 제거하고 별도 `ProfileMusic` 테이블(JSONB)로 분리,
프로필 음악 검색(#68)·삭제(#69) API 신규 추가 및 조회/수정(#3, #5) 응답 변경.

<br/>

## 📝 작업 내용

1. Prisma 스키마 변경: `ProfileMusic` 테이블 신규 추가 (`userId` UNIQUE FK, `trackData` JSONB), `profileMusicUrl` 제거
2. `ProfileMusicRepository` 인터페이스 및 `ProfileMusicPrismaRepository` 구현체 추가 (`findByUserId` / `upsertByUserId` / `deleteByUserId`)
3. **#68** `GET /users/profile-music/search` — Deezer 검색 결과를 `ProfileMusicTrack` 목록으로 반환 (공개)
4. **#69** `DELETE /users/:userId/profile-music` — 프로필 음악 삭제, 없으면 404
5. **#5** `PATCH /users/:userId/profiles` — `profileMusic` 전달 시 upsert, `null`·미전달 시 변경 없음
6. **#3** `GET /users/:userId/profiles` — `profileMusic` 객체 포함 반환
7. `songs` 모듈의 임시 `GET /songs/deezer/tracks/search` 제거 (#68로 대체)

<br/>

## 🚨 주요 고민 및 해결 과정

### 문제 1 — inline 컬럼 vs JSONB

기존 `feat/profile-music-metadata` 브랜치는 `UserProfile`에 9개 inline 컬럼으로 구현했으나, `UserProfile`과 음악 메타데이터의 관심사가 달라 별도 테이블이 적합하다고 판단.

### 해결 과정

별도 `ProfileMusic` 테이블 + `trackData JSONB`로 설계. 1:1 관계이므로 JOIN 비용은 동일하나 `UserProfile` 스키마가 단순해지고 음악 데이터 구조 변경 시 마이그레이션 없이 대응 가능.

### 문제 2 — Repository 간 의존성

`PATCH /profile`에서 `userProfile`과 `profileMusic`을 같은 트랜잭션으로 처리해야 하는데, `UsersPrismaRepository`가 `ProfileMusicRepository`를 주입받으면 Repository→Repository 의존이 발생.

### 해결 과정

`UsersPrismaRepository.updateUserProfile` 내부에서 동일 `tx` client로 `client.profileMusic.upsert`를 직접 호출하는 방식으로 해결. `ProfileMusicRepository`는 독립적인 단일 책임만 유지.

### 문제 3 — Prisma Json 타입 캐스팅

Prisma의 `Json` 타입은 TypeScript 타입과 직접 할당이 불가.

### 해결 과정

`as unknown as ProfileMusicTrack` / `as unknown as Prisma.InputJsonValue` 이중 캐스팅 패턴 적용.

<br/>

## 💬 리뷰 요구사항

- `user.prisma-repository.ts` `updateUserProfile` 내 `client.profileMusic.upsert` 직접 호출 방식이 적절한지 (Repository 경계 측면)
- `profileMusic: null` 전달 시 삭제하지 않는 정책이 클라이언트 요구사항과 일치하는지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 프로필 음악을 별도 트랙 정보로 조회·수정할 수 있게 되었습니다.
  * 사용자 프로필에서 음악 검색과 삭제가 가능해졌습니다.
  * 음악 검색 결과와 프로필 응답 형식이 더 상세한 트랙 정보로 개선되었습니다.

* **Bug Fixes**
  * 프로필 음악 삭제가 일반 수정 흐름과 분리되어, 삭제 동작이 더 명확해졌습니다.
  * 프로필 조회/수정 시 음악 정보 처리 방식이 일관되게 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->