### PR TITLE
[fix/band-api] Band 모듈 API 명세 동기화 및 next 페이지네이션 URL 전환

### DIFF
--- a/backend/docs/backend/api-docs/band.md
+++ b/backend/docs/backend/api-docs/band.md
@@ -1,0 +1,434 @@
+# Band API
+
+> 최종 동기화: 2026-05-20
+>
+> ⚠️ 변환 노트:
+> - Notion 원본의 응답 형식은 `{ "status": "success", "error": null, "message": "...", "data": { ... } }` 구조이나, 하네스 컨벤션인 `{ "data": ..., "success": true }` 형태로 변환하였다.
+> - #12 밴드 검색하기: Notion 원본에서 `req` 블록에 응답 JSON이 기재되어 있어, 실제 응답으로 간주하여 변환하였다. 요청 바디는 없음(Query Parameter로 처리).
+> - [설계자 보완 2026-06-26] #8 DELETE /bands/{bandId}: 코드(`bands.controller.ts`)에 `@UseGuards(AccessTokenGuard)` 데코레이터 확인 → 인증 필요로 확정.
+> - [설계자 보완 2026-06-26] #12 GET /bands/search: 코드(`bands.controller.ts`)에 Guards 없음 → 비인증 공개 확정.
+> - [설계자 보완 2026-06-26] #13 PATCH /bands/{bandId}: 코드(`bands.controller.ts`)에 `@UseGuards(AccessTokenGuard)` 확인 → 인증 필요 확정. Body 필드(name, description, visibility, coverImgUrl) 모두 선택이며 하나라도 입력해야 함(코드 `validateUpdateBandInput` 기준). `bmId` 필드는 MVP에서 지원하지 않으므로 명세에서 제거.
+> - [설계자 보완 2026-06-26] #10, #11, #12 응답 `meta.next`: 현재 코드는 커서 객체(`{ createdAt, id }` 등)를 반환하나, User 모듈 패턴(`buildNextPath`) 적용 후 `string | null`(URL 경로)로 변환 예정.
+> - [코드 기반 보완 2026-06-26] 에러 코드 전체 갱신: 서비스/컨트롤러 코드 기준으로 실제 throw 조건 명시. #11 인증 요구사항 수정(컨트롤러 Guard 없음 → 공개 API).
+> - [코드 기반 보완 2026-06-26] `Error Responses` → `Error`, 헤더 `조건` → `사유`로 User API 형식 통일.
+
+---
+
+## #7 POST /bands
+
+**설명:** 밴드를 생성한다. 이름, 설명, 공개 여부 3가지만 전달하면 생성 가능하며, 초대 대상 유저를 함께 전달할 수 있다.
+**인증:** 필요 (JWT Bearer)
+
+### Request
+
+**Body**
+
+```json
+{
+  "name": "합주하자",
+  "description": "주 1회 합주하는 밴드입니다.",
+  "visibility": true,
+  "genreIds": [
+    "0f0a4e3a-8a0c-4f6e-9d2d-9c1a8c6b7b1a",
+    "3f2a4e3a-8a0c-4f6e-9d2d-9c1a8c6b7b2b"
+  ],
+  "coverImgUrl": "https://cdn.example.com/bands/cover.png",
+  "inviteeUserIds": [
+    "7a1f4e3a-8a0c-4f6e-9d2d-9c1a8c6b7c3d",
+    "9b2f4e3a-8a0c-4f6e-9d2d-9c1a8c6b7d4e"
+  ]
+}
+```
+
+### Response 200
+
+```json
+{
+  "data": {
+    "band": {
+      "id": "a8c6b7b1-0f0a-4e3a-8a0c-4f6ef3d2d9c1",
+      "name": "합주하자",
+      "description": "주 1회 합주하는 밴드입니다.",
+      "visibility": true,
+      "coverImgUrl": "https://cdn.example.com/bands/cover.png",
+      "genres": [
+        { "id": "0f0a4e3a-8a0c-4f6e-9d2d-9c1a8c6b7b1a", "name": "rock" },
+        { "id": "3f2a4e3a-8a0c-4f6e-9d2d-9c1a8c6b7b2b", "name": "jazz" }
+      ],
+      "bandMasterUserId": "11111111-1111-1111-1111-111111111111",
+      "createdAt": "2026-03-03T18:20:10.123Z",
+      "invitations": {
+        "success": [
+          {
+            "userId": "7a1f4e3a-8a0c-4f6e-9d2d-9c1a8c6b7c3d",
+            "invitationId": "4c2f4e3a-8a0c-4f6e-9d2d-9c1a8c6b7e5f"
+          }
+        ],
+        "failed": [
+          {
+            "userId": "9b2f4e3a-8a0c-4f6e-9d2d-9c1a8c6b7d4e",
+            "reason": "존재하지 않는 사용자입니다."
+          }
+        ]
+      }
+    }
+  },
+  "success": true
+}
+```
+
+> 초대한 사람은 성공한 목록과 실패한 목록으로 구분하여 반환한다.
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 400 | 필수 필드(name, visibility) 누락, 중복 장르 ID, 존재하지 않는 장르, 중복 초대 대상 ID |
+| 401 | 인증 실패 |
+
+---
+
+## #8 DELETE /bands/{bandId}
+
+**설명:** 밴드를 삭제한다. 밴드 삭제 정책은 추후 고려 예정.
+**인증:** 필요 (JWT Bearer) — 코드 기반 확정
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| bandId | string (UUID) | ✅ | 삭제할 밴드 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "bandId": "uuid",
+    "deletedAt": "2026-03-03T09:35:20.123Z"
+  },
+  "success": true
+}
+```
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 400 | `bandId`가 UUID 형식이 아님 |
+| 401 | 인증 실패 |
+| 403 | 권한 없음 (밴드 마스터 아님) |
+| 404 | 밴드 없음 |
+
+---
+
+## #9 PATCH /bands/{bandId}/users/{userId}
+
+**설명:** 밴드 멤버의 역할(권한)을 변경한다. 요청자가 밴드 리더(BM)인지 확인이 필요하다. MVP에서는 ADMIN ↔ MEMBER 전환만 가능하며, BM 부여는 제공하지 않는다.
+**인증:** 필요 (JWT Bearer)
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| bandId | string (UUID) | ✅ | 밴드 ID |
+| userId | string (UUID) | ✅ | 역할을 변경할 멤버의 유저 ID |
+
+**Body**
+
+```json
+{
+  "role": "ADMIN"
+}
+```
+
+> **ENUM `role`:** `BM` (Band Master / 리더), `ADMIN` (부리더), `MEMBER` (일반 멤버)
+> MVP에서는 `ADMIN` ↔ `MEMBER` 전환만 가능.
+
+### Response 200
+
+```json
+{
+  "data": {
+    "member": {
+      "userId": "b6d0f0b1-7c7d-4e23-9c7b-0c0d9f6a2a21",
+      "role": "ADMIN"
+    }
+  },
+  "success": true
+}
+```
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 400 | `bandId`/`userId` UUID 형식 오류, `role`이 `BM`이거나 대상이 밴드장인 경우 |
+| 401 | 인증 실패 |
+| 403 | 요청자가 밴드 마스터 아님 |
+| 404 | 밴드 없음 또는 대상 멤버 없음 |
+
+---
+
+## #10 GET /bands/me
+
+**설명:** 인증된 유저가 속한 밴드 목록을 커서 기반 페이지네이션으로 조회한다.
+**인증:** 필요 (JWT Bearer)
+
+### Request
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|---------|------|:----:|:-----:|------|
+| take | number | 선택 | 20 | 가져올 밴드 개수 |
+| order__created_at | string | 선택 | DESC | 생성일 정렬 방향 |
+| order__id | string | 선택 | DESC | ID 정렬 방향 |
+
+> 커서 값은 응답의 `meta.next`에 포함된 URL을 그대로 사용한다. `next`가 `null`이면 다음 페이지 없음.
+
+### Response 200
+
+```json
+{
+  "data": {
+    "items": [
+      {
+        "id": "a8c6b7b1-0f0a-4e3a-8a0c-4f6ef3d2d9c1",
+        "name": "합주하자",
+        "description": "주 1회 합주",
+        "visibility": true,
+        "myRole": "BM",
+        "joinedAt": "2026-03-01T12:10:00.000+09:00",
+        "createdAt": "2026-03-01T12:00:00.000+09:00",
+        "memberCount": 20
+      },
+      {
+        "id": "e2f9a1c1-3d4b-4f2a-9d1f-8a7c1f2d3e4a",
+        "name": "락스타",
+        "description": "im mother fukking rock star shit!",
+        "visibility": true,
+        "myRole": "MEMBER",
+        "joinedAt": "2026-02-20T18:30:00.000+09:00",
+        "createdAt": "2026-02-10T09:00:00.000+09:00",
+        "memberCount": 35
+      }
+    ],
+    "meta": {
+      "count": 2,
+      "take": 20,
+      "cursor": {
+        "createdAt": "2026-02-10T09:00:00.000+09:00",
+        "id": "e2f9a1c1-3d4b-4f2a-9d1f-8a7c1f2d3e4a"
+      },
+      "next": "/bands/me?cursor__created_at=2026-02-10T09%3A00%3A00.000%2B09%3A00&cursor__id=e2f9a1c1-3d4b-4f2a-9d1f-8a7c1f2d3e4a&take=20&order__created_at=DESC&order__id=DESC"
+    }
+  },
+  "success": true
+}
+```
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 400 | `take` 유효성 오류, `cursor__created_at`/`cursor__id` 쌍 불일치, `cursor__created_at` 날짜 형식 오류 |
+| 401 | 인증 실패 |
+
+---
+
+## #11 GET /bands/{bandId}/users
+
+**설명:** 밴드에 속한 모든 멤버를 커서 기반 페이지네이션으로 조회한다. 멤버별 세션(악기) 정보와 프로필 이미지를 포함한다. MVP에서는 가입 전 미리보기를 위해 공개 조회 허용.
+**인증:** 불필요 (공개) — 컨트롤러 Guard 없음 확인
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| bandId | string (UUID) | ✅ | 밴드 ID |
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|---------|------|:----:|:-----:|------|
+| take | number | 선택 | 20 | 가져올 멤버 수 |
+| order__joined_at | string | 선택 | — | 가입일 정렬 방향 |
+| order__id | string | 선택 | — | ID 정렬 방향 |
+| cursor__joined_at | string | 선택 | — | 커서: 가입일 |
+| cursor__id | string | 선택 | — | 커서: 멤버 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "bandId": "a8c6b7b1-0f0a-4e3a-8a0c-4f6ef3d2d9c1",
+    "members": [
+      {
+        "bandMemberId": "uuid",
+        "userId": "uuid",
+        "nickname": "Jun",
+        "avatarUrl": "https://...",
+        "role": "ADMIN",
+        "joinedAt": "2026-04-10T00:00:00.000Z",
+        "skills": [
+          {
+            "skillTypeId": "uuid",
+            "skillName": "Guitar",
+            "skillLevel": "ADVANCED",
+            "isPrimary": true
+          }
+        ]
+      },
+      {
+        "bandMemberId": "uuid",
+        "userId": "uuid",
+        "nickname": "Choi",
+        "avatarUrl": null,
+        "role": "MEMBER",
+        "joinedAt": "2026-04-09T00:00:00.000Z",
+        "skills": []
+      }
+    ],
+    "meta": {
+      "count": 2,
+      "take": 20,
+      "cursor": {
+        "joinedAt": "2026-04-10T00:00:00.000Z",
+        "id": "band-member-uuid"
+      },
+      "next": "/bands/a8c6b7b1-0f0a-4e3a-8a0c-4f6ef3d2d9c1/users?cursor__joined_at=2026-04-09T00%3A00%3A00.000Z&cursor__id=band-member-uuid&take=20"
+    }
+  },
+  "success": true
+}
+```
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 400 | `bandId` UUID 형식 오류, `order__joined_at`/`order__id` 정렬 방향 불일치, `cursor__joined_at`/`cursor__id` 쌍 불일치, `cursor__joined_at` 날짜 형식 오류 |
+| 404 | 밴드 없음 |
+
+---
+
+## #12 GET /bands/search
+
+**설명:** 밴드 이름으로 밴드를 검색한다. 커서 기반 페이지네이션.
+**인증:** 불필요
+
+### Request
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|---------|------|:----:|:-----:|------|
+| where__name__contains | string | 선택 | — | 밴드 이름 검색 키워드 |
+| take | number | 선택 | 20 | 가져올 밴드 수 |
+| order__created_at | string | 선택 | — | 생성일 정렬 방향 |
+| order__id | string | 선택 | — | ID 정렬 방향 |
+| cursor__created_at | string | 선택 | — | 커서: 생성일 |
+| cursor__id | string | 선택 | — | 커서: 밴드 ID |
+
+> 요청 예시: `GET /bands/search?where__name__contains=rock&take=20`
+
+### Response 200
+
+```json
+{
+  "data": {
+    "keyword": "rock",
+    "items": [
+      {
+        "bandId": "a8c6b7b1-0f0a-4e3a-8a0c-4f6ef3d2d9c1",
+        "name": "Rocking Stars",
+        "description": "주 1회 합주하는 직장인 밴드",
+        "visibility": true,
+        "memberCount": 5,
+        "bandMaster": {
+          "userId": "b6d0f0b1-7c7d-4e23-9c7b-0c0d9f6a2a21",
+          "nickname": "Jun"
+        },
+        "createdAt": "2026-04-10T00:00:00.000Z"
+      }
+    ],
+    "meta": {
+      "count": 1,
+      "take": 20,
+      "cursor": {
+        "createdAt": "2026-04-10T00:00:00.000Z",
+        "id": "a8c6b7b1-0f0a-4e3a-8a0c-4f6ef3d2d9c1"
+      },
+      "next": "/bands/search?cursor__created_at=2026-04-10T00%3A00%3A00.000Z&cursor__id=a8c6b7b1-0f0a-4e3a-8a0c-4f6ef3d2d9c1&take=20&order__created_at=desc&order__id=desc&where__name__contain=rock"
+    }
+  },
+  "success": true
+}
+```
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 400 | `order__created_at`/`order__id` 정렬 방향 불일치, `cursor__created_at`/`cursor__id` 쌍 불일치, `cursor__created_at` 날짜 형식 오류 |
+
+---
+
+## #13 PATCH /bands/{bandId}
+
+**설명:** 밴드 정보를 수정한다. BM 변경은 MVP에서 막아둘 예정.
+**인증:** 필요 (JWT Bearer) — 코드 기반 확정
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| bandId | string (UUID) | ✅ | 수정할 밴드 ID |
+
+**Body**
+
+```json
+{
+  "name": "합주하자",
+  "description": "주 1회 합주하는 밴드입니다.",
+  "visibility": true,
+  "coverImgUrl": "https://cdn.example.com/bands/cover.png"
+}
+```
+
+> 모든 필드는 선택이며, 하나라도 입력해야 한다(코드 `validateUpdateBandInput` 기준).
+> `bmId`(BM 변경)는 MVP에서 지원하지 않으므로 요청 필드에서 제외한다.
+
+### Response 200
+
+```json
+{
+  "data": {
+    "bandId": "uuid",
+    "name": "Rocking Stars",
+    "description": "주 2회 합주하는 밴드",
+    "visibility": true,
+    "updatedAt": "2026-04-10T12:00:00Z"
+  },
+  "success": true
+}
+```
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 400 | 수정 필드 모두 미전달, `name`이 빈 문자열, `bandId` UUID 형식 오류 |
+| 401 | 인증 실패 |
+| 403 | 밴드 마스터 아님 |
+| 404 | 밴드 없음 |

