### PR TITLE
[fix/invite-api] 밴드 초대 API 명세 동기화 및 next URL 빌더·totalCount 파라미터 적용

### DIFF
--- a/backend/docs/backend/api-docs/band-invitation.md
+++ b/backend/docs/backend/api-docs/band-invitation.md
@@ -1,0 +1,307 @@
+# band-invitation API
+
+> 최종 동기화: 2026-06-26
+>
+> ⚠️ 변환 노트:
+> - Notion 원본 응답 형식이 `{ status, error, message, data }` 구조이나, 프로젝트 컨벤션(`ApiSuccessResponse<T>`)에 맞게 `{ data, success }` 형식으로 표기함.
+> - [설계자 보완 2026-06-26] 인증 여부 → "필요 (JWT Bearer)"로 수정; #14 권한 명시, 409 에러 코드 추가; #15/#16 409 에러 코드 추가; `count` 쿼리 파라미터를 boolean 타입으로 보완; `message` 필드 optional 명시; `next` 타입을 `string | null`로 수정; `meta.totalCount` 필드 추가.
+
+---
+
+## #14 POST /bands/{bandId}/invitations
+
+**설명:** 밴드 리더/관리자가 특정 유저를 밴드에 초대한다.
+**인증:** 필요 (JWT Bearer)
+**권한:** BM 또는 ADMIN 역할 필요
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| bandId | string (UUID) | ✅ | 초대를 보낼 밴드 ID |
+
+**Body**
+
+```json
+{
+  "inviteeUserId": "uuid",
+  "message": "같이 밴드 하실래요?"
+}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|:----:|------|
+| inviteeUserId | string (UUID) | ✅ | 초대 대상 사용자 ID |
+| message | string | ❌ | 초대 메시지 (optional) |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "invitationId": "uuid",
+    "bandId": "uuid",
+    "inviterUserId": "uuid",
+    "inviteeUserId": "uuid",
+    "status": "PENDING",
+    "createdAt": "2026-04-10T12:00:00Z"
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400 | 잘못된 입력 |
+| 401 | 인증 실패 |
+| 403 | 권한 없음 (BM 또는 ADMIN 아님) |
+| 404 | 밴드 또는 대상 유저 없음 |
+| 409 | 이미 밴드 멤버인 사용자 / 이미 초대가 존재함 / 차단된 사용자 |
+
+---
+
+## #15 POST /invitations/{inviteId}/accept
+
+**설명:** 초대를 받은 유저가 초대를 수락한다.
+**인증:** 필요 (JWT Bearer)
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| inviteId | string (UUID) | ✅ | 수락할 초대 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "invitationId": "uuid",
+    "bandId": "uuid",
+    "userId": "uuid",
+    "invitationStatus": "ACCEPTED",
+    "joinedAt": "2026-04-30T10:00:00.000Z"
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 401 | 인증 실패 |
+| 403 | 권한 없음 (본인 초대가 아님) |
+| 404 | 초대 없음 |
+| 409 | 이미 처리된 초대 (PENDING 상태가 아님) |
+
+---
+
+## #16 POST /invitations/{inviteId}/decline
+
+**설명:** 초대를 받은 유저가 초대를 거절한다.
+**인증:** 필요 (JWT Bearer)
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| inviteId | string (UUID) | ✅ | 거절할 초대 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "invitationId": "uuid",
+    "bandId": "uuid",
+    "userId": "uuid",
+    "invitationStatus": "DECLINED",
+    "respondedAt": "2026-04-30T10:00:00.000Z"
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 401 | 인증 실패 |
+| 403 | 권한 없음 (본인 초대가 아님) |
+| 404 | 초대 없음 |
+| 409 | 이미 처리된 초대 (PENDING 상태가 아님) |
+
+---
+
+## #17 DELETE /invitations/{inviteId}
+
+**설명:** 초대를 보낸 사람이 초대를 취소한다.
+**인증:** 필요 (JWT Bearer)
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| inviteId | string (UUID) | ✅ | 취소할 초대 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "invitationId": "uuid",
+    "invitationStatus": "CANCELED"
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 401 | 인증 실패 |
+| 403 | 권한 없음 (본인이 보낸 초대가 아님) |
+| 404 | 초대 없음 |
+
+---
+
+## #18 GET /invitations/received
+
+**설명:** 내가 받은 초대 목록을 조회한다. (Notion 원본 경로: `/invitations/recevied` — 오타)
+**인증:** 필요 (JWT Bearer)
+
+### Request
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|---------|------|:----:|:-----:|------|
+| count | boolean | ❌ | false | true이면 meta.totalCount에 전체 개수 포함 |
+| take | number | ❌ | 20 | 페이지당 항목 수 |
+| order__created_at | string | ❌ | desc | createdAt 정렬 방향 |
+| order__id | string | ❌ | desc | id 정렬 방향 |
+| cursor__id | string (UUID) | ❌ | - | 커서 ID |
+| where__invitation_status | string | ❌ | PENDING | 초대 상태 필터 |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "items": [
+      {
+        "invitationId": "uuid",
+        "band": {
+          "bandId": "uuid",
+          "name": "Rocking Stars",
+          "description": "직장인 밴드"
+        },
+        "inviter": {
+          "userId": "uuid",
+          "nickname": "Jun"
+        },
+        "message": "같이 밴드 하실래요?",
+        "invitationStatus": "PENDING",
+        "createdAt": "2026-04-30T10:00:00.000Z"
+      }
+    ],
+    "meta": {
+      "count": 10,
+      "take": 20,
+      "totalCount": 42,
+      "cursor": {
+        "id": "uuid"
+      },
+      "next": "/invitations/received?take=20&cursor__id=uuid&order__created_at=desc&order__id=desc"
+    }
+  },
+  "success": true
+}
+```
+
+> `meta.totalCount`: `count=true`이면 전체 개수(COUNT 쿼리 결과), `count=false` 또는 미전달이면 `null`.
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 401 | 인증 실패 |
+
+---
+
+## #19 GET /invitations/sent
+
+**설명:** 내가 보낸 초대 목록을 조회한다.
+**인증:** 필요 (JWT Bearer)
+
+### Request
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|---------|------|:----:|:-----:|------|
+| count | boolean | ❌ | false | true이면 meta.totalCount에 전체 개수 포함 |
+| take | number | ❌ | 20 | 페이지당 항목 수 |
+| order__created_at | string | ❌ | desc | createdAt 정렬 방향 |
+| order__id | string | ❌ | desc | id 정렬 방향 |
+| cursor__id | string (UUID) | ❌ | - | 커서 ID |
+| where__invitation_status | string | ❌ | PENDING | 초대 상태 필터 |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "items": [
+      {
+        "invitationId": "b8f1c3d2-...",
+        "band": {
+          "bandId": "a1b2c3d4-...",
+          "name": "Rocking Stars",
+          "description": "직장인 밴드",
+          "memberCount": 5
+        },
+        "invitee": {
+          "userId": "u123...",
+          "nickname": "Choi",
+          "avatarUrl": "https://..."
+        },
+        "invitationStatus": "PENDING",
+        "message": "같이 합주해요!",
+        "createdAt": "2026-04-30T10:00:00.000Z",
+        "respondedAt": null
+      }
+    ],
+    "meta": {
+      "count": 2,
+      "take": 20,
+      "totalCount": null,
+      "cursor": {
+        "id": "c9d2e4f5-..."
+      },
+      "next": null
+    }
+  },
+  "success": true
+}
+```
+
+> `meta.totalCount`: `count=true`이면 전체 개수(COUNT 쿼리 결과), `count=false` 또는 미전달이면 `null`.
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 401 | 인증 실패 |

--- a/backend/docs/backend/api-docs/band-invitation.md
+++ b/backend/docs/backend/api-docs/band-invitation.md
@@ -36,7 +36,7 @@
 | inviteeUserId | string (UUID) | ✅ | 초대 대상 사용자 ID |
 | message | string | ❌ | 초대 메시지 (optional) |
 
-### Response 200
+### Response 201
 
 ```json
 {
@@ -77,7 +77,7 @@
 |---------|------|:----:|------|
 | inviteId | string (UUID) | ✅ | 수락할 초대 ID |
 
-### Response 200
+### Response 201
 
 ```json
 {
@@ -116,7 +116,7 @@
 |---------|------|:----:|------|
 | inviteId | string (UUID) | ✅ | 거절할 초대 ID |
 
-### Response 200
+### Response 201
 
 ```json
 {

--- a/backend/docs/backend/designs/bands/band-invitation-improvements.md
+++ b/backend/docs/backend/designs/bands/band-invitation-improvements.md
@@ -1,0 +1,154 @@
+# 밴드 초대 API 개선 설계
+
+## 작업 범위
+
+```
+수정: src/modules/bands/dto/get-received-band-invitations-query.dto.ts
+      (count 필드 추가)
+수정: src/modules/bands/dto/get-sent-band-invitations-query.dto.ts
+      (count 필드 추가)
+수정: src/modules/bands/types/received-band-invitation-list.type.ts
+      (next 타입 변경, meta에 totalCount 추가)
+수정: src/modules/bands/types/sent-band-invitation-list.type.ts
+      (next 타입 변경, meta에 totalCount 추가)
+수정: src/modules/bands/repositories/bands.repository.ts
+      (인터페이스 시그니처는 기존 유지 — 타입 변경이 구현에만 영향)
+수정: src/modules/bands/repositories/bands.prisma-repository.ts
+      - findReceivedBandInvitations: next를 string | null로 변경, totalCount COUNT 쿼리 추가, buildNextReceivedUrl 메서드 추가
+      - findSentBandInvitations: next를 string | null로 변경, totalCount COUNT 쿼리 추가, buildNextSentUrl 메서드 추가
+수정: src/modules/bands/band-invitations.controller.ts
+      (@ApiResponse 409 추가: accept/decline)
+수정: src/modules/bands/bands.controller.ts
+      (@ApiResponse 409 추가: createBandInvitation 핸들러)
+수정: docs/backend/api-docs/band-invitation.md  ← 이미 완료
+```
+
+---
+
+## API 번호
+
+- #14 `POST /bands/{bandId}/invitations` — 409 Swagger 추가
+- #15 `POST /invitations/{inviteId}/accept` — 409 Swagger 추가
+- #16 `POST /invitations/{inviteId}/decline` — 409 Swagger 추가
+- #18 `GET /invitations/received` — next 타입 변경, count 파라미터 추가
+- #19 `GET /invitations/sent` — next 타입 변경, count 파라미터 추가
+
+---
+
+## DTO 정의
+
+### GetReceivedBandInvitationsQueryDto 변경
+
+기존 필드는 유지하고 `count` 필드를 추가한다.
+
+```typescript
+@ApiPropertyOptional({ description: '전체 개수 포함 여부. true이면 meta.totalCount에 COUNT 쿼리 결과 포함', default: false })
+@Transform(parseOptionalBooleanValue)
+@IsOptional()
+@IsBoolean({ message: booleanValidationMessage })
+count?: boolean;
+```
+
+### GetSentBandInvitationsQueryDto 변경
+
+동일하게 `count` 필드를 추가한다.
+
+```typescript
+@ApiPropertyOptional({ description: '전체 개수 포함 여부. true이면 meta.totalCount에 COUNT 쿼리 결과 포함', default: false })
+@Transform(parseOptionalBooleanValue)
+@IsOptional()
+@IsBoolean({ message: booleanValidationMessage })
+count?: boolean;
+```
+
+---
+
+## 타입 변경
+
+### ReceivedBandInvitationCursor / GetReceivedBandInvitationsResult
+
+```typescript
+export interface GetReceivedBandInvitationsResult {
+  items: ReceivedBandInvitationListItem[];
+  meta: {
+    count: number;
+    take: number;
+    totalCount: number | null;   // 신규: count=true이면 COUNT 쿼리 결과, 아니면 null
+    cursor: ReceivedBandInvitationCursor | null;
+    next: string | null;         // 변경: { id: string } | null → string | null
+  };
+}
+```
+
+### SentBandInvitationCursor / GetSentBandInvitationsResult
+
+```typescript
+export interface GetSentBandInvitationsResult {
+  items: SentBandInvitationListItem[];
+  meta: {
+    count: number;
+    take: number;
+    totalCount: number | null;   // 신규
+    cursor: SentBandInvitationCursor | null;
+    next: string | null;         // 변경: { id: string } | null → string | null
+  };
+}
+```
+
+---
+
+## Repository 인터페이스 변경
+
+`bands.repository.ts`의 인터페이스 시그니처는 **변경하지 않는다.** 반환 타입이 `GetReceivedBandInvitationsResult` / `GetSentBandInvitationsResult`를 그대로 참조하므로, 해당 타입에 `totalCount`와 `next: string | null`을 추가하면 인터페이스도 함께 변경된다.
+
+---
+
+## Repository 구현 변경 (bands.prisma-repository.ts)
+
+### findReceivedBandInvitations
+
+변경 내용:
+1. `count` 조건부 COUNT 쿼리 추가: `query.count === true`이면 `client.bandInvitation.count(where)` 실행, 아니면 `null`
+2. `next` 계산: `{ id: ... }` 객체 대신 `this.buildNextReceivedUrl(query, lastItem.invitationId)` 반환
+3. 반환 `meta`에 `totalCount` 추가
+
+### buildNextReceivedUrl / buildNextSentUrl
+
+`buildNextPath` 유틸(`src/common/url/url.util.ts`)을 사용해 다음 페이지 URL을 생성한다.
+
+---
+
+## Service 비즈니스 규칙
+
+`getReceivedBandInvitations`, `getSentBandInvitations`는 Repository에 단순 위임이므로 변경 없음.
+
+`count` 처리는 Repository 레이어에서 담당한다 (Service에서 COUNT 판단 로직 없음).
+
+---
+
+## Controller Swagger 변경
+
+- `bands.controller.ts` createBandInvitation: 400 설명 보강, 403 설명 보강, 409 추가
+- `band-invitations.controller.ts` acceptBandInvitation: 409 추가
+- `band-invitations.controller.ts` declineBandInvitation: 409 추가
+
+---
+
+## 트랜잭션 경계
+
+두 쿼리(findMany + count)가 동일한 `tx?` client를 사용. `$transaction`을 새로 열지 않는다.
+
+---
+
+## 테스트 계획
+
+| 메서드 | 케이스 | 결과 |
+|--------|--------|------|
+| findReceivedBandInvitations | happy path | ✅ |
+| findReceivedBandInvitations | next 있음 (URL string) | ✅ |
+| findReceivedBandInvitations | count=true → totalCount | ✅ |
+| findReceivedBandInvitations | count=false → totalCount null | ✅ |
+| findSentBandInvitations | happy path | ✅ |
+| findSentBandInvitations | next 있음 (URL string) | ✅ |
+| findSentBandInvitations | count=true → totalCount | ✅ |
+| findSentBandInvitations | count=false → totalCount null | ✅ |

--- a/backend/src/modules/bands/band-invitations.controller.ts
+++ b/backend/src/modules/bands/band-invitations.controller.ts
@@ -60,6 +60,7 @@ export class BandInvitationsController {
   @ApiResponse({ status: 401, description: '인증 실패' })
   @ApiResponse({ status: 403, description: '권한 없음' })
   @ApiResponse({ status: 404, description: '초대를 찾을 수 없음' })
+  @ApiResponse({ status: 409, description: '이미 처리된 초대 / 이미 밴드 멤버' })
   async acceptBandInvitation(
     @Req() request: AuthenticatedRequest,
     @Param('invitationId') invitationId: string,
@@ -77,6 +78,7 @@ export class BandInvitationsController {
   @ApiResponse({ status: 401, description: '인증 실패' })
   @ApiResponse({ status: 403, description: '권한 없음' })
   @ApiResponse({ status: 404, description: '초대를 찾을 수 없음' })
+  @ApiResponse({ status: 409, description: '이미 처리된 초대' })
   async declineBandInvitation(
     @Req() request: AuthenticatedRequest,
     @Param('invitationId') invitationId: string,

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -55,10 +55,11 @@ export class BandsController {
   @ApiOperation({ summary: '밴드 초대 전송' })
   @ApiParam({ name: 'bandId', description: '밴드 ID (UUID)', type: String })
   @ApiResponse({ status: 201, description: '밴드 초대 전송 성공' })
-  @ApiResponse({ status: 400, description: '잘못된 요청' })
+  @ApiResponse({ status: 400, description: '잘못된 요청 / 자기 자신 초대 불가' })
   @ApiResponse({ status: 401, description: '인증 실패' })
-  @ApiResponse({ status: 403, description: '권한 없음' })
+  @ApiResponse({ status: 403, description: '권한 없음 (BM/ADMIN만 초대 가능) / 차단된 사용자' })
   @ApiResponse({ status: 404, description: '밴드 또는 초대 대상 유저를 찾을 수 없음' })
+  @ApiResponse({ status: 409, description: '이미 밴드 멤버 / 이미 초대가 존재함' })
   async createBandInvitation(
     @Req() request: AuthenticatedRequest,
     @Param('bandId') bandId: string,

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -347,6 +347,7 @@ function createBandsRepositoryStub(options?: {
         meta: {
           count: 1,
           take: query.take,
+          totalCount: null,
           cursor: {
             id: 'invitation-001',
           },
@@ -381,6 +382,7 @@ function createBandsRepositoryStub(options?: {
         meta: {
           count: 1,
           take: query.take,
+          totalCount: null,
           cursor: {
             id: 'invitation-001',
           },

--- a/backend/src/modules/bands/dto/get-received-band-invitations-query.dto.ts
+++ b/backend/src/modules/bands/dto/get-received-band-invitations-query.dto.ts
@@ -1,7 +1,8 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsEnum, IsInt, IsOptional, IsUUID, Min } from 'class-validator';
-import { normalizeOptionalStringValue, parseOptionalPositiveIntegerValue } from 'src/common/validation/transform.util';
+import { IsBoolean, IsEnum, IsInt, IsOptional, IsUUID, Min } from 'class-validator';
+import { normalizeOptionalStringValue, parseOptionalBooleanValue, parseOptionalPositiveIntegerValue } from 'src/common/validation/transform.util';
+import { booleanValidationMessage } from 'src/common/validation-message/boolean-validation.message';
 import { enumValidationMessage } from 'src/common/validation-message/enum-validation.message';
 import { intValidationMessage } from 'src/common/validation-message/int-validation.message';
 import { minValidationMessage } from 'src/common/validation-message/min-validation.message';
@@ -43,6 +44,12 @@ export class GetReceivedBandInvitationsQueryDto {
   @IsOptional()
   @IsUUID(undefined, { message: uuidValidationMessage })
   cursor__id?: string;
+
+  @ApiPropertyOptional({ description: '전체 개수 포함 여부. true이면 meta.totalCount에 전체 건수 포함', default: false })
+  @Transform(parseOptionalBooleanValue)
+  @IsOptional()
+  @IsBoolean({ message: booleanValidationMessage })
+  count?: boolean;
 }
 
 export type GetReceivedBandInvitationsQuery = GetReceivedBandInvitationsQueryDto;

--- a/backend/src/modules/bands/dto/get-sent-band-invitations-query.dto.ts
+++ b/backend/src/modules/bands/dto/get-sent-band-invitations-query.dto.ts
@@ -1,7 +1,8 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsEnum, IsInt, IsOptional, IsUUID, Min } from 'class-validator';
-import { normalizeOptionalStringValue, parseOptionalPositiveIntegerValue } from 'src/common/validation/transform.util';
+import { IsBoolean, IsEnum, IsInt, IsOptional, IsUUID, Min } from 'class-validator';
+import { normalizeOptionalStringValue, parseOptionalBooleanValue, parseOptionalPositiveIntegerValue } from 'src/common/validation/transform.util';
+import { booleanValidationMessage } from 'src/common/validation-message/boolean-validation.message';
 import { enumValidationMessage } from 'src/common/validation-message/enum-validation.message';
 import { intValidationMessage } from 'src/common/validation-message/int-validation.message';
 import { minValidationMessage } from 'src/common/validation-message/min-validation.message';
@@ -43,6 +44,12 @@ export class GetSentBandInvitationsQueryDto {
   @IsOptional()
   @IsUUID(undefined, { message: uuidValidationMessage })
   cursor__id?: string;
+
+  @ApiPropertyOptional({ description: '전체 개수 포함 여부. true이면 meta.totalCount에 전체 건수 포함', default: false })
+  @Transform(parseOptionalBooleanValue)
+  @IsOptional()
+  @IsBoolean({ message: booleanValidationMessage })
+  count?: boolean;
 }
 
 export type GetSentBandInvitationsQuery = GetSentBandInvitationsQueryDto;

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
@@ -8,6 +8,7 @@ function createPrismaMock() {
   return {
     bandInvitation: {
       create: jest.fn(),
+      count: jest.fn(),
       delete: jest.fn(),
       findMany: jest.fn(),
       findFirst: jest.fn(),
@@ -131,6 +132,7 @@ describe('BandsPrismaRepository', () => {
       expect(result.meta).toEqual({
         count: 1,
         take: 20,
+        totalCount: null,
         cursor: {
           id: 'invitation-001',
         },
@@ -188,9 +190,34 @@ describe('BandsPrismaRepository', () => {
       });
 
       expect(result.items).toHaveLength(1);
-      expect(result.meta.next).toEqual({
-        id: 'invitation-001',
+      expect(result.meta.next).toBe(
+        '/invitations/sent?where__invitation_status=PENDING&order__created_at=desc&order__id=desc&take=1&cursor__id=invitation-001',
+      );
+    });
+
+    it('count=true이면 totalCount에 COUNT 쿼리 결과를 반환한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.findMany.mockResolvedValue([]);
+      prisma.bandInvitation.count.mockResolvedValue(42);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findSentBandInvitations('user-001', {
+        where__invitation_status: 'PENDING',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+        count: true,
       });
+
+      expect(prisma.bandInvitation.count).toHaveBeenCalledWith({
+        where: {
+          status: 'PENDING',
+          band: { deletedAt: null },
+          inviterBandMember: { userId: 'user-001' },
+          inviteeUser: { deletedAt: null },
+        },
+      });
+      expect(result.meta.totalCount).toBe(42);
     });
   });
 
@@ -534,6 +561,7 @@ describe('BandsPrismaRepository', () => {
       expect(result.meta).toEqual({
         count: 1,
         take: 20,
+        totalCount: null,
         cursor: {
           id: 'invitation-001',
         },
@@ -587,9 +615,34 @@ describe('BandsPrismaRepository', () => {
       });
 
       expect(result.items).toHaveLength(1);
-      expect(result.meta.next).toEqual({
-        id: 'invitation-001',
+      expect(result.meta.next).toBe(
+        '/invitations/received?where__invitation_status=PENDING&order__created_at=desc&order__id=desc&take=1&cursor__id=invitation-001',
+      );
+    });
+
+    it('count=true이면 totalCount에 COUNT 쿼리 결과를 반환한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.findMany.mockResolvedValue([]);
+      prisma.bandInvitation.count.mockResolvedValue(7);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findReceivedBandInvitations('user-002', {
+        where__invitation_status: 'PENDING',
+        order__created_at: 'desc',
+        order__id: 'desc',
+        take: 20,
+        count: true,
       });
+
+      expect(prisma.bandInvitation.count).toHaveBeenCalledWith({
+        where: {
+          inviteeUserId: 'user-002',
+          status: 'PENDING',
+          band: { deletedAt: null },
+          inviterBandMember: { user: { deletedAt: null } },
+        },
+      });
+      expect(result.meta.totalCount).toBe(7);
     });
   });
 

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -857,13 +857,25 @@ export class BandsPrismaRepository implements BandsRepository {
     const items = rows.map(invitation => this.mapReceivedBandInvitationListItem(invitation));
     const count = items.length;
     const cursor = count > 0 ? { id: items[0].invitationId } : null;
-    const next = hasNext && count > 0 ? { id: items[count - 1].invitationId } : null;
+    const next = hasNext && count > 0 ? this.buildNextReceivedUrl(query, items[count - 1].invitationId) : null;
+    const totalCount =
+      query.count === true
+        ? await client.bandInvitation.count({
+            where: {
+              inviteeUserId: userId,
+              status: query.where__invitation_status,
+              band: { deletedAt: null },
+              inviterBandMember: { user: { deletedAt: null } },
+            },
+          })
+        : null;
 
     return {
       items,
       meta: {
         count,
         take: query.take,
+        totalCount,
         cursor,
         next,
       },
@@ -929,13 +941,25 @@ export class BandsPrismaRepository implements BandsRepository {
     const items = rows.map(invitation => this.mapSentBandInvitationListItem(invitation));
     const count = items.length;
     const cursor = count > 0 ? { id: items[0].invitationId } : null;
-    const next = hasNext && count > 0 ? { id: items[count - 1].invitationId } : null;
+    const next = hasNext && count > 0 ? this.buildNextSentUrl(query, items[count - 1].invitationId) : null;
+    const totalCount =
+      query.count === true
+        ? await client.bandInvitation.count({
+            where: {
+              status: query.where__invitation_status,
+              band: { deletedAt: null },
+              inviterBandMember: { userId },
+              inviteeUser: { deletedAt: null },
+            },
+          })
+        : null;
 
     return {
       items,
       meta: {
         count,
         take: query.take,
+        totalCount,
         cursor,
         next,
       },
@@ -1654,6 +1678,32 @@ export class BandsPrismaRepository implements BandsRepository {
         memberCount: band._count.members,
       },
     ];
+  }
+
+  /**
+   * 받은 초대 목록 다음 페이지 URL을 생성한다.
+   */
+  private buildNextReceivedUrl(query: GetReceivedBandInvitationsQuery, lastId: string): string {
+    return buildNextPath('/invitations/received', {
+      where__invitation_status: query.where__invitation_status,
+      order__created_at: query.order__created_at,
+      order__id: query.order__id,
+      take: query.take,
+      cursor__id: lastId,
+    });
+  }
+
+  /**
+   * 보낸 초대 목록 다음 페이지 URL을 생성한다.
+   */
+  private buildNextSentUrl(query: GetSentBandInvitationsQuery, lastId: string): string {
+    return buildNextPath('/invitations/sent', {
+      where__invitation_status: query.where__invitation_status,
+      order__created_at: query.order__created_at,
+      order__id: query.order__id,
+      take: query.take,
+      cursor__id: lastId,
+    });
   }
 
   private mapReceivedBandInvitationListItem(

--- a/backend/src/modules/bands/types/received-band-invitation-list.type.ts
+++ b/backend/src/modules/bands/types/received-band-invitation-list.type.ts
@@ -25,7 +25,8 @@ export interface GetReceivedBandInvitationsResult {
   meta: {
     count: number;
     take: number;
+    totalCount: number | null;
     cursor: ReceivedBandInvitationCursor | null;
-    next: ReceivedBandInvitationCursor | null;
+    next: string | null;
   };
 }

--- a/backend/src/modules/bands/types/sent-band-invitation-list.type.ts
+++ b/backend/src/modules/bands/types/sent-band-invitation-list.type.ts
@@ -28,7 +28,8 @@ export interface GetSentBandInvitationsResult {
   meta: {
     count: number;
     take: number;
+    totalCount: number | null;
     cursor: SentBandInvitationCursor | null;
-    next: SentBandInvitationCursor | null;
+    next: string | null;
   };
 }


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 15분

<br/>

## 📌 작업 요약

밴드 초대 API Notion 명세를 동기화하고, next를 커서 객체에서 URL 문자열로 전환하며 totalCount 쿼리 파라미터를 추가했습니다.

<br/>

## 📝 작업 내용

1. Notion 밴드 초대 API 명세 동기화 (`docs/backend/api-docs/band-invitation.md` 신규)
   - 인증 여부, 권한(BM/ADMIN), 에러 코드(409), count 파라미터, message optional 등 보완
2. #18 `GET /invitations/received`, #19 `GET /invitations/sent` — next URL 빌더 적용
   - `next: { id } | null` → `string | null` (URL 경로 문자열)
   - `buildNextPath` 공통 유틸(`src/common/url/url.util.ts`) 사용
   - `count=true` 쿼리 시 `meta.totalCount`에 전체 건수 포함 (기본값 null)
3. #14 `POST /bands/{bandId}/invitations`, #15 accept, #16 decline — Swagger 409 에러 응답 추가
   - #14: 400 설명 보강(자기 자신 초대), 403 설명 보강(BM/ADMIN), 409(이미 멤버/이미 초대 존재)
   - #15: 409(이미 처리된 초대/이미 밴드 멤버)
   - #16: 409(이미 처리된 초대)

<br/>

## 🚨 주요 고민 및 해결 과정

### 문제

`next`가 `{ id: string } | null` 커서 객체로 반환되고 있어 클라이언트가 직접 URL을 조립해야 했으며, notifications 모듈과 패턴이 불일치했습니다.

### 해결 과정

notifications 모듈의 `buildNextUrl` 패턴을 참고해 공통 유틸 `buildNextPath`를 사용하는 private 메서드(`buildNextReceivedUrl`, `buildNextSentUrl`)를 리포지토리에 추가했습니다.

<br/>

## 💬 리뷰 요구사항

- `count=true`일 때 findMany와 count 쿼리가 동일 Prisma client를 공유하지만 `$transaction`으로 묶지 않았습니다. 단순 읽기 2쿼리이므로 문제없다고 판단했는데 이견이 있으시면 말씀 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 밴드 초대 목록(받은/보낸)에 `count=true` 옵션을 추가해 `meta.totalCount`를 제공하고, 다음 페이지 정보(`meta.next`)를 URL 문자열 형태로 노출합니다.
* **Documentation**
  * 밴드 초대 생성/수락/거절/취소 및 받은·보낸 초대 조회 API 문서를 정리했으며, 인증/권한과 응답 스키마를 더 명확히 했습니다.
* **Bug Fixes**
  * 이미 처리된 초대 등 상태별 409 오류 응답이 세부 케이스로 문서에 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->