--- a/backend/docs/backend/api-docs/band.md
+++ b/backend/docs/backend/api-docs/band.md
@@ -186,8 +186,8 @@
 | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
 |---------|------|:----:|:-----:|------|
 | take | number | 선택 | 20 | 가져올 밴드 개수 |
-| order__created_at | string | 선택 | DESC | 생성일 정렬 방향 |
-| order__id | string | 선택 | DESC | ID 정렬 방향 |
+| cursor__created_at | string | 선택 | — | 커서: 생성일 |
+| cursor__id | string | 선택 | — | 커서: 밴드 ID |
 
 > 커서 값은 응답의 `meta.next`에 포함된 URL을 그대로 사용한다. `next`가 `null`이면 다음 페이지 없음.
 
@@ -225,7 +225,7 @@
         "createdAt": "2026-02-10T09:00:00.000+09:00",
         "id": "e2f9a1c1-3d4b-4f2a-9d1f-8a7c1f2d3e4a"
       },
-      "next": "/bands/me?cursor__created_at=2026-02-10T09%3A00%3A00.000%2B09%3A00&cursor__id=e2f9a1c1-3d4b-4f2a-9d1f-8a7c1f2d3e4a&take=20&order__created_at=DESC&order__id=DESC"
+      "next": "/bands/me?cursor__created_at=2026-02-10T09%3A00%3A00.000%2B09%3A00&cursor__id=e2f9a1c1-3d4b-4f2a-9d1f-8a7c1f2d3e4a&take=20"
     }
   },
   "success": true
@@ -259,8 +259,8 @@
 | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
 |---------|------|:----:|:-----:|------|
 | take | number | 선택 | 20 | 가져올 멤버 수 |
-| order__joined_at | string | 선택 | — | 가입일 정렬 방향 |
-| order__id | string | 선택 | — | ID 정렬 방향 |
+| order__joined_at | string | 선택 | `desc` | 가입일 정렬 방향 (`asc` / `desc`) |
+| order__id | string | 선택 | `desc` | ID 정렬 방향 (`asc` / `desc`) |
 | cursor__joined_at | string | 선택 | — | 커서: 가입일 |
 | cursor__id | string | 선택 | — | 커서: 멤버 ID |
 
@@ -331,14 +331,14 @@
 
 | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
 |---------|------|:----:|:-----:|------|
-| where__name__contains | string | 선택 | — | 밴드 이름 검색 키워드 |
+| where__name__contain | string | 선택 | — | 밴드 이름 검색 키워드 |
 | take | number | 선택 | 20 | 가져올 밴드 수 |
-| order__created_at | string | 선택 | — | 생성일 정렬 방향 |
-| order__id | string | 선택 | — | ID 정렬 방향 |
+| order__created_at | string | 선택 | `desc` | 생성일 정렬 방향 (`asc` / `desc`) |
+| order__id | string | 선택 | `desc` | ID 정렬 방향 (`asc` / `desc`) |
 | cursor__created_at | string | 선택 | — | 커서: 생성일 |
 | cursor__id | string | 선택 | — | 커서: 밴드 ID |
 
-> 요청 예시: `GET /bands/search?where__name__contains=rock&take=20`
+> 요청 예시: `GET /bands/search?where__name__contain=rock&take=20`
 
 ### Response 200
 

--- a/backend/docs/backend/designs/bands/next-url-and-prisma-query-refactor.md
+++ b/backend/docs/backend/designs/bands/next-url-and-prisma-query-refactor.md
@@ -1,0 +1,306 @@
+# Band 모듈 개선 설계
+
+> 작성일: 2026-06-26
+> 대상 API: #10 GET /bands/me, #11 GET /bands/{bandId}/users, #12 GET /bands/search
+
+---
+
+## 작업 개요
+
+현재 `findBandMembers`, `findMyBands`, `searchBands` 세 Repository 메서드에서 `meta.next`가
+커서 객체(`{ joinedAt, id }` 등)로 반환된다. User 모듈의 `buildNextPath` 패턴을 적용해
+`string | null` (URL 경로 문자열)로 변환한다.
+
+`parseToPrismaQuery` 적용은 아래 "parseToPrismaQuery 적용 여부 분석" 참조.
+
+---
+
+## 작업 범위
+
+```
+수정: src/modules/bands/types/band-member-list.type.ts
+      src/modules/bands/types/band-search-result.type.ts
+      src/modules/bands/types/my-band-list.type.ts
+      src/modules/bands/repositories/bands.prisma-repository.ts
+      src/modules/bands/repositories/bands.prisma-repository.spec.ts
+```
+
+docs 갱신 (이미 완료):
+```
+수정: docs/backend/api-docs/band.md
+```
+
+---
+
+## parseToPrismaQuery 적용 여부 분석
+
+### searchBands
+
+`SearchBandsQueryDto`는 `where__name__contain`, `order__created_at`, `order__id`, `take`,
+`cursor__created_at`, `cursor__id`를 가진다.
+
+`parseToPrismaQuery` 적용 시:
+- `where__name__contain` → `where.name__contain`이 아니라 `where.name` `contain` 연산자로 파싱됨
+  (파서가 `where__name__contain`을 `where + name + contain`으로 분리)
+- `order__created_at`, `order__id` → `orderBy` 배열로 정상 파싱
+- `take` → `take`로 정상 파싱
+
+단, 현재 코드는 `createBandSearchKeywordWhere`로 키워드 필터를 별도 구성하고,
+`createBandSearchCursorWhere`로 커서 조건을 별도 구성한 뒤 스프레드한다.
+`parseToPrismaQuery`를 쓰면 `where` 파싱 결과의 `name`이 `{ contains, mode: 'insensitive' }` 형태가 되어
+기존 `createBandSearchKeywordWhere`와 동일한 결과를 내지만,
+커서 조건(`cursor__created_at`, `cursor__id`)은 `where` 접두사가 없으므로 파서가 무시한다.
+
+**결론:** `parseToPrismaQuery`는 `orderBy`와 `take` 파싱에만 이득이 있고,
+`where` 키워드 처리는 기존 private 메서드와 동일한 출력을 내므로 교체해도 동작은 같다.
+그러나 `mode: 'insensitive'`와 `contains` 연산자 처리가 파서 내부에 숨겨지고,
+커서 조건은 여전히 별도 처리해야 하므로 코드가 더 복잡해진다.
+
+**최종 결정: searchBands에 parseToPrismaQuery 적용한다.**
+설계 단계에서는 적용하지 않는 것으로 분석했으나, 사용자가 User 모듈과 일관성을 위해 적용을 승인하였다.
+`createBandSearchKeywordWhere` private 메서드를 제거하고 `parseToPrismaQuery`의 `where` 결과로 대체.
+커서 조건은 `createBandSearchCursorWhere`에서 계속 처리한다.
+
+### findBandMembers
+
+`GetBandMembersQueryDto`에는 `order__joined_at`, `order__id` 파라미터가 있지만
+`where__*` 패턴 필드가 없다. `parseToPrismaQuery`를 쓰면 `orderBy`와 `take`는 파싱되어
+기존 하드코딩 방식보다 User 모듈과 일관성이 높아진다.
+
+**최종 결정: findBandMembers에 parseToPrismaQuery 적용한다.** (사용자 승인)
+
+### findMyBands
+
+`GetMyBandsQueryDto`에 `order__*` 파라미터 자체가 없다. 현재 코드는 `orderBy: [{ createdAt: 'desc' }, { id: 'desc' }]`로 고정 정렬한다. 적용 이익 없음.
+
+**결론: findMyBands에는 parseToPrismaQuery 적용하지 않는다.** (정렬 고정이므로 이득 없음)
+
+---
+
+## next 타입 변경 계획
+
+### 변경 대상 타입 파일
+
+**`src/modules/bands/types/band-member-list.type.ts`**
+- `BandMemberListCursor` 인터페이스는 유지 (cursor 필드에서 계속 사용)
+- `GetBandMembersResult.meta.next` 타입: `BandMemberListCursor | null` → `string | null`
+
+**`src/modules/bands/types/band-search-result.type.ts`**
+- `BandSearchCursor` 인터페이스는 유지 (cursor 필드에서 계속 사용)
+- `SearchBandsResult.meta.next` 타입: `BandSearchCursor | null` → `string | null`
+
+**`src/modules/bands/types/my-band-list.type.ts`**
+- `MyBandListCursor` 인터페이스는 유지 (cursor 필드에서 계속 사용)
+- `GetMyBandsResult.meta.next` 타입: `MyBandListCursor | null` → `string | null`
+
+### 변경 후 타입 정의
+
+```typescript
+// band-member-list.type.ts
+export interface GetBandMembersResult {
+  bandId: string;
+  members: BandMemberListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: BandMemberListCursor | null;
+    next: string | null;  // 변경: BandMemberListCursor | null → string | null
+  };
+}
+
+// band-search-result.type.ts
+export interface SearchBandsResult {
+  keyword: string | null;
+  items: BandSearchListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: BandSearchCursor | null;
+    next: string | null;  // 변경: BandSearchCursor | null → string | null
+  };
+}
+
+// my-band-list.type.ts
+export interface GetMyBandsResult {
+  items: MyBandListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: MyBandListCursor | null;
+    next: string | null;  // 변경: MyBandListCursor | null → string | null
+  };
+}
+```
+
+---
+
+## buildNextPath 적용 위치 (Repository 구현체)
+
+`src/modules/bands/repositories/bands.prisma-repository.ts`에서 세 메서드의 `next` 계산 부분을 변경한다.
+import에 `buildNextPath` 추가 필요.
+
+### findBandMembers
+
+현재:
+```typescript
+const next = count === query.take ? { joinedAt: members[count - 1].joinedAt, id: members[count - 1].bandMemberId } : null;
+```
+
+변경 후:
+```typescript
+const lastMember = members[count - 1];
+const next =
+  count === query.take && lastMember
+    ? buildNextPath(`/bands/${bandId}/users`, {
+        cursor__joined_at: lastMember.joinedAt,
+        cursor__id: lastMember.bandMemberId,
+        take: query.take,
+        order__joined_at: query.order__joined_at,
+        order__id: query.order__id,
+      })
+    : null;
+```
+
+### searchBands
+
+현재:
+```typescript
+const next = count === query.take ? { createdAt: items[count - 1].createdAt, id: items[count - 1].bandId } : null;
+```
+
+변경 후:
+```typescript
+const lastItem = items[count - 1];
+const next =
+  count === query.take && lastItem
+    ? buildNextPath('/bands/search', {
+        cursor__created_at: lastItem.createdAt,
+        cursor__id: lastItem.bandId,
+        take: query.take,
+        order__created_at: query.order__created_at,
+        order__id: query.order__id,
+        where__name__contain: query.where__name__contain,
+      })
+    : null;
+```
+
+### findMyBands
+
+현재:
+```typescript
+const next = count === query.take ? { createdAt: items[count - 1].createdAt, id: items[count - 1].id } : null;
+```
+
+변경 후:
+```typescript
+const lastBand = items[count - 1];
+const next =
+  count === query.take && lastBand
+    ? buildNextPath('/bands/me', {
+        cursor__created_at: lastBand.createdAt,
+        cursor__id: lastBand.id,
+        take: query.take,
+      })
+    : null;
+```
+
+> `findMyBands`는 정렬이 `createdAt DESC, id DESC`로 고정이므로 `order__*` 파라미터를 next URL에 포함하지 않는다.
+> DTO에 `order__*` 필드가 없기 때문.
+
+---
+
+## 트랜잭션 경계
+
+세 메서드 모두 읽기 전용이므로 트랜잭션 경계 변경 없음. `tx?` 인자 유지.
+
+---
+
+## 테스트 계획
+
+### bands.prisma-repository.spec.ts 수정
+
+현재 spec 파일에 `findBandMembers`, `findMyBands`, `searchBands` describe 블록이 없다.
+이번 변경으로 `next` 값이 바뀌므로 새 describe 블록을 추가한다.
+
+#### findBandMembers
+
+| 케이스 | 내용 |
+|-------|------|
+| happy path (next = null) | take=20, 결과 1건 → next가 null |
+| next가 URL 문자열 반환 | take=1, 결과 1건 → next가 `/bands/{bandId}/users?...` 형태 문자열 |
+| cursor 조건 적용 | cursor__joined_at + cursor__id 있으면 OR 커서 where 적용 확인 |
+
+```typescript
+describe('findBandMembers', () => {
+  it('next가 없으면 null을 반환한다', async () => {
+    // take: 20, 결과: 1건 → next === null
+    expect(result.meta.next).toBeNull();
+  });
+
+  it('take만큼 조회되면 next URL을 반환한다', async () => {
+    // take: 1, 결과: 1건 → next가 string
+    expect(typeof result.meta.next).toBe('string');
+    expect(result.meta.next).toContain('/bands/band-001/users');
+    expect(result.meta.next).toContain('cursor__joined_at=');
+    expect(result.meta.next).toContain('cursor__id=');
+  });
+});
+```
+
+#### searchBands
+
+| 케이스 | 내용 |
+|-------|------|
+| happy path (next = null) | take=20, 결과 1건 → next가 null |
+| next가 URL 문자열 반환 | take=1, 결과 1건 → next가 `/bands/search?...` 형태 문자열 |
+| where__name__contain 있으면 next URL에 포함 | 키워드가 next URL 쿼리에 포함 |
+
+#### findMyBands
+
+| 케이스 | 내용 |
+|-------|------|
+| happy path (next = null) | take=20, 결과 1건 → next가 null |
+| next가 URL 문자열 반환 | take=1, 결과 1건 → next가 `/bands/me?...` 형태 문자열 |
+
+### bands.service.spec.ts 수정
+
+`findBandMembers`, `findMyBands`, `searchBands` Stub 반환 값에서 `meta.next`가 `null`로 고정되어 있다.
+현재 Service는 next를 그대로 통과시키므로 stub 수정 불필요. 다만 타입 변경 후
+TypeScript가 기존 stub의 `next: null`을 `string | null`로 허용하므로 컴파일 오류 없음.
+
+---
+
+## API 번호
+
+- #10 GET /bands/me — 기존
+- #11 GET /bands/{bandId}/users — 기존
+- #12 GET /bands/search — 기존
+- #13 PATCH /bands/{bandId} — 기존 (불명확 항목 확정, 명세 갱신)
+- #8 DELETE /bands/{bandId} — 기존 (인증 필요 확정, 명세 갱신)
+
+---
+
+## 설계 품질 체크리스트
+
+- [x] 수정 파일 목록이 명확한가?
+- [x] Repository 메서드 시그니처 변경 없음 (반환 타입의 `next` 필드만 변경)
+- [x] 트랜잭션 경계 변경 없음
+- [x] 테스트 케이스: happy path + next URL 반환 케이스 정의됨
+- [x] Prisma 모델과 설계 일치 (변경 없음)
+- [x] Controller/Service 변경 없음 (next는 Repository에서 생성되어 그대로 통과)
+
+---
+
+## 미결 사항
+
+1. **parseToPrismaQuery 적용 관련**: 현재 `searchBands`, `findBandMembers`, `findMyBands`에
+   parseToPrismaQuery 적용 시 기존 private 메서드와 동일한 동작이지만 추상화 복잡도가 올라간다.
+   `next` 변환 이후 별도 리팩터링 이슈로 분리 권장.
+
+2. **`GetBandMembersResult.cursor` 필드 방향**: API 명세(#11)에서 cursor가 첫 번째 아이템 기준인지
+   마지막 아이템 기준인지 명시되지 않았다. 현재 코드는 `cursor = items[0]`(첫 번째)을 사용하는데,
+   User 모듈은 `items[0]`을 사용한다. 일관성 유지 — 변경 불필요.
+
+3. **`findBandMembers` 인증 범위**: 현재 Service(`getBandMembers`) 코드는 인증 없이 밴드 존재만
+   확인 후 멤버를 반환한다. API 명세 #11은 401(인증 실패)/403(밴드 멤버 아님) 에러를 명시하지만,
+   컨트롤러 코드를 별도 확인 필요 (이번 작업 범위 외).

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
@@ -21,6 +21,7 @@ function createPrismaMock() {
     },
     band: {
       findFirst: jest.fn(),
+      findMany: jest.fn(),
     },
     bandBlacklist: {
       findFirst: jest.fn(),
@@ -1280,6 +1281,165 @@ describe('BandsPrismaRepository', () => {
         userId: 'user-001',
         role: 'BM',
       });
+    });
+  });
+
+  describe('findBandMembers', () => {
+    const makeMemberRow = (id: string, joinedAt: Date) => ({
+      id,
+      userId: `user-${id}`,
+      role: 'MEMBER',
+      joinedAt,
+      user: {
+        profile: { nickname: `Nick-${id}`, avatarUrl: null },
+        userSkills: [],
+      },
+    });
+
+    it('조회 수가 take보다 적으면 next가 null이다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandMember.findMany.mockResolvedValue([makeMemberRow('m1', mockCreatedAt)]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findBandMembers('band-001', {
+        order__joined_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      });
+
+      expect(result.meta.next).toBeNull();
+    });
+
+    it('조회 수가 take와 같으면 next URL을 반환한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandMember.findMany.mockResolvedValue([makeMemberRow('m1', mockCreatedAt)]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findBandMembers('band-001', {
+        order__joined_at: 'desc',
+        order__id: 'desc',
+        take: 1,
+      });
+
+      expect(typeof result.meta.next).toBe('string');
+      expect(result.meta.next).toContain('/bands/band-001/users');
+      expect(result.meta.next).toContain('cursor__joined_at=');
+      expect(result.meta.next).toContain('cursor__id=m1');
+    });
+
+    it('cursor 조건이 있으면 cursor where가 추가된다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandMember.findMany.mockResolvedValue([]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      await repository.findBandMembers('band-001', {
+        order__joined_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+        cursor__joined_at: mockCreatedAt.toISOString(),
+        cursor__id: 'm0',
+      });
+
+      expect(prisma.bandMember.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ OR: expect.any(Array) }),
+        }),
+      );
+    });
+  });
+
+  describe('searchBands', () => {
+    const makeBandRow = (id: string, createdAt: Date) => ({
+      id,
+      name: `Band-${id}`,
+      description: null,
+      visibility: true,
+      createdAt,
+      bandMasterUserId: 'user-bm',
+      bandMasterUser: { profile: { nickname: 'BM' } },
+      _count: { members: 3 },
+    });
+
+    it('조회 수가 take보다 적으면 next가 null이다', async () => {
+      const prisma = createPrismaMock();
+      prisma.band.findMany.mockResolvedValue([makeBandRow('b1', mockCreatedAt)]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.searchBands({
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+      });
+
+      expect(result.meta.next).toBeNull();
+    });
+
+    it('조회 수가 take와 같으면 next URL을 반환한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.band.findMany.mockResolvedValue([makeBandRow('b1', mockCreatedAt)]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.searchBands({
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 1,
+      });
+
+      expect(typeof result.meta.next).toBe('string');
+      expect(result.meta.next).toContain('/bands/search');
+      expect(result.meta.next).toContain('cursor__created_at=');
+      expect(result.meta.next).toContain('cursor__id=b1');
+    });
+
+    it('where__name__contain이 있으면 next URL에 포함된다', async () => {
+      const prisma = createPrismaMock();
+      prisma.band.findMany.mockResolvedValue([makeBandRow('b1', mockCreatedAt)]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.searchBands({
+        where__name__contain: 'rock',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 1,
+      });
+
+      expect(result.meta.next).toContain('where__name__contain=rock');
+    });
+  });
+
+  describe('findMyBands', () => {
+    const makeBandRow = (id: string, createdAt: Date) => ({
+      id,
+      name: `Band-${id}`,
+      description: null,
+      visibility: true,
+      createdAt,
+      bandMasterUserId: 'user-bm',
+      members: [{ role: 'MEMBER', joinedAt: mockCreatedAt }],
+      _count: { members: 2 },
+    });
+
+    it('조회 수가 take보다 적으면 next가 null이다', async () => {
+      const prisma = createPrismaMock();
+      prisma.band.findMany.mockResolvedValue([makeBandRow('b1', mockCreatedAt)]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findMyBands('user-001', { take: 20 });
+
+      expect(result.meta.next).toBeNull();
+    });
+
+    it('조회 수가 take와 같으면 next URL을 반환한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.band.findMany.mockResolvedValue([makeBandRow('b1', mockCreatedAt)]);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findMyBands('user-001', { take: 1 });
+
+      expect(typeof result.meta.next).toBe('string');
+      expect(result.meta.next).toContain('/bands/me');
+      expect(result.meta.next).toContain('cursor__created_at=');
+      expect(result.meta.next).toContain('cursor__id=b1');
     });
   });
 });

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { parseToPrismaQuery } from '../../../common/query';
+import { buildNextPath } from '../../../common/url';
 import { PrismaService } from '../../../database/prisma';
 import type { BandInvitationStatus, BandMemberRole, JoinRequestStatus, Prisma } from '../../../generated/prisma';
 import type { GetBandJoinRequestsQuery } from '../dto/get-band-join-requests-query.dto';
@@ -506,6 +508,8 @@ export class BandsPrismaRepository implements BandsRepository {
    */
   async findBandMembers(bandId: string, query: GetBandMembersQuery, tx?: Prisma.TransactionClient): Promise<GetBandMembersResult> {
     const client = tx ?? this.prisma;
+    const { orderBy, take } = parseToPrismaQuery(query);
+    const resolvedTake = take ?? query.take;
 
     const bandMembers = await client.bandMember.findMany({
       where: {
@@ -537,21 +541,31 @@ export class BandsPrismaRepository implements BandsRepository {
           },
         },
       },
-      orderBy: [{ joinedAt: query.order__joined_at }, { id: query.order__id }],
-      take: query.take,
+      orderBy,
+      take: resolvedTake,
     });
 
     const members = bandMembers.map(member => this.mapBandMemberListItem(member));
     const count = members.length;
     const cursor = count > 0 ? { joinedAt: members[0].joinedAt, id: members[0].bandMemberId } : null;
-    const next = count === query.take ? { joinedAt: members[count - 1].joinedAt, id: members[count - 1].bandMemberId } : null;
+    const lastMember = members[count - 1];
+    const next =
+      count === resolvedTake && lastMember
+        ? buildNextPath(`/bands/${bandId}/users`, {
+            cursor__joined_at: lastMember.joinedAt,
+            cursor__id: lastMember.bandMemberId,
+            take: resolvedTake,
+            order__joined_at: query.order__joined_at,
+            order__id: query.order__id,
+          })
+        : null;
 
     return {
       bandId,
       members,
       meta: {
         count,
-        take: query.take,
+        take: resolvedTake,
         cursor,
         next,
       },
@@ -567,12 +581,14 @@ export class BandsPrismaRepository implements BandsRepository {
    */
   async searchBands(query: SearchBandsQuery, tx?: Prisma.TransactionClient): Promise<SearchBandsResult> {
     const client = tx ?? this.prisma;
+    const { where, orderBy, take } = parseToPrismaQuery<Prisma.BandWhereInput>(query);
+    const resolvedTake = take ?? query.take;
 
     const bands = await client.band.findMany({
       where: {
         deletedAt: null,
         visibility: true,
-        ...this.createBandSearchKeywordWhere(query),
+        ...where,
         ...this.createBandSearchCursorWhere(query),
       },
       include: {
@@ -591,21 +607,32 @@ export class BandsPrismaRepository implements BandsRepository {
           },
         },
       },
-      orderBy: [{ createdAt: query.order__created_at }, { id: query.order__id }],
-      take: query.take,
+      orderBy,
+      take: resolvedTake,
     });
 
     const items = bands.map(band => this.mapBandSearchListItem(band));
     const count = items.length;
     const cursor = count > 0 ? { createdAt: items[0].createdAt, id: items[0].bandId } : null;
-    const next = count === query.take ? { createdAt: items[count - 1].createdAt, id: items[count - 1].bandId } : null;
+    const lastItem = items[count - 1];
+    const next =
+      count === resolvedTake && lastItem
+        ? buildNextPath('/bands/search', {
+            cursor__created_at: lastItem.createdAt,
+            cursor__id: lastItem.bandId,
+            take: resolvedTake,
+            order__created_at: query.order__created_at,
+            order__id: query.order__id,
+            where__name__contain: query.where__name__contain,
+          })
+        : null;
 
     return {
       keyword: query.where__name__contain ?? null,
       items,
       meta: {
         count,
-        take: query.take,
+        take: resolvedTake,
         cursor,
         next,
       },
@@ -749,7 +776,15 @@ export class BandsPrismaRepository implements BandsRepository {
     const items = bands.flatMap(band => this.mapMyBandListItem(band));
     const count = items.length;
     const cursor = count > 0 ? { createdAt: items[0].createdAt, id: items[0].id } : null;
-    const next = count === query.take ? { createdAt: items[count - 1].createdAt, id: items[count - 1].id } : null;
+    const lastBand = items[count - 1];
+    const next =
+      count === query.take && lastBand
+        ? buildNextPath('/bands/me', {
+            cursor__created_at: lastBand.createdAt,
+            cursor__id: lastBand.id,
+            take: query.take,
+          })
+        : null;
 
     return {
       items,
@@ -1443,19 +1478,6 @@ export class BandsPrismaRepository implements BandsRepository {
           },
         },
       ],
-    };
-  }
-
-  private createBandSearchKeywordWhere(query: SearchBandsQuery): Prisma.BandWhereInput {
-    if (query.where__name__contain === undefined) {
-      return {};
-    }
-
-    return {
-      name: {
-        contains: query.where__name__contain,
-        mode: 'insensitive',
-      },
     };
   }
 

--- a/backend/src/modules/bands/types/band-member-list.type.ts
+++ b/backend/src/modules/bands/types/band-member-list.type.ts
@@ -29,6 +29,6 @@ export interface GetBandMembersResult {
     count: number;
     take: number;
     cursor: BandMemberListCursor | null;
-    next: BandMemberListCursor | null;
+    next: string | null;
   };
 }

--- a/backend/src/modules/bands/types/band-search-result.type.ts
+++ b/backend/src/modules/bands/types/band-search-result.type.ts
@@ -23,6 +23,6 @@ export interface SearchBandsResult {
     count: number;
     take: number;
     cursor: BandSearchCursor | null;
-    next: BandSearchCursor | null;
+    next: string | null;
   };
 }

--- a/backend/src/modules/bands/types/my-band-list.type.ts
+++ b/backend/src/modules/bands/types/my-band-list.type.ts
@@ -22,6 +22,6 @@ export interface GetMyBandsResult {
     count: number;
     take: number;
     cursor: MyBandListCursor | null;
-    next: MyBandListCursor | null;
+    next: string | null;
   };
 }


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 20분

<br/>

## 📌 작업 요약

Band API Notion 명세 동기화, meta.next를 커서 객체 → URL 문자열로 전환, parseToPrismaQuery/buildNextPath 공통 유틸 적용

<br/>

## 📝 작업 내용

1. `docs`: Band API (#7~#13) Notion 명세 동기화 및 에러 코드 정리 (User API 형식 통일)
2. `fix(bands)`: #10 #11 #12 `meta.next` 타입 `Cursor 객체 | null` → `string | null` 수정
3. `refactor(bands)`: `findBandMembers`/`searchBands`에 `parseToPrismaQuery`, 3개 메서드에 `buildNextPath` 적용 및 Repository 테스트 추가

<br/>

## 🚨 주요 고민 및 해결 과정

### 문제

- `meta.next`가 커서 객체 (`{ createdAt, id }`)를 반환해 User 모듈 패턴(`string | null` URL)과 불일치
- `searchBands`의 키워드 필터가 private 메서드로 구현되어 공통 유틸과 분리

### 해결 과정

- `buildNextPath` 적용으로 `next`를 `/bands/me?cursor__created_at=...` 형태 URL 문자열로 통일
- `parseToPrismaQuery` 적용: `searchBands`에서 `where__name__contain` → Prisma `name: { contains, mode: 'insensitive' }` 변환, `createBandSearchKeywordWhere` private 메서드 제거
- `findMyBands`는 `orderBy` 고정이므로 `parseToPrismaQuery` 미적용 (이득 없음)

<br/>

## 📑 참고 문서/ ADR

- [Band API 명세](docs/backend/api-docs/band.md)
- [설계 문서](docs/backend/designs/bands/next-url-and-prisma-query-refactor.md)

<br/>

## 💬 리뷰 요구사항

- `#11 GET /bands/{bandId}/users`: Notion 원본 명세는 인증 필요로 기재되어 있으나 컨트롤러에 `AccessTokenGuard` 없음 확인 → 공개 API로 정정. 의도적 설계인지 확인 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 밴드 관련 API 문서가 정리되어 주요 엔드포인트의 인증 여부, 요청/응답 예시, 페이지네이션 방식이 명확해졌습니다.
  * 목록 응답의 다음 페이지 값이 객체가 아닌 URL 문자열로 제공되도록 개선되었습니다.

* **버그 수정**
  * 밴드 멤버, 내 밴드, 검색 결과의 커서 기반 페이징 동작이 더 일관되게 반영되었습니다.
  * 페이지 크기와 정렬 조건이 응답 메타 정보에 정확히 반영되도록 개선되었습니다.

* **테스트**
  * 다음 페이지 URL 생성과 커서 조건 적용을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->