### PR TITLE
[KAN-58] 팀 관리 API 구현 (#53~#55, #60~#66)

### DIFF
--- a/backend/docs/backend/api-docs/teams.md
+++ b/backend/docs/backend/api-docs/teams.md
@@ -1,0 +1,565 @@
+# teams API
+
+> 최종 동기화: 2026-06-28
+
+---
+
+## #53 POST /bands/{bandId}/teams
+
+**설명:** 밴드 내에 새 팀을 생성한다. 생성자가 자동으로 팀 리더가 된다.
+**인증:** 필요 (JWT Bearer)
+**권한:** 밴드 멤버
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| bandId | string (UUID) | ✅ | 팀을 생성할 밴드 ID |
+
+**Body**
+
+```json
+{
+  "name": "보컬팀",
+  "description": "여자 보컬 중심 팀",
+  "teamCoverUrl": "https://example.com/images/team-cover.png"
+}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|:----:|------|
+| name | string | ✅ | 팀 이름 |
+| description | string | ❌ | 팀 설명 |
+| teamCoverUrl | string (URL) | ❌ | 팀 커버 이미지 URL |
+
+### Response 201
+
+```json
+{
+  "data": {
+    "teamId": "uuid",
+    "bandId": "uuid",
+    "name": "보컬팀",
+    "description": "여자 보컬 중심 팀",
+    "status": "ACTIVE",
+    "teamLeaderUserId": "uuid",
+    "teamCoverUrl": "https://example.com/team-cover.png",
+    "createdAt": "2026-05-01T12:00:00Z"
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400 | 잘못된 입력 (name 누락 등) |
+| 401 | 인증 실패 |
+| 403 | 해당 밴드의 멤버가 아님 |
+| 404 | 밴드 없음 |
+
+---
+
+## #54 GET /bands/{bandId}/teams
+
+**설명:** 밴드에 속한 모든 팀 목록을 조회한다.
+**인증:** 불필요 (공개)
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| bandId | string (UUID) | ✅ | 조회할 밴드 ID |
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|---------|------|:----:|:-----:|------|
+| take | number | ❌ | 20 | 페이지당 항목 수 |
+| order__created_at | string | ❌ | desc | createdAt 정렬 방향 (asc / desc) |
+| order__id | string | ❌ | desc | id 정렬 방향 (asc / desc) |
+| cursor__created_at | string (ISO8601) | ❌ | - | 커서 createdAt |
+| cursor__id | string (UUID) | ❌ | - | 커서 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "bandId": "uuid",
+    "items": [
+      {
+        "teamId": "uuid",
+        "name": "보컬팀",
+        "description": "여자 보컬 중심 팀",
+        "status": "ACTIVE",
+        "teamCoverUrl": "https://example.com/team-cover.png",
+        "memberCount": 3,
+        "teamLeader": {
+          "userId": "uuid",
+          "nickname": "Jun"
+        },
+        "createdAt": "2026-05-01T12:00:00Z"
+      }
+    ],
+    "meta": {
+      "count": 20,
+      "take": 20,
+      "cursor": {
+        "createdAt": "2026-05-01T12:00:00Z",
+        "id": "last-team-id"
+      },
+      "next": "/bands/uuid/teams?take=20&cursor__created_at=2026-05-01T12%3A00%3A00Z&cursor__id=last-team-id&order__created_at=desc&order__id=desc"
+    }
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400 | bandId가 UUID 형식이 아님 |
+| 404 | 밴드 없음 |
+
+---
+
+## #55 GET /teams/me
+
+**설명:** 내가 속해 있는 팀 목록을 조회한다.
+**인증:** 필요 (JWT Bearer)
+
+### Request
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|---------|------|:----:|:-----:|------|
+| take | number | ❌ | 20 | 페이지당 항목 수 |
+| order__joined_at | string | ❌ | desc | joinedAt 정렬 방향 (asc / desc) |
+| order__id | string | ❌ | desc | id 정렬 방향 (asc / desc) |
+| cursor__joined_at | string (ISO8601) | ❌ | - | 커서 joinedAt |
+| cursor__id | string (UUID) | ❌ | - | 커서 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "items": [
+      {
+        "teamId": "uuid",
+        "bandId": "uuid",
+        "bandName": "Rocking Stars",
+        "name": "보컬팀",
+        "description": "여자 보컬 중심 팀",
+        "status": "ACTIVE",
+        "teamCoverUrl": "https://example.com/team-cover.png",
+        "myTeamRole": "LEADER",
+        "memberCount": 3,
+        "teamLeader": {
+          "userId": "uuid",
+          "nickname": "Jun"
+        },
+        "joinedAt": "2026-05-01T12:00:00Z",
+        "createdAt": "2026-05-01T12:00:00Z"
+      }
+    ],
+    "meta": {
+      "count": 20,
+      "take": 20,
+      "cursor": {
+        "joinedAt": "2026-05-01T12:00:00Z",
+        "id": "last-team-member-id"
+      },
+      "next": "/teams/me?take=20&cursor__joined_at=2026-05-01T12%3A00%3A00Z&cursor__id=last-team-member-id&order__joined_at=desc&order__id=desc"
+    }
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 401 | 인증 실패 |
+
+---
+
+## #60 GET /teams/{teamId}
+
+**설명:** 팀 상세 정보를 조회한다.
+**인증:** 불필요 (공개)
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| teamId | string (UUID) | ✅ | 조회할 팀 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "teamId": "uuid",
+    "bandId": "uuid",
+    "name": "보컬팀",
+    "description": "여자 보컬 중심 팀",
+    "status": "ACTIVE",
+    "teamCoverUrl": "https://example.com/team-cover.png",
+    "teamLeader": {
+      "userId": "uuid",
+      "nickname": "Jun"
+    },
+    "memberCount": 3,
+    "createdAt": "2026-05-01T12:00:00Z",
+    "updatedAt": "2026-05-01T12:00:00Z"
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400 | teamId가 UUID 형식이 아님 |
+| 404 | 팀 없음 |
+
+---
+
+## #61 PATCH /teams/{teamId}
+
+**설명:** 팀 정보를 수정한다. 전달된 필드만 업데이트된다.
+**인증:** 필요 (JWT Bearer)
+**권한:** 팀 리더 (TeamMemberRole.LEADER)
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| teamId | string (UUID) | ✅ | 수정할 팀 ID |
+
+**Body**
+
+모든 필드는 선택. 전달된 필드만 업데이트.
+
+```json
+{
+  "name": "메인 보컬팀",
+  "description": "메인 보컬 중심 팀",
+  "status": "ACTIVE",
+  "teamCoverUrl": "https://example.com/new-cover.png"
+}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|:----:|------|
+| name | string | ❌ | 팀 이름 |
+| description | string | ❌ | 팀 설명 |
+| status | string | ❌ | 팀 상태 (ACTIVE \| INACTIVE) |
+| teamCoverUrl | string (URL) | ❌ | 팀 커버 이미지 URL |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "teamId": "uuid",
+    "bandId": "uuid",
+    "name": "메인 보컬팀",
+    "description": "메인 보컬 중심 팀",
+    "status": "ACTIVE",
+    "teamCoverUrl": "https://example.com/new-cover.png",
+    "teamLeader": {
+      "userId": "uuid",
+      "nickname": "Jun"
+    },
+    "memberCount": 3,
+    "updatedAt": "2026-05-01T12:30:00Z"
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400 | 잘못된 입력 |
+| 401 | 인증 실패 |
+| 403 | 권한 없음 (팀 리더 아님) |
+| 404 | 팀 없음 |
+
+---
+
+## #62 GET /teams/{teamId}/members
+
+**설명:** 팀 멤버 목록을 조회한다.
+**인증:** 불필요 (공개)
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| teamId | string (UUID) | ✅ | 조회할 팀 ID |
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|---------|------|:----:|:-----:|------|
+| take | number | ❌ | 20 | 페이지당 항목 수 |
+| order__joined_at | string | ❌ | desc | joinedAt 정렬 방향 (asc / desc) |
+| order__id | string | ❌ | desc | id 정렬 방향 (asc / desc) |
+| cursor__joined_at | string (ISO8601) | ❌ | - | 커서 joinedAt |
+| cursor__id | string (UUID) | ❌ | - | 커서 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "teamId": "uuid",
+    "items": [
+      {
+        "teamMemberId": "uuid",
+        "bandMemberId": "uuid",
+        "user": {
+          "userId": "uuid",
+          "nickname": "Jun",
+          "profileImageUrl": "https://example.com/profile.png"
+        },
+        "teamRole": "LEADER",
+        "joinedAt": "2026-05-01T12:00:00Z"
+      },
+      {
+        "teamMemberId": "uuid",
+        "bandMemberId": "uuid",
+        "user": {
+          "userId": "uuid",
+          "nickname": "Min",
+          "profileImageUrl": "https://example.com/profile2.png"
+        },
+        "teamRole": "MEMBER",
+        "joinedAt": "2026-05-02T12:00:00Z"
+      }
+    ],
+    "meta": {
+      "count": 20,
+      "take": 20,
+      "cursor": {
+        "joinedAt": "2026-05-02T12:00:00Z",
+        "id": "last-team-member-id"
+      },
+      "next": "/teams/uuid/members?take=20&cursor__joined_at=2026-05-02T12%3A00%3A00Z&cursor__id=last-team-member-id&order__joined_at=desc&order__id=desc"
+    }
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400 | teamId가 UUID 형식이 아님 |
+| 404 | 팀 없음 |
+
+---
+
+## #63 PATCH /teams/{teamId}/leader
+
+**설명:** 팀 리더를 다른 팀 멤버로 변경한다.
+**인증:** 필요 (JWT Bearer)
+**권한:** 팀 리더 (TeamMemberRole.LEADER)
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| teamId | string (UUID) | ✅ | 리더를 변경할 팀 ID |
+
+**Body**
+
+```json
+{
+  "teamMemberId": "uuid"
+}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|:----:|------|
+| teamMemberId | string (UUID) | ✅ | 새 팀 리더로 지정할 팀 멤버 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "teamId": "uuid",
+    "teamLeader": {
+      "userId": "uuid",
+      "nickname": "NewLeader"
+    }
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400 | teamMemberId가 UUID 형식이 아님 또는 누락 |
+| 401 | 인증 실패 |
+| 403 | 권한 없음 (팀 리더 아님) |
+| 404 | 팀 없음 또는 팀 멤버 없음 |
+
+---
+
+## #64 DELETE /teams/{teamId}/members/{teamMemberId}
+
+**설명:** 팀에서 특정 멤버를 제거한다.
+**인증:** 필요 (JWT Bearer)
+**권한:** 팀 리더 (TeamMemberRole.LEADER)
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| teamId | string (UUID) | ✅ | 팀 ID |
+| teamMemberId | string (UUID) | ✅ | 제거할 팀 멤버 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "teamMemberId": "uuid",
+    "removed": true
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400 | teamId 또는 teamMemberId가 UUID 형식이 아님 / 팀 리더는 자기 자신을 제거할 수 없음 (리더 변경 후 제거 가능) |
+| 401 | 인증 실패 |
+| 403 | 권한 없음 (팀 리더 아님) |
+| 404 | 팀 없음 또는 팀 멤버 없음 |
+
+---
+
+## #65 POST /teams/{teamId}/members
+
+**설명:** 팀에 밴드 멤버를 추가한다.
+**인증:** 필요 (JWT Bearer)
+**권한:** 팀 리더 (TeamMemberRole.LEADER)
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| teamId | string (UUID) | ✅ | 팀 ID |
+
+**Body**
+
+```json
+{
+  "bandMemberId": "uuid"
+}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|:----:|------|
+| bandMemberId | string (UUID) | ✅ | 팀에 추가할 밴드 멤버 ID |
+
+### Response 201
+
+```json
+{
+  "data": {
+    "teamMemberId": "uuid",
+    "teamId": "uuid",
+    "bandMemberId": "uuid",
+    "user": {
+      "userId": "uuid",
+      "nickname": "Jun",
+      "profileImageUrl": "https://example.com/profile.png"
+    },
+    "teamRole": "MEMBER",
+    "joinedAt": "2026-05-01T12:00:00Z"
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400 | bandMemberId가 UUID 형식이 아님 또는 누락 |
+| 401 | 인증 실패 |
+| 403 | 권한 없음 (팀 리더 아님) |
+| 404 | 팀 없음 또는 밴드 멤버 없음 |
+| 409 | 이미 해당 팀의 멤버 |
+
+---
+
+## #66 DELETE /teams/{teamId}
+
+**설명:** 팀을 삭제한다.
+**인증:** 필요 (JWT Bearer)
+**권한:** 팀 리더 (TeamMemberRole.LEADER)
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| teamId | string (UUID) | ✅ | 삭제할 팀 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "teamId": "uuid",
+    "deleted": true
+  },
+  "success": true
+}
+```
+
+### Error Responses
+
+| 코드 | 조건 |
+|------|------|
+| 400 | teamId가 UUID 형식이 아님 |
+| 401 | 인증 실패 |
+| 403 | 권한 없음 (팀 리더 아님) |
+| 404 | 팀 없음 |

--- a/backend/docs/backend/designs/teams/teams-module.md
+++ b/backend/docs/backend/designs/teams/teams-module.md
@@ -1,0 +1,1023 @@
+# Teams 모듈 설계 문서
+
+**작성일:** 2026-06-28
+**API 명세 위치:** `docs/backend/api-docs/teams.md` (#53, #54, #55, #60, #61, #62, #63, #64, #65, #66)
+
+---
+
+## API 명세 보완 내역
+
+> ⚠️ 변환 노트: [설계자 보완 2026-06-28] #53 응답 필드 보완 — `teamLeaderUserId` 단일 필드 대신 teams.md에 없던 `teamLeaderBandMemberId`를 schema 기반으로 추가하고, 생성 응답에서는 리더 object 대신 단순 ID 반환으로 확정.
+
+**상세:**
+- #53 생성 응답에서 명세의 `teamLeaderUserId` 필드는 BandMember → User 조인 없이도 반환 가능한 `teamLeaderBandMemberId`로 보완. 생성 직후 User 정보까지 반환하면 추가 조인 쿼리가 필요하므로, 생성 응답은 ID만 반환하는 것이 단순하다.
+- 단, 명세가 `teamLeaderUserId`를 명시하고 있으므로 BandMember를 join해 userId도 함께 반환하는 방향으로 설계한다 (명세 준수).
+
+---
+
+## 관련 DB 모델
+
+### Team
+
+```
+id                     String          PK
+bandId                 String          FK → Band.id
+name                   String          VARCHAR(150)
+description            String?
+status                 TeamStatus      ACTIVE | INACTIVE (default: ACTIVE)
+teamLeaderBandMemberId String?         FK → BandMember.id
+createdAt              DateTime
+updatedAt              DateTime
+teamCoverUrl           String?         VARCHAR(255)
+```
+
+### TeamMember
+
+```
+id           String          PK
+teamId       String          FK → Team.id
+bandMemberId String          FK → BandMember.id
+joinedAt     DateTime        (default: now())
+teamRole     TeamMemberRole  LEADER | MEMBER (default: MEMBER)
+@@unique([teamId, bandMemberId])
+```
+
+### BandMember (참조)
+
+```
+id       String          PK
+bandId   String          FK → Band.id
+userId   String          FK → User.id
+role     BandMemberRole  BM | ADMIN | MEMBER
+joinedAt DateTime
+@@unique([bandId, userId])
+```
+
+### UserProfile (참조 — nickname, avatarUrl 조회용)
+
+```
+userId    String   PK
+nickname  String
+avatarUrl String?
+```
+
+---
+
+## 작업 범위
+
+```
+신규: src/modules/teams/teams.module.ts
+신규: src/modules/teams/teams.controller.ts
+신규: src/modules/teams/teams.service.ts
+신규: src/modules/teams/teams.service.spec.ts
+신규: src/modules/teams/repositories/teams.repository.ts
+신규: src/modules/teams/repositories/teams.prisma-repository.ts
+신규: src/modules/teams/dto/create-team.dto.ts
+신규: src/modules/teams/dto/update-team.dto.ts
+신규: src/modules/teams/dto/get-band-teams-query.dto.ts
+신규: src/modules/teams/dto/get-my-teams-query.dto.ts
+신규: src/modules/teams/dto/get-team-members-query.dto.ts
+신규: src/modules/teams/dto/change-team-leader.dto.ts
+신규: src/modules/teams/dto/add-team-member.dto.ts
+신규: src/modules/teams/types/create-team-result.type.ts
+신규: src/modules/teams/types/get-band-teams-result.type.ts
+신규: src/modules/teams/types/get-my-teams-result.type.ts
+신규: src/modules/teams/types/get-team-result.type.ts
+신규: src/modules/teams/types/update-team-result.type.ts
+신규: src/modules/teams/types/get-team-members-result.type.ts
+신규: src/modules/teams/types/change-team-leader-result.type.ts
+신규: src/modules/teams/types/remove-team-member-result.type.ts
+신규: src/modules/teams/types/add-team-member-result.type.ts
+신규: src/modules/teams/types/delete-team-result.type.ts
+
+수정: src/modules/index.ts (TeamsModule export 추가)
+수정: src/app.module.ts (TeamsModule import 추가)
+```
+
+---
+
+## DTO 정의
+
+### CreateTeamBodyDto (`create-team.dto.ts`)
+
+```typescript
+export class CreateTeamBodyDto {
+  @ApiProperty({ description: '팀 이름', example: '보컬팀' })
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty({ message: notEmptyValidationMessage })
+  @MaxLength(150, { message: maxLengthValidationMessage })
+  name: string;
+
+  @ApiPropertyOptional({ description: '팀 설명', example: '여자 보컬 중심 팀' })
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  description?: string;
+
+  @ApiPropertyOptional({ description: '팀 커버 이미지 URL', example: 'https://example.com/cover.png' })
+  @IsOptional()
+  @IsUrl({}, { message: urlValidationMessage })
+  teamCoverUrl?: string;
+}
+
+export type CreateTeamInput = CreateTeamBodyDto;
+```
+
+### UpdateTeamBodyDto (`update-team.dto.ts`)
+
+```typescript
+export class UpdateTeamBodyDto {
+  @ApiPropertyOptional({ description: '팀 이름', example: '메인 보컬팀' })
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty({ message: notEmptyValidationMessage })
+  @MaxLength(150, { message: maxLengthValidationMessage })
+  name?: string;
+
+  @ApiPropertyOptional({ description: '팀 설명', example: '메인 보컬 중심 팀' })
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  description?: string;
+
+  @ApiPropertyOptional({ enum: ['ACTIVE', 'INACTIVE'], description: '팀 상태' })
+  @IsOptional()
+  @IsEnum(['ACTIVE', 'INACTIVE'], { message: enumValidationMessage })
+  status?: 'ACTIVE' | 'INACTIVE';
+
+  @ApiPropertyOptional({ description: '팀 커버 이미지 URL', example: 'https://example.com/new-cover.png' })
+  @IsOptional()
+  @IsUrl({}, { message: urlValidationMessage })
+  teamCoverUrl?: string;
+}
+
+export type UpdateTeamInput = UpdateTeamBodyDto;
+```
+
+### GetBandTeamsQueryDto (`get-band-teams-query.dto.ts`)
+
+```typescript
+// cursor 기준: createdAt + id
+export class GetBandTeamsQueryDto {
+  @ApiPropertyOptional({ enum: ['asc', 'desc'], default: 'desc' })
+  @IsOptional()
+  @IsEnum(['asc', 'desc'], { message: enumValidationMessage })
+  order__created_at: 'asc' | 'desc' = 'desc';
+
+  @ApiPropertyOptional({ enum: ['asc', 'desc'], default: 'desc' })
+  @IsOptional()
+  @IsEnum(['asc', 'desc'], { message: enumValidationMessage })
+  order__id: 'asc' | 'desc' = 'desc';
+
+  @ApiPropertyOptional({ default: 20, minimum: 1 })
+  @Transform(parseOptionalPositiveIntegerValue)
+  @IsInt({ message: intValidationMessage })
+  @Min(1, { message: minValidationMessage })
+  take: number = 20;
+
+  @ApiPropertyOptional()
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  cursor__created_at?: string;
+
+  @ApiPropertyOptional()
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  cursor__id?: string;
+}
+
+export type GetBandTeamsQuery = GetBandTeamsQueryDto;
+```
+
+### GetMyTeamsQueryDto (`get-my-teams-query.dto.ts`)
+
+```typescript
+// cursor 기준: joinedAt + id (TeamMember.joinedAt 기준)
+export class GetMyTeamsQueryDto {
+  @ApiPropertyOptional({ enum: ['asc', 'desc'], default: 'desc' })
+  order__joined_at: 'asc' | 'desc' = 'desc';
+
+  @ApiPropertyOptional({ enum: ['asc', 'desc'], default: 'desc' })
+  order__id: 'asc' | 'desc' = 'desc';
+
+  @ApiPropertyOptional({ default: 20, minimum: 1 })
+  take: number = 20;
+
+  @ApiPropertyOptional()
+  cursor__joined_at?: string;
+
+  @ApiPropertyOptional()
+  cursor__id?: string;
+}
+
+export type GetMyTeamsQuery = GetMyTeamsQueryDto;
+```
+
+### GetTeamMembersQueryDto (`get-team-members-query.dto.ts`)
+
+```typescript
+// GetMyTeamsQueryDto와 동일한 cursor 전략 (joinedAt + id)
+export class GetTeamMembersQueryDto {
+  // GetMyTeamsQueryDto와 동일한 필드 구성
+}
+
+export type GetTeamMembersQuery = GetTeamMembersQueryDto;
+```
+
+### ChangeTeamLeaderBodyDto (`change-team-leader.dto.ts`)
+
+```typescript
+export class ChangeTeamLeaderBodyDto {
+  @ApiProperty({ description: '새 팀 리더로 지정할 팀 멤버 ID', example: 'uuid' })
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  teamMemberId: string;
+}
+```
+
+### AddTeamMemberBodyDto (`add-team-member.dto.ts`)
+
+```typescript
+export class AddTeamMemberBodyDto {
+  @ApiProperty({ description: '팀에 추가할 밴드 멤버 ID', example: 'uuid' })
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  bandMemberId: string;
+}
+```
+
+---
+
+## 타입 정의
+
+### create-team-result.type.ts
+
+```typescript
+export interface CreateTeamResult {
+  teamId: string;
+  bandId: string;
+  name: string;
+  description: string | null;
+  status: string;
+  teamLeaderUserId: string;       // BandMember.userId
+  teamCoverUrl: string | null;
+  createdAt: string;
+}
+```
+
+### get-band-teams-result.type.ts
+
+```typescript
+export interface TeamLeaderInfo {
+  userId: string;
+  nickname: string;
+}
+
+export interface BandTeamListItem {
+  teamId: string;
+  name: string;
+  description: string | null;
+  status: string;
+  teamCoverUrl: string | null;
+  memberCount: number;
+  teamLeader: TeamLeaderInfo | null;
+  createdAt: string;
+}
+
+export interface BandTeamListCursor {
+  createdAt: string;
+  id: string;
+}
+
+export interface GetBandTeamsResult {
+  bandId: string;
+  items: BandTeamListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: BandTeamListCursor | null;
+    next: string | null;
+  };
+}
+```
+
+### get-my-teams-result.type.ts
+
+```typescript
+export interface MyTeamListItem {
+  teamId: string;
+  bandId: string;
+  bandName: string;
+  name: string;
+  description: string | null;
+  status: string;
+  teamCoverUrl: string | null;
+  myTeamRole: string;             // TeamMemberRole (LEADER | MEMBER)
+  memberCount: number;
+  teamLeader: TeamLeaderInfo | null;
+  joinedAt: string;
+  createdAt: string;
+}
+
+export interface MyTeamListCursor {
+  joinedAt: string;
+  id: string;                     // TeamMember.id
+}
+
+export interface GetMyTeamsResult {
+  items: MyTeamListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: MyTeamListCursor | null;
+    next: string | null;
+  };
+}
+```
+
+### get-team-result.type.ts
+
+```typescript
+export interface GetTeamResult {
+  teamId: string;
+  bandId: string;
+  name: string;
+  description: string | null;
+  status: string;
+  teamCoverUrl: string | null;
+  teamLeader: TeamLeaderInfo | null;
+  memberCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+### update-team-result.type.ts
+
+```typescript
+export interface UpdateTeamResult {
+  teamId: string;
+  bandId: string;
+  name: string;
+  description: string | null;
+  status: string;
+  teamCoverUrl: string | null;
+  teamLeader: TeamLeaderInfo | null;
+  memberCount: number;
+  updatedAt: string;
+}
+```
+
+### get-team-members-result.type.ts
+
+```typescript
+export interface TeamMemberUserInfo {
+  userId: string;
+  nickname: string;
+  profileImageUrl: string | null;
+}
+
+export interface TeamMemberListItem {
+  teamMemberId: string;
+  bandMemberId: string;
+  user: TeamMemberUserInfo;
+  teamRole: string;
+  joinedAt: string;
+}
+
+export interface TeamMemberListCursor {
+  joinedAt: string;
+  id: string;
+}
+
+export interface GetTeamMembersResult {
+  teamId: string;
+  items: TeamMemberListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: TeamMemberListCursor | null;
+    next: string | null;
+  };
+}
+```
+
+### change-team-leader-result.type.ts
+
+```typescript
+export interface ChangeTeamLeaderResult {
+  teamId: string;
+  teamLeader: TeamLeaderInfo;
+}
+```
+
+### remove-team-member-result.type.ts
+
+```typescript
+export interface RemoveTeamMemberResult {
+  teamMemberId: string;
+  removed: boolean;
+}
+```
+
+### add-team-member-result.type.ts
+
+```typescript
+export interface AddTeamMemberResult {
+  teamMemberId: string;
+  teamId: string;
+  bandMemberId: string;
+  user: TeamMemberUserInfo;
+  teamRole: string;
+  joinedAt: string;
+}
+```
+
+### delete-team-result.type.ts
+
+```typescript
+export interface DeleteTeamResult {
+  teamId: string;
+  deleted: boolean;
+}
+```
+
+---
+
+## Repository 인터페이스
+
+**심볼:** `TEAMS_REPOSITORY`
+**파일:** `src/modules/teams/repositories/teams.repository.ts`
+
+```typescript
+export const TEAMS_REPOSITORY = Symbol('TEAMS_REPOSITORY');
+
+export interface TeamsRepository {
+  /**
+   * 밴드가 삭제되지 않은 활성 밴드인지 확인하고 기본 정보를 반환한다.
+   * Band.deletedAt이 null인 경우만 반환.
+   */
+  findActiveBandById(
+    bandId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{ id: string } | null>;
+
+  /**
+   * 특정 사용자가 해당 밴드의 멤버인지 확인한다.
+   * BandMember를 bandId + userId 조합으로 조회한다.
+   */
+  findBandMemberByBandIdAndUserId(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{ id: string } | null>;
+
+  /**
+   * 팀을 생성하고 생성자를 LEADER 역할의 TeamMember로 동시에 등록한다.
+   * Team + TeamMember를 하나의 트랜잭션 내에서 생성.
+   * Team.teamLeaderBandMemberId = 생성자의 BandMember.id로 설정.
+   */
+  createTeam(
+    input: CreateTeamRepositoryInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<CreateTeamResult>;
+
+  /**
+   * 밴드에 속한 팀 목록을 cursor 기반으로 조회한다.
+   * memberCount와 teamLeader(nickname 포함)를 함께 반환.
+   */
+  findTeamsByBandId(
+    bandId: string,
+    query: GetBandTeamsQuery,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetBandTeamsResult>;
+
+  /**
+   * 인증 사용자가 TeamMember로 등록된 팀 목록을 cursor 기반으로 조회한다.
+   * TeamMember.joinedAt 기준으로 정렬.
+   * bandName, myTeamRole, memberCount, teamLeader 포함.
+   */
+  findMyTeams(
+    userId: string,
+    query: GetMyTeamsQuery,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetMyTeamsResult>;
+
+  /**
+   * 팀 ID로 팀 상세 정보를 조회한다.
+   * memberCount와 teamLeader 정보를 함께 반환.
+   */
+  findTeamById(
+    teamId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetTeamResult | null>;
+
+  /**
+   * 팀 리더 권한 확인을 위해 팀과 팀의 현재 리더 BandMember.userId를 반환한다.
+   */
+  findTeamForLeaderCheck(
+    teamId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    teamLeaderBandMemberId: string | null;
+    teamLeaderUserId: string | null;
+  } | null>;
+
+  /**
+   * 팀 정보(name, description, status, teamCoverUrl)를 수정한다.
+   * 전달된 필드만 업데이트하는 partial update.
+   */
+  updateTeam(
+    teamId: string,
+    input: UpdateTeamInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<UpdateTeamResult>;
+
+  /**
+   * 팀 멤버 목록을 cursor 기반으로 조회한다.
+   * BandMember → UserProfile(nickname, avatarUrl) join 포함.
+   */
+  findTeamMembersByTeamId(
+    teamId: string,
+    query: GetTeamMembersQuery,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetTeamMembersResult>;
+
+  /**
+   * 팀 멤버 ID로 TeamMember를 조회한다.
+   * 리더 변경/멤버 제거 시 대상 검증에 사용.
+   */
+  findTeamMemberById(
+    teamMemberId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    teamId: string;
+    bandMemberId: string;
+    userId: string;         // BandMember.userId
+    nickname: string;       // UserProfile.nickname
+    teamRole: string;
+  } | null>;
+
+  /**
+   * 팀의 리더를 변경한다.
+   * Team.teamLeaderBandMemberId 업데이트 + 기존 리더의 TeamMember.teamRole → MEMBER
+   * + 새 리더의 TeamMember.teamRole → LEADER를 하나의 트랜잭션으로 처리.
+   */
+  changeTeamLeader(
+    teamId: string,
+    newLeaderTeamMemberId: string,
+    currentLeaderBandMemberId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<ChangeTeamLeaderResult>;
+
+  /**
+   * 팀에서 멤버를 제거(delete)한다.
+   */
+  removeTeamMember(
+    teamMemberId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<RemoveTeamMemberResult>;
+
+  /**
+   * 밴드 멤버 ID로 BandMember를 조회한다.
+   * 팀 멤버 추가 시 대상 검증에 사용.
+   * bandId 파라미터로 해당 밴드의 멤버인지 함께 검증.
+   */
+  findBandMemberById(
+    bandMemberId: string,
+    bandId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{ id: string; userId: string } | null>;
+
+  /**
+   * teamId + bandMemberId 조합으로 기존 TeamMember 존재 여부를 확인한다.
+   * 중복 추가 방지에 사용.
+   */
+  findTeamMemberByTeamIdAndBandMemberId(
+    teamId: string,
+    bandMemberId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{ id: string } | null>;
+
+  /**
+   * 팀에 새 멤버를 추가한다. teamRole은 MEMBER로 고정.
+   * BandMember → UserProfile join으로 user 정보 포함 반환.
+   */
+  addTeamMember(
+    teamId: string,
+    bandMemberId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<AddTeamMemberResult>;
+
+  /**
+   * 팀을 삭제한다. Team 레코드를 실제로 삭제(hard delete).
+   * TeamMember는 onDelete: Cascade로 함께 삭제됨.
+   */
+  deleteTeam(
+    teamId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<DeleteTeamResult>;
+}
+
+export interface CreateTeamRepositoryInput {
+  bandId: string;
+  creatorBandMemberId: string;   // 생성자 BandMember.id (자동으로 리더가 됨)
+  creatorUserId: string;         // 생성 응답의 teamLeaderUserId 반환용
+  name: string;
+  description?: string;
+  teamCoverUrl?: string;
+}
+```
+
+---
+
+## Service 비즈니스 규칙
+
+**파일:** `src/modules/teams/teams.service.ts`
+**심볼:** `TEAMS_REPOSITORY`
+
+### 공통 패턴
+
+모든 Service 메서드는 `tx?: Prisma.TransactionClient`를 마지막 선택 인자로 받는다.
+트랜잭션이 필요한 경우:
+
+```typescript
+const run = async (client: Prisma.TransactionClient) => { ... };
+return tx ? run(tx) : this.prisma.$transaction(run);
+```
+
+---
+
+### #53 createTeam(requesterUserId, bandId, input, tx?)
+
+**API:** `POST /bands/{bandId}/teams`
+
+처리 흐름:
+1. `bandId`로 밴드 존재 확인 → 없거나 deletedAt이 있으면 `NotFoundException('요청한 밴드를 찾을 수 없습니다.')`
+2. `bandId + requesterUserId`로 BandMember 조회 → 없으면 `ForbiddenException('밴드 멤버만 팀을 생성할 수 있습니다.')`
+3. `teamsRepository.createTeam({ bandId, creatorBandMemberId: bandMember.id, creatorUserId: requesterUserId, ...input })` 호출
+4. 결과 반환
+
+트랜잭션 경계: 필요 (밴드 확인 + BandMember 확인 + Team/TeamMember 생성을 하나의 tx로)
+
+---
+
+### #54 getBandTeams(bandId, query, tx?)
+
+**API:** `GET /bands/{bandId}/teams`
+
+처리 흐름:
+1. 쿼리 cursor 쌍 유효성 검증 (cursor__created_at, cursor__id 중 하나만 있으면 400)
+2. `order__created_at !== order__id`이면 `BadRequestException`
+3. `bandId`로 밴드 존재 확인 → 없으면 `NotFoundException`
+4. `teamsRepository.findTeamsByBandId(bandId, query)` 호출
+5. 결과 반환
+
+트랜잭션 경계: 불필요 (읽기 전용, tx 전달만)
+
+---
+
+### #55 getMyTeams(requesterUserId, query, tx?)
+
+**API:** `GET /teams/me`
+
+처리 흐름:
+1. 쿼리 cursor 쌍 유효성 검증 (cursor__joined_at, cursor__id)
+2. `order__joined_at !== order__id`이면 `BadRequestException`
+3. `teamsRepository.findMyTeams(requesterUserId, query)` 호출
+4. 결과 반환
+
+트랜잭션 경계: 불필요
+
+---
+
+### #60 getTeam(teamId, tx?)
+
+**API:** `GET /teams/{teamId}`
+
+처리 흐름:
+1. `teamsRepository.findTeamById(teamId)` 호출
+2. 결과가 null이면 `NotFoundException('요청한 팀을 찾을 수 없습니다.')`
+3. 결과 반환
+
+트랜잭션 경계: 불필요
+
+---
+
+### #61 updateTeam(requesterUserId, teamId, input, tx?)
+
+**API:** `PATCH /teams/{teamId}`
+
+처리 흐름:
+1. input이 모두 undefined이면 `BadRequestException('수정할 팀 정보가 필요합니다.')`
+2. `teamsRepository.findTeamForLeaderCheck(teamId)` 호출
+3. 결과가 null이면 `NotFoundException('요청한 팀을 찾을 수 없습니다.')`
+4. `team.teamLeaderUserId !== requesterUserId`이면 `ForbiddenException('팀 리더만 팀 정보를 수정할 수 있습니다.')`
+5. `teamsRepository.updateTeam(teamId, input)` 호출
+6. 결과 반환
+
+트랜잭션 경계: 필요 (리더 확인 + 업데이트를 같은 tx로)
+
+---
+
+### #62 getTeamMembers(teamId, query, tx?)
+
+**API:** `GET /teams/{teamId}/members`
+
+처리 흐름:
+1. 쿼리 cursor 쌍 유효성 검증 (cursor__joined_at, cursor__id)
+2. `order__joined_at !== order__id`이면 `BadRequestException`
+3. `teamsRepository.findTeamForLeaderCheck(teamId)` 호출 (팀 존재 확인 목적)
+4. 결과가 null이면 `NotFoundException('요청한 팀을 찾을 수 없습니다.')`
+5. `teamsRepository.findTeamMembersByTeamId(teamId, query)` 호출
+6. 결과 반환
+
+트랜잭션 경계: 불필요
+
+---
+
+### #63 changeTeamLeader(requesterUserId, teamId, teamMemberId, tx?)
+
+**API:** `PATCH /teams/{teamId}/leader`
+
+처리 흐름:
+1. `teamsRepository.findTeamForLeaderCheck(teamId)` 호출
+2. 결과가 null이면 `NotFoundException('요청한 팀을 찾을 수 없습니다.')`
+3. `team.teamLeaderUserId !== requesterUserId`이면 `ForbiddenException('팀 리더만 리더를 변경할 수 있습니다.')`
+4. `teamsRepository.findTeamMemberById(teamMemberId)` 호출
+5. 결과가 null이면 `NotFoundException('요청한 팀 멤버를 찾을 수 없습니다.')`
+6. `targetTeamMember.teamId !== teamId`이면 `NotFoundException` (다른 팀의 teamMemberId 방지)
+7. `targetTeamMember.teamRole === 'LEADER'`이면 이미 리더 — `BadRequestException('이미 팀 리더인 멤버입니다.')`
+8. `teamsRepository.changeTeamLeader(teamId, teamMemberId, currentLeaderBandMemberId)` 호출
+9. 결과 반환
+
+트랜잭션 경계: 필요 (리더 확인 + 변경을 같은 tx로)
+
+---
+
+### #64 removeTeamMember(requesterUserId, teamId, teamMemberId, tx?)
+
+**API:** `DELETE /teams/{teamId}/members/{teamMemberId}`
+
+처리 흐름:
+1. `teamsRepository.findTeamForLeaderCheck(teamId)` 호출
+2. 결과가 null이면 `NotFoundException('요청한 팀을 찾을 수 없습니다.')`
+3. `team.teamLeaderUserId !== requesterUserId`이면 `ForbiddenException('팀 리더만 멤버를 제거할 수 있습니다.')`
+4. `teamsRepository.findTeamMemberById(teamMemberId)` 호출
+5. 결과가 null이면 `NotFoundException('요청한 팀 멤버를 찾을 수 없습니다.')`
+6. `targetTeamMember.teamId !== teamId`이면 `NotFoundException`
+7. `targetTeamMember.userId === requesterUserId`이면 `BadRequestException('팀 리더는 자기 자신을 팀에서 제거할 수 없습니다. 리더를 먼저 변경하세요.')`
+8. `teamsRepository.removeTeamMember(teamMemberId)` 호출
+9. 결과 반환
+
+트랜잭션 경계: 필요 (리더 확인 + 멤버 확인 + 삭제를 같은 tx로)
+
+---
+
+### #65 addTeamMember(requesterUserId, teamId, bandMemberId, tx?)
+
+**API:** `POST /teams/{teamId}/members`
+
+처리 흐름:
+1. `teamsRepository.findTeamForLeaderCheck(teamId)` 호출
+2. 결과가 null이면 `NotFoundException('요청한 팀을 찾을 수 없습니다.')`
+3. `team.teamLeaderUserId !== requesterUserId`이면 `ForbiddenException('팀 리더만 멤버를 추가할 수 있습니다.')`
+4. `teamsRepository.findBandMemberById(bandMemberId, team.bandId)` 호출
+   - bandId는 findTeamForLeaderCheck 결과에 포함 → findTeamForLeaderCheck에 bandId 반환 필요 (추가 반환 필드)
+5. 결과가 null이면 `NotFoundException('요청한 밴드 멤버를 찾을 수 없습니다.')`
+6. `teamsRepository.findTeamMemberByTeamIdAndBandMemberId(teamId, bandMemberId)` 호출
+7. 결과가 있으면 `ConflictException('이미 해당 팀의 멤버입니다.')`
+8. `teamsRepository.addTeamMember(teamId, bandMemberId)` 호출
+9. 결과 반환
+
+트랜잭션 경계: 필요
+
+**주의:** findTeamForLeaderCheck의 반환 타입에 `bandId: string`을 추가해야 한다.
+
+---
+
+### #66 deleteTeam(requesterUserId, teamId, tx?)
+
+**API:** `DELETE /teams/{teamId}`
+
+처리 흐름:
+1. `teamsRepository.findTeamForLeaderCheck(teamId)` 호출
+2. 결과가 null이면 `NotFoundException('요청한 팀을 찾을 수 없습니다.')`
+3. `team.teamLeaderUserId !== requesterUserId`이면 `ForbiddenException('팀 리더만 팀을 삭제할 수 있습니다.')`
+4. `teamsRepository.deleteTeam(teamId)` 호출
+5. 결과 반환
+
+트랜잭션 경계: 필요 (리더 확인 + 삭제를 같은 tx로)
+
+---
+
+## Controller 설계
+
+**파일:** `src/modules/teams/teams.controller.ts`
+
+Controller는 두 개의 경로 prefix를 처리해야 한다:
+- `/bands/:bandId/teams` — #53, #54
+- `/teams` — #55, #60, #61, #62, #63, #64, #65, #66
+
+NestJS는 단일 Controller에 복수 prefix를 지원하지 않는다.
+따라서 **Controller를 두 개로 분리**한다:
+
+1. `BandTeamsController` — prefix: `bands` — #53, #54 담당
+2. `TeamsController` — prefix: `teams` — #55, #60, #61, #62, #63, #64, #65, #66 담당
+
+두 Controller 모두 `TeamsService`를 주입받는다.
+
+### BandTeamsController
+
+```typescript
+@ApiTags('팀')
+@Controller('bands')
+export class BandTeamsController {
+  @Post(':bandId/teams')
+  @HttpCode(201)
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '팀 생성' })
+  @ApiParam({ name: 'bandId', type: String })
+  @ApiResponse({ status: 201, description: '팀 생성 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 입력' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  @ApiResponse({ status: 403, description: '밴드 멤버가 아님' })
+  @ApiResponse({ status: 404, description: '밴드 없음' })
+  async createTeam(...): Promise<ApiSuccessResponse<CreateTeamResult>>
+
+  @Get(':bandId/teams')
+  @ApiOperation({ summary: '밴드 팀 목록 조회' })
+  @ApiParam({ name: 'bandId', type: String })
+  @ApiResponse({ status: 200, description: '조회 성공' })
+  @ApiResponse({ status: 404, description: '밴드 없음' })
+  async getBandTeams(...): Promise<ApiSuccessResponse<GetBandTeamsResult>>
+}
+```
+
+### TeamsController
+
+```typescript
+@ApiTags('팀')
+@Controller('teams')
+export class TeamsController {
+  @Get('me')           // #55 — @UseGuards(AccessTokenGuard)
+  @Get(':teamId')      // #60 — public
+  @Patch(':teamId')    // #61 — @UseGuards(AccessTokenGuard)
+  @Get(':teamId/members')  // #62 — public
+  @Patch(':teamId/leader') // #63 — @UseGuards(AccessTokenGuard)
+  @Delete(':teamId/members/:teamMemberId') // #64 — @UseGuards(AccessTokenGuard)
+  @Post(':teamId/members') // #65 — @UseGuards(AccessTokenGuard)
+  @Delete(':teamId')   // #66 — @UseGuards(AccessTokenGuard)
+}
+```
+
+**주의:** `GET /teams/me`와 `GET /teams/:teamId`가 충돌하지 않도록 `me` 핸들러를 `:teamId` 핸들러보다 **먼저** 선언해야 한다.
+
+---
+
+## Repository 인터페이스 보완: findTeamForLeaderCheck 반환 타입
+
+#65 설계에서 `bandId`가 필요하므로 아래로 확정한다:
+
+```typescript
+findTeamForLeaderCheck(
+  teamId: string,
+  tx?: Prisma.TransactionClient,
+): Promise<{
+  id: string;
+  bandId: string;
+  teamLeaderBandMemberId: string | null;
+  teamLeaderUserId: string | null;   // BandMember.userId (join 필요)
+} | null>;
+```
+
+---
+
+## 트랜잭션 경계 요약
+
+| 메서드 | tx 필요 | 이유 |
+|--------|:-------:|------|
+| createTeam | ✅ | 밴드/멤버 확인 + Team/TeamMember 생성 원자성 |
+| getBandTeams | 없음 | 읽기 전용 |
+| getMyTeams | 없음 | 읽기 전용 |
+| getTeam | 없음 | 읽기 전용 |
+| updateTeam | ✅ | 리더 확인 + 업데이트 원자성 |
+| getTeamMembers | 없음 | 읽기 전용 |
+| changeTeamLeader | ✅ | 리더 확인 + Team/TeamMember 3개 업데이트 원자성 |
+| removeTeamMember | ✅ | 리더 확인 + 멤버 확인 + 삭제 원자성 |
+| addTeamMember | ✅ | 리더/멤버 확인 + 중복 확인 + 추가 원자성 |
+| deleteTeam | ✅ | 리더 확인 + 삭제 원자성 |
+
+---
+
+## 테스트 계획
+
+**파일:** `src/modules/teams/teams.service.spec.ts`
+**패턴:** 손으로 만든 Repository Stub (TestingModule, jest.fn() 금지)
+
+### UUID 상수 (파일 상단 선언)
+
+```typescript
+const USER_ID         = '11111111-1111-4111-8111-111111111111';
+const OTHER_USER_ID   = '22222222-2222-4222-8222-222222222222';
+const BAND_ID         = '33333333-3333-4333-8333-333333333333';
+const TEAM_ID         = '44444444-4444-4444-8444-444444444444';
+const BAND_MEMBER_ID  = '55555555-5555-4555-8555-555555555555';
+const TEAM_MEMBER_ID  = '66666666-6666-4666-8666-666666666666';
+const OTHER_BAND_MEMBER_ID = '77777777-7777-4777-8777-777777777777';
+const OTHER_TEAM_MEMBER_ID = '88888888-8888-4888-8888-888888888888';
+```
+
+### 테스트 케이스 목록
+
+| 메서드 | 케이스 | 기대 결과 |
+|--------|--------|-----------|
+| createTeam | happy path | CreateTeamResult 반환 |
+| createTeam | 밴드 없음 | NotFoundException |
+| createTeam | 밴드 멤버 아님 | ForbiddenException |
+| createTeam | tx 일관성 | capturedTransactions 동일 client 확인 |
+| createTeam | 외부 tx 전달 | createPrismaServiceFailingTransactionStub |
+| getBandTeams | happy path | GetBandTeamsResult 반환 |
+| getBandTeams | 밴드 없음 | NotFoundException |
+| getBandTeams | cursor 한쪽만 입력 | BadRequestException |
+| getBandTeams | order 방향 불일치 | BadRequestException |
+| getMyTeams | happy path | GetMyTeamsResult 반환 |
+| getMyTeams | cursor 한쪽만 입력 | BadRequestException |
+| getMyTeams | order 방향 불일치 | BadRequestException |
+| getTeam | happy path | GetTeamResult 반환 |
+| getTeam | 팀 없음 | NotFoundException |
+| updateTeam | happy path | UpdateTeamResult 반환 |
+| updateTeam | 팀 없음 | NotFoundException |
+| updateTeam | 팀 리더 아님 | ForbiddenException |
+| updateTeam | 수정 필드 없음 | BadRequestException |
+| updateTeam | tx 일관성 | capturedTransactions 동일 client 확인 |
+| updateTeam | 외부 tx 전달 | createPrismaServiceFailingTransactionStub |
+| getTeamMembers | happy path | GetTeamMembersResult 반환 |
+| getTeamMembers | 팀 없음 | NotFoundException |
+| getTeamMembers | cursor 한쪽만 입력 | BadRequestException |
+| changeTeamLeader | happy path | ChangeTeamLeaderResult 반환 |
+| changeTeamLeader | 팀 없음 | NotFoundException |
+| changeTeamLeader | 팀 리더 아님 | ForbiddenException |
+| changeTeamLeader | 팀 멤버 없음 | NotFoundException |
+| changeTeamLeader | 이미 리더 | BadRequestException |
+| changeTeamLeader | tx 일관성 | capturedTransactions 동일 client 확인 |
+| changeTeamLeader | 외부 tx 전달 | createPrismaServiceFailingTransactionStub |
+| removeTeamMember | happy path | RemoveTeamMemberResult 반환 |
+| removeTeamMember | 팀 없음 | NotFoundException |
+| removeTeamMember | 팀 리더 아님 | ForbiddenException |
+| removeTeamMember | 팀 멤버 없음 | NotFoundException |
+| removeTeamMember | 자기 자신 제거 | BadRequestException |
+| removeTeamMember | tx 일관성 | capturedTransactions 동일 client 확인 |
+| removeTeamMember | 외부 tx 전달 | createPrismaServiceFailingTransactionStub |
+| addTeamMember | happy path | AddTeamMemberResult 반환 |
+| addTeamMember | 팀 없음 | NotFoundException |
+| addTeamMember | 팀 리더 아님 | ForbiddenException |
+| addTeamMember | 밴드 멤버 없음 (해당 밴드) | NotFoundException |
+| addTeamMember | 이미 팀 멤버 | ConflictException |
+| addTeamMember | tx 일관성 | capturedTransactions 동일 client 확인 |
+| addTeamMember | 외부 tx 전달 | createPrismaServiceFailingTransactionStub |
+| deleteTeam | happy path | DeleteTeamResult 반환 |
+| deleteTeam | 팀 없음 | NotFoundException |
+| deleteTeam | 팀 리더 아님 | ForbiddenException |
+| deleteTeam | tx 일관성 | capturedTransactions 동일 client 확인 |
+| deleteTeam | 외부 tx 전달 | createPrismaServiceFailingTransactionStub |
+
+### Stub 구조 (핵심)
+
+```typescript
+function createTeamsRepositoryStub(options?: {
+  band?: { id: string } | null;
+  bandMember?: { id: string } | null;
+  team?: { id: string; bandId: string; teamLeaderBandMemberId: string | null; teamLeaderUserId: string | null } | null;
+  teamMember?: { id: string; teamId: string; bandMemberId: string; userId: string; nickname: string; teamRole: string } | null;
+  existingTeamMember?: { id: string } | null;
+  onCreateTeam?: (input: CreateTeamRepositoryInput, tx: unknown) => void;
+  onChangeTeamLeader?: (teamId: string, newLeaderTeamMemberId: string, currentLeaderBandMemberId: string, tx: unknown) => void;
+}): TeamsRepository {
+  return {
+    async findActiveBandById() { return options?.band !== undefined ? options.band : { id: BAND_ID }; },
+    async findBandMemberByBandIdAndUserId() { return options?.bandMember !== undefined ? options.bandMember : { id: BAND_MEMBER_ID }; },
+    async findTeamForLeaderCheck() { return options?.team !== undefined ? options.team : DEFAULT_TEAM; },
+    async createTeam(input, tx) {
+      options?.onCreateTeam?.(input, tx);
+      return DEFAULT_CREATE_TEAM_RESULT;
+    },
+    // ... 나머지 메서드
+  };
+}
+```
+
+---
+
+## 미결 사항
+
+1. **Team soft delete 여부:** 현재 `Team` 모델에 `deletedAt`이 없다. 설계에서는 hard delete로 처리한다. 향후 soft delete가 필요하면 스키마 변경 필요.
+
+2. **밴드 삭제 시 팀 처리:** `Band → Team`이 `onDelete: Cascade`로 설정되어 있어 밴드 삭제 시 팀도 cascade 삭제된다. teams 모듈에서는 별도 처리 불필요.
+
+3. **`#53` 응답 `teamLeaderUserId` 필드:** API 명세의 응답 필드명이 `teamLeaderUserId`이나 이는 BandMember를 join해서 얻는 값이다. 명세를 준수해 join 후 반환하도록 설계함.
+
+4. **팀 리더 권한 확인 방법:** 현재 설계에서는 `findTeamForLeaderCheck`가 `teamLeaderUserId`(BandMember.userId)를 반환하고, Service에서 `requesterUserId`와 비교한다. BandMember join이 필요하므로 Prisma 쿼리에 `include: { teamLeaderBandMember: { select: { userId: true } } }` 패턴이 필요하다.
+
+5. **`GET /teams/me` cursor의 id 필드:** 명세상 cursor.id가 `last-team-member-id` (TeamMember.id)이다. 이 설계는 TeamMember.id를 cursor로 사용한다.

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { NotificationsModule } from './modules/notifications/notifications.modul
 import { PlacesModule } from './modules/places/places.module';
 import { SchedulesModule } from './modules/schedules/schedules.module';
 import { SongsModule } from './modules/songs/songs.module';
+import { TeamsModule } from './modules/teams/teams.module';
 import { UsersModule } from './modules/users/users.module';
 import { StorageModule } from './storage/storage.module';
 
@@ -27,6 +28,7 @@ import { StorageModule } from './storage/storage.module';
     SchedulesModule,
     CommonModule,
     PlacesModule,
+    TeamsModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/modules/teams/dto/add-team-member.dto.ts
+++ b/backend/src/modules/teams/dto/add-team-member.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+import { uuidValidationMessage } from '../../../common/validation-message/uuid-validation.message';
+
+export class AddTeamMemberBodyDto {
+  @ApiProperty({ description: '팀에 추가할 밴드 멤버 ID', example: '550e8400-e29b-41d4-a716-446655440000' })
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  bandMemberId!: string;
+}

--- a/backend/src/modules/teams/dto/change-team-leader.dto.ts
+++ b/backend/src/modules/teams/dto/change-team-leader.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+import { uuidValidationMessage } from '../../../common/validation-message/uuid-validation.message';
+
+export class ChangeTeamLeaderBodyDto {
+  @ApiProperty({ description: '새 팀 리더로 지정할 팀 멤버 ID', example: '550e8400-e29b-41d4-a716-446655440000' })
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  teamMemberId!: string;
+}

--- a/backend/src/modules/teams/dto/create-team.dto.ts
+++ b/backend/src/modules/teams/dto/create-team.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+import { normalizeOptionalStringValue, trimStringValue } from '../../../common/validation/transform.util';
+import { lengthValidationMessage } from '../../../common/validation-message/length-validation.message';
+import { notemptyValidationMessage } from '../../../common/validation-message/notempty-validation.message';
+import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
+
+export class CreateTeamBodyDto {
+  @ApiProperty({ description: '팀 이름 (최대 150자)', example: '보컬팀' })
+  @Transform(trimStringValue)
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty({ message: notemptyValidationMessage })
+  @MaxLength(150, { message: lengthValidationMessage })
+  name!: string;
+
+  @ApiPropertyOptional({ description: '팀 설명', example: '여자 보컬 중심 팀' })
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  description?: string;
+
+  @ApiPropertyOptional({ description: '팀 커버 이미지 URL', example: 'https://example.com/cover.png' })
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  teamCoverUrl?: string;
+}
+
+export type CreateTeamInput = CreateTeamBodyDto;

--- a/backend/src/modules/teams/dto/get-band-teams-query.dto.ts
+++ b/backend/src/modules/teams/dto/get-band-teams-query.dto.ts
@@ -1,0 +1,42 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, IsUUID, Min } from 'class-validator';
+
+import { normalizeOptionalStringValue, parseOptionalPositiveIntegerValue } from '../../../common/validation/transform.util';
+import { enumValidationMessage } from '../../../common/validation-message/enum-validation.message';
+import { intValidationMessage } from '../../../common/validation-message/int-validation.message';
+import { minValidationMessage } from '../../../common/validation-message/min-validation.message';
+import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
+import { uuidValidationMessage } from '../../../common/validation-message/uuid-validation.message';
+
+export class GetBandTeamsQueryDto {
+  @ApiPropertyOptional({ description: '한 번에 가져올 항목 수', default: 20, minimum: 1 })
+  @Transform(parseOptionalPositiveIntegerValue)
+  @IsInt({ message: intValidationMessage })
+  @Min(1, { message: minValidationMessage })
+  take: number = 20;
+
+  @ApiPropertyOptional({ enum: ['asc', 'desc'], default: 'desc', description: 'createdAt 정렬 방향' })
+  @IsOptional()
+  @IsEnum(['asc', 'desc'], { message: enumValidationMessage })
+  order__created_at: 'asc' | 'desc' = 'desc';
+
+  @ApiPropertyOptional({ enum: ['asc', 'desc'], default: 'desc', description: 'id 정렬 방향' })
+  @IsOptional()
+  @IsEnum(['asc', 'desc'], { message: enumValidationMessage })
+  order__id: 'asc' | 'desc' = 'desc';
+
+  @ApiPropertyOptional({ description: '커서 createdAt (ISO 8601)', example: '2026-05-01T12:00:00.000Z' })
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  cursor__created_at?: string;
+
+  @ApiPropertyOptional({ description: '커서 ID (UUID)', example: '550e8400-e29b-41d4-a716-446655440000' })
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  cursor__id?: string;
+}
+
+export type GetBandTeamsQuery = GetBandTeamsQueryDto;

--- a/backend/src/modules/teams/dto/get-my-teams-query.dto.ts
+++ b/backend/src/modules/teams/dto/get-my-teams-query.dto.ts
@@ -1,0 +1,42 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, IsUUID, Min } from 'class-validator';
+
+import { normalizeOptionalStringValue, parseOptionalPositiveIntegerValue } from '../../../common/validation/transform.util';
+import { enumValidationMessage } from '../../../common/validation-message/enum-validation.message';
+import { intValidationMessage } from '../../../common/validation-message/int-validation.message';
+import { minValidationMessage } from '../../../common/validation-message/min-validation.message';
+import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
+import { uuidValidationMessage } from '../../../common/validation-message/uuid-validation.message';
+
+export class GetMyTeamsQueryDto {
+  @ApiPropertyOptional({ description: '한 번에 가져올 항목 수', default: 20, minimum: 1 })
+  @Transform(parseOptionalPositiveIntegerValue)
+  @IsInt({ message: intValidationMessage })
+  @Min(1, { message: minValidationMessage })
+  take: number = 20;
+
+  @ApiPropertyOptional({ enum: ['asc', 'desc'], default: 'desc', description: 'joinedAt 정렬 방향' })
+  @IsOptional()
+  @IsEnum(['asc', 'desc'], { message: enumValidationMessage })
+  order__joined_at: 'asc' | 'desc' = 'desc';
+
+  @ApiPropertyOptional({ enum: ['asc', 'desc'], default: 'desc', description: 'id 정렬 방향' })
+  @IsOptional()
+  @IsEnum(['asc', 'desc'], { message: enumValidationMessage })
+  order__id: 'asc' | 'desc' = 'desc';
+
+  @ApiPropertyOptional({ description: '커서 joinedAt (ISO 8601)', example: '2026-05-01T12:00:00.000Z' })
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  cursor__joined_at?: string;
+
+  @ApiPropertyOptional({ description: '커서 ID (UUID)', example: '550e8400-e29b-41d4-a716-446655440000' })
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  cursor__id?: string;
+}
+
+export type GetMyTeamsQuery = GetMyTeamsQueryDto;

--- a/backend/src/modules/teams/dto/get-team-members-query.dto.ts
+++ b/backend/src/modules/teams/dto/get-team-members-query.dto.ts
@@ -1,0 +1,42 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, IsUUID, Min } from 'class-validator';
+
+import { normalizeOptionalStringValue, parseOptionalPositiveIntegerValue } from '../../../common/validation/transform.util';
+import { enumValidationMessage } from '../../../common/validation-message/enum-validation.message';
+import { intValidationMessage } from '../../../common/validation-message/int-validation.message';
+import { minValidationMessage } from '../../../common/validation-message/min-validation.message';
+import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
+import { uuidValidationMessage } from '../../../common/validation-message/uuid-validation.message';
+
+export class GetTeamMembersQueryDto {
+  @ApiPropertyOptional({ description: '한 번에 가져올 항목 수', default: 20, minimum: 1 })
+  @Transform(parseOptionalPositiveIntegerValue)
+  @IsInt({ message: intValidationMessage })
+  @Min(1, { message: minValidationMessage })
+  take: number = 20;
+
+  @ApiPropertyOptional({ enum: ['asc', 'desc'], default: 'desc', description: 'joinedAt 정렬 방향' })
+  @IsOptional()
+  @IsEnum(['asc', 'desc'], { message: enumValidationMessage })
+  order__joined_at: 'asc' | 'desc' = 'desc';
+
+  @ApiPropertyOptional({ enum: ['asc', 'desc'], default: 'desc', description: 'id 정렬 방향' })
+  @IsOptional()
+  @IsEnum(['asc', 'desc'], { message: enumValidationMessage })
+  order__id: 'asc' | 'desc' = 'desc';
+
+  @ApiPropertyOptional({ description: '커서 joinedAt (ISO 8601)', example: '2026-05-01T12:00:00.000Z' })
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  cursor__joined_at?: string;
+
+  @ApiPropertyOptional({ description: '커서 ID (UUID)', example: '550e8400-e29b-41d4-a716-446655440000' })
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsUUID(undefined, { message: uuidValidationMessage })
+  cursor__id?: string;
+}
+
+export type GetTeamMembersQuery = GetTeamMembersQueryDto;

--- a/backend/src/modules/teams/dto/update-team.dto.ts
+++ b/backend/src/modules/teams/dto/update-team.dto.ts
@@ -1,0 +1,38 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsEnum, IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+import { normalizeOptionalStringValue, trimStringValue } from '../../../common/validation/transform.util';
+import { enumValidationMessage } from '../../../common/validation-message/enum-validation.message';
+import { lengthValidationMessage } from '../../../common/validation-message/length-validation.message';
+import { notemptyValidationMessage } from '../../../common/validation-message/notempty-validation.message';
+import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
+
+export class UpdateTeamBodyDto {
+  @ApiPropertyOptional({ description: '팀 이름 (최대 150자)', example: '메인 보컬팀' })
+  @Transform(trimStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty({ message: notemptyValidationMessage })
+  @MaxLength(150, { message: lengthValidationMessage })
+  name?: string;
+
+  @ApiPropertyOptional({ description: '팀 설명', example: '메인 보컬 중심 팀' })
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  description?: string;
+
+  @ApiPropertyOptional({ enum: ['ACTIVE', 'INACTIVE'], description: '팀 상태' })
+  @IsOptional()
+  @IsEnum(['ACTIVE', 'INACTIVE'], { message: enumValidationMessage })
+  status?: 'ACTIVE' | 'INACTIVE';
+
+  @ApiPropertyOptional({ description: '팀 커버 이미지 URL', example: 'https://example.com/new-cover.png' })
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
+  teamCoverUrl?: string;
+}
+
+export type UpdateTeamInput = UpdateTeamBodyDto;

--- a/backend/src/modules/teams/repositories/teams.prisma-repository.ts
+++ b/backend/src/modules/teams/repositories/teams.prisma-repository.ts
@@ -1,0 +1,678 @@
+import { Injectable } from '@nestjs/common';
+
+import { parseToPrismaQuery } from '../../../common/query';
+import { buildNextPath } from '../../../common/url';
+import { PrismaService } from '../../../database/prisma';
+import type { Prisma } from '../../../generated/prisma';
+import type { GetBandTeamsQuery } from '../dto/get-band-teams-query.dto';
+import type { GetMyTeamsQuery } from '../dto/get-my-teams-query.dto';
+import type { GetTeamMembersQuery } from '../dto/get-team-members-query.dto';
+import type { UpdateTeamInput } from '../dto/update-team.dto';
+import type { AddTeamMemberResult } from '../types/add-team-member-result.type';
+import type { ChangeTeamLeaderResult } from '../types/change-team-leader-result.type';
+import type { CreateTeamResult } from '../types/create-team-result.type';
+import type { DeleteTeamResult } from '../types/delete-team-result.type';
+import type { BandTeamListItem, GetBandTeamsResult } from '../types/get-band-teams-result.type';
+import type { GetMyTeamsResult, MyTeamListItem } from '../types/get-my-teams-result.type';
+import type { GetTeamMembersResult, TeamMemberListItem } from '../types/get-team-members-result.type';
+import type { GetTeamResult } from '../types/get-team-result.type';
+import type { RemoveTeamMemberResult } from '../types/remove-team-member-result.type';
+import type { UpdateTeamResult } from '../types/update-team-result.type';
+
+import type { CreateTeamRepositoryInput, TeamsRepository } from './teams.repository';
+
+@Injectable()
+export class TeamsPrismaRepository implements TeamsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findBandById(bandId: string, tx?: Prisma.TransactionClient): Promise<{ id: string } | null> {
+    const client = tx ?? this.prisma;
+    return client.band.findFirst({
+      where: { id: bandId, deletedAt: null },
+      select: { id: true },
+    });
+  }
+
+  async findBandMemberByBandIdAndUserId(bandId: string, userId: string, tx?: Prisma.TransactionClient): Promise<{ id: string } | null> {
+    const client = tx ?? this.prisma;
+    return client.bandMember.findFirst({
+      where: { bandId, userId },
+      select: { id: true },
+    });
+  }
+
+  async findBandMemberById(bandMemberId: string, tx?: Prisma.TransactionClient): Promise<{ id: string; bandId: string } | null> {
+    const client = tx ?? this.prisma;
+    return client.bandMember.findUnique({
+      where: { id: bandMemberId },
+      select: { id: true, bandId: true },
+    });
+  }
+
+  /**
+   * 팀 생성과 동시에 팀 리더 TeamMember를 삽입한다.
+   * 두 쿼리를 트랜잭션으로 묶어 정합성을 보장한다.
+   *
+   * @param {CreateTeamRepositoryInput} input - 팀 생성 입력값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<CreateTeamResult>} 생성된 팀 정보
+   */
+  async createTeam(input: CreateTeamRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateTeamResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<CreateTeamResult> => {
+      const team = await client.team.create({
+        data: {
+          bandId: input.bandId,
+          name: input.name,
+          description: input.description,
+          teamCoverUrl: input.teamCoverUrl,
+          teamLeaderBandMemberId: input.teamLeaderBandMemberId,
+        },
+        select: {
+          id: true,
+          bandId: true,
+          name: true,
+          description: true,
+          status: true,
+          teamLeaderBandMemberId: true,
+          teamCoverUrl: true,
+          createdAt: true,
+        },
+      });
+
+      await client.teamMember.create({
+        data: {
+          teamId: team.id,
+          bandMemberId: input.teamLeaderBandMemberId,
+          teamRole: 'LEADER',
+        },
+      });
+
+      return {
+        teamId: team.id,
+        bandId: team.bandId,
+        name: team.name,
+        description: team.description,
+        status: team.status,
+        teamLeaderUserId: input.teamLeaderUserId,
+        teamCoverUrl: team.teamCoverUrl,
+        createdAt: team.createdAt.toISOString(),
+      };
+    };
+
+    return tx ? run(tx) : this.prisma.$transaction(run);
+  }
+
+  /**
+   * 밴드에 속한 팀 목록을 createdAt + id 커서 기반으로 조회한다.
+   *
+   * @param {string} bandId - 대상 밴드 ID
+   * @param {GetBandTeamsQuery} query - 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetBandTeamsResult>} 밴드 팀 목록
+   */
+  async findBandTeams(bandId: string, query: GetBandTeamsQuery, tx?: Prisma.TransactionClient): Promise<GetBandTeamsResult> {
+    const client = tx ?? this.prisma;
+    const { orderBy } = parseToPrismaQuery(query);
+
+    const teams = await client.team.findMany({
+      where: {
+        bandId,
+        ...this.createBandTeamsCursorWhere(query),
+      },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        status: true,
+        teamCoverUrl: true,
+        createdAt: true,
+        teamLeaderBandMember: {
+          select: {
+            userId: true,
+            user: {
+              select: {
+                profile: {
+                  select: { nickname: true },
+                },
+              },
+            },
+          },
+        },
+        _count: {
+          select: { members: true },
+        },
+      },
+      orderBy,
+      take: query.take,
+    });
+
+    const items: BandTeamListItem[] = teams.map(team => ({
+      teamId: team.id,
+      name: team.name,
+      description: team.description,
+      status: team.status,
+      teamCoverUrl: team.teamCoverUrl,
+      memberCount: team._count.members,
+      teamLeader: team.teamLeaderBandMember
+        ? {
+            userId: team.teamLeaderBandMember.userId,
+            nickname: team.teamLeaderBandMember.user?.profile?.nickname ?? '',
+          }
+        : null,
+      createdAt: team.createdAt.toISOString(),
+    }));
+
+    const count = items.length;
+    const cursor = count > 0 ? { createdAt: items[0].createdAt, id: teams[0].id } : null;
+    const lastItem = items[count - 1];
+    const next =
+      count === query.take && lastItem
+        ? buildNextPath(`/bands/${bandId}/teams`, {
+            cursor__created_at: lastItem.createdAt,
+            cursor__id: teams[count - 1].id,
+            take: query.take,
+            order__created_at: query.order__created_at,
+            order__id: query.order__id,
+          })
+        : null;
+
+    return {
+      bandId,
+      items,
+      meta: {
+        count,
+        take: query.take,
+        cursor,
+        next,
+      },
+    };
+  }
+
+  /**
+   * 팀 상세 정보를 조회한다. 팀 리더·멤버 수 포함.
+   *
+   * @param {string} teamId - 조회할 팀 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetTeamResult | null>} 팀 상세 정보
+   */
+  async findTeamById(teamId: string, tx?: Prisma.TransactionClient): Promise<GetTeamResult | null> {
+    const client = tx ?? this.prisma;
+
+    const team = await client.team.findUnique({
+      where: { id: teamId },
+      select: {
+        id: true,
+        bandId: true,
+        name: true,
+        description: true,
+        status: true,
+        teamCoverUrl: true,
+        createdAt: true,
+        updatedAt: true,
+        teamLeaderBandMember: {
+          select: {
+            userId: true,
+            user: {
+              select: {
+                profile: {
+                  select: { nickname: true },
+                },
+              },
+            },
+          },
+        },
+        _count: {
+          select: { members: true },
+        },
+      },
+    });
+
+    if (!team) return null;
+
+    return {
+      teamId: team.id,
+      bandId: team.bandId,
+      name: team.name,
+      description: team.description,
+      status: team.status,
+      teamCoverUrl: team.teamCoverUrl,
+      teamLeader: team.teamLeaderBandMember
+        ? {
+            userId: team.teamLeaderBandMember.userId,
+            nickname: team.teamLeaderBandMember.user?.profile?.nickname ?? '',
+          }
+        : null,
+      memberCount: team._count.members,
+      createdAt: team.createdAt.toISOString(),
+      updatedAt: team.updatedAt.toISOString(),
+    };
+  }
+
+  async findTeamForUpdate(
+    teamId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{ id: string; bandId: string; teamLeaderBandMemberId: string | null } | null> {
+    const client = tx ?? this.prisma;
+    return client.team.findUnique({
+      where: { id: teamId },
+      select: { id: true, bandId: true, teamLeaderBandMemberId: true },
+    });
+  }
+
+  async findTeamMemberByTeamAndBandMember(
+    teamId: string,
+    bandMemberId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{ id: string; teamRole: string } | null> {
+    const client = tx ?? this.prisma;
+    return client.teamMember.findUnique({
+      where: { teamId_bandMemberId: { teamId, bandMemberId } },
+      select: { id: true, teamRole: true },
+    });
+  }
+
+  async findTeamMemberById(
+    teamMemberId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{ id: string; teamId: string; bandMemberId: string; teamRole: string } | null> {
+    const client = tx ?? this.prisma;
+    return client.teamMember.findUnique({
+      where: { id: teamMemberId },
+      select: { id: true, teamId: true, bandMemberId: true, teamRole: true },
+    });
+  }
+
+  async updateTeam(teamId: string, input: UpdateTeamInput, tx?: Prisma.TransactionClient): Promise<UpdateTeamResult> {
+    const client = tx ?? this.prisma;
+
+    const team = await client.team.update({
+      where: { id: teamId },
+      data: {
+        ...(input.name !== undefined && { name: input.name }),
+        ...(input.description !== undefined && { description: input.description }),
+        ...(input.status !== undefined && { status: input.status }),
+        ...(input.teamCoverUrl !== undefined && { teamCoverUrl: input.teamCoverUrl }),
+      },
+      select: {
+        id: true,
+        bandId: true,
+        name: true,
+        description: true,
+        status: true,
+        teamCoverUrl: true,
+        updatedAt: true,
+        teamLeaderBandMember: {
+          select: {
+            userId: true,
+            user: {
+              select: {
+                profile: { select: { nickname: true } },
+              },
+            },
+          },
+        },
+        _count: { select: { members: true } },
+      },
+    });
+
+    return {
+      teamId: team.id,
+      bandId: team.bandId,
+      name: team.name,
+      description: team.description,
+      status: team.status,
+      teamCoverUrl: team.teamCoverUrl,
+      teamLeader: team.teamLeaderBandMember
+        ? {
+            userId: team.teamLeaderBandMember.userId,
+            nickname: team.teamLeaderBandMember.user?.profile?.nickname ?? '',
+          }
+        : null,
+      memberCount: team._count.members,
+      updatedAt: team.updatedAt.toISOString(),
+    };
+  }
+
+  /**
+   * 팀 멤버 목록을 joinedAt + id 커서 기반으로 조회한다.
+   *
+   * @param {string} teamId - 대상 팀 ID
+   * @param {GetTeamMembersQuery} query - 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetTeamMembersResult>} 팀 멤버 목록
+   */
+  async findTeamMembers(teamId: string, query: GetTeamMembersQuery, tx?: Prisma.TransactionClient): Promise<GetTeamMembersResult> {
+    const client = tx ?? this.prisma;
+    const { orderBy } = parseToPrismaQuery(query);
+
+    const teamMembers = await client.teamMember.findMany({
+      where: {
+        teamId,
+        ...this.createTeamMembersCursorWhere(query),
+      },
+      select: {
+        id: true,
+        bandMemberId: true,
+        teamRole: true,
+        joinedAt: true,
+        bandMember: {
+          select: {
+            userId: true,
+            user: {
+              select: {
+                profile: {
+                  select: { nickname: true, avatarUrl: true },
+                },
+              },
+            },
+          },
+        },
+      },
+      orderBy,
+      take: query.take,
+    });
+
+    const items: TeamMemberListItem[] = teamMembers.map(member => ({
+      teamMemberId: member.id,
+      bandMemberId: member.bandMemberId,
+      user: {
+        userId: member.bandMember.userId,
+        nickname: member.bandMember.user?.profile?.nickname ?? '',
+        profileImageUrl: member.bandMember.user?.profile?.avatarUrl ?? null,
+      },
+      teamRole: member.teamRole,
+      joinedAt: member.joinedAt.toISOString(),
+    }));
+
+    const count = items.length;
+    const cursor = count > 0 ? { joinedAt: items[0].joinedAt, id: teamMembers[0].id } : null;
+    const lastItem = items[count - 1];
+    const next =
+      count === query.take && lastItem
+        ? buildNextPath(`/teams/${teamId}/members`, {
+            cursor__joined_at: lastItem.joinedAt,
+            cursor__id: teamMembers[count - 1].id,
+            take: query.take,
+            order__joined_at: query.order__joined_at,
+            order__id: query.order__id,
+          })
+        : null;
+
+    return {
+      teamId,
+      items,
+      meta: {
+        count,
+        take: query.take,
+        cursor,
+        next,
+      },
+    };
+  }
+
+  /**
+   * 기존 리더의 teamRole을 MEMBER로 낮추고 새 리더를 LEADER로 승격한다.
+   * Team.teamLeaderBandMemberId도 동시에 갱신한다.
+   *
+   * @param {string} teamId - 대상 팀 ID
+   * @param {string} newLeaderTeamMemberId - 새 리더가 될 TeamMember ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<ChangeTeamLeaderResult>} 변경 결과
+   */
+  async changeTeamLeader(teamId: string, newLeaderTeamMemberId: string, tx?: Prisma.TransactionClient): Promise<ChangeTeamLeaderResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<ChangeTeamLeaderResult> => {
+      await client.teamMember.updateMany({
+        where: { teamId, teamRole: 'LEADER' },
+        data: { teamRole: 'MEMBER' },
+      });
+
+      await client.teamMember.update({
+        where: { id: newLeaderTeamMemberId },
+        data: { teamRole: 'LEADER' },
+      });
+
+      const newLeaderMember = await client.teamMember.findUnique({
+        where: { id: newLeaderTeamMemberId },
+        select: {
+          bandMemberId: true,
+          bandMember: {
+            select: {
+              userId: true,
+              user: {
+                select: {
+                  profile: { select: { nickname: true } },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      await client.team.update({
+        where: { id: teamId },
+        data: { teamLeaderBandMemberId: newLeaderMember!.bandMemberId },
+      });
+
+      return {
+        teamId,
+        teamLeader: {
+          userId: newLeaderMember!.bandMember.userId,
+          nickname: newLeaderMember!.bandMember.user?.profile?.nickname ?? '',
+        },
+      };
+    };
+
+    return tx ? run(tx) : this.prisma.$transaction(run);
+  }
+
+  async removeTeamMember(teamMemberId: string, teamId: string, tx?: Prisma.TransactionClient): Promise<RemoveTeamMemberResult> {
+    const client = tx ?? this.prisma;
+
+    await client.teamMember.delete({
+      where: { id: teamMemberId },
+    });
+
+    return { teamMemberId, removed: true };
+  }
+
+  /**
+   * 사용자가 속한 팀 목록을 joinedAt + id 커서 기반으로 조회한다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {GetMyTeamsQuery} query - 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetMyTeamsResult>} 내가 속한 팀 목록
+   */
+  async findMyTeams(userId: string, query: GetMyTeamsQuery, tx?: Prisma.TransactionClient): Promise<GetMyTeamsResult> {
+    const client = tx ?? this.prisma;
+    const { orderBy } = parseToPrismaQuery(query);
+
+    const myTeamMembers = await client.teamMember.findMany({
+      where: {
+        bandMember: { userId },
+        ...this.createMyTeamsCursorWhere(query),
+      },
+      select: {
+        id: true,
+        teamRole: true,
+        joinedAt: true,
+        team: {
+          select: {
+            id: true,
+            bandId: true,
+            band: { select: { name: true } },
+            name: true,
+            description: true,
+            status: true,
+            teamCoverUrl: true,
+            createdAt: true,
+            teamLeaderBandMember: {
+              select: {
+                userId: true,
+                user: {
+                  select: {
+                    profile: { select: { nickname: true } },
+                  },
+                },
+              },
+            },
+            _count: { select: { members: true } },
+          },
+        },
+      },
+      orderBy,
+      take: query.take,
+    });
+
+    const items: MyTeamListItem[] = myTeamMembers.map(member => ({
+      teamId: member.team.id,
+      bandId: member.team.bandId,
+      bandName: member.team.band.name ?? '',
+      name: member.team.name,
+      description: member.team.description,
+      status: member.team.status,
+      teamCoverUrl: member.team.teamCoverUrl,
+      myTeamRole: member.teamRole,
+      memberCount: member.team._count.members,
+      teamLeader: member.team.teamLeaderBandMember
+        ? {
+            userId: member.team.teamLeaderBandMember.userId,
+            nickname: member.team.teamLeaderBandMember.user?.profile?.nickname ?? '',
+          }
+        : null,
+      joinedAt: member.joinedAt.toISOString(),
+      createdAt: member.team.createdAt.toISOString(),
+    }));
+
+    const count = items.length;
+    const cursor = count > 0 ? { joinedAt: items[0].joinedAt, id: myTeamMembers[0].id } : null;
+    const lastItem = items[count - 1];
+    const next =
+      count === query.take && lastItem
+        ? buildNextPath(`/teams/me`, {
+            cursor__joined_at: lastItem.joinedAt,
+            cursor__id: myTeamMembers[count - 1].id,
+            take: query.take,
+            order__joined_at: query.order__joined_at,
+            order__id: query.order__id,
+          })
+        : null;
+
+    return {
+      items,
+      meta: {
+        count,
+        take: query.take,
+        cursor,
+        next,
+      },
+    };
+  }
+
+  async addTeamMember(teamId: string, bandMemberId: string, tx?: Prisma.TransactionClient): Promise<AddTeamMemberResult> {
+    const client = tx ?? this.prisma;
+
+    const teamMember = await client.teamMember.create({
+      data: {
+        teamId,
+        bandMemberId,
+        teamRole: 'MEMBER',
+      },
+      select: {
+        id: true,
+        teamId: true,
+        bandMemberId: true,
+        teamRole: true,
+        joinedAt: true,
+        bandMember: {
+          select: {
+            userId: true,
+            user: {
+              select: {
+                profile: { select: { nickname: true, avatarUrl: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return {
+      teamMemberId: teamMember.id,
+      teamId: teamMember.teamId,
+      bandMemberId: teamMember.bandMemberId,
+      user: {
+        userId: teamMember.bandMember.userId,
+        nickname: teamMember.bandMember.user?.profile?.nickname ?? '',
+        profileImageUrl: teamMember.bandMember.user?.profile?.avatarUrl ?? null,
+      },
+      teamRole: teamMember.teamRole,
+      joinedAt: teamMember.joinedAt.toISOString(),
+    };
+  }
+
+  async deleteTeam(teamId: string, tx?: Prisma.TransactionClient): Promise<DeleteTeamResult> {
+    const client = tx ?? this.prisma;
+
+    await client.team.delete({ where: { id: teamId } });
+
+    return { teamId, deleted: true };
+  }
+
+  private createBandTeamsCursorWhere(query: GetBandTeamsQuery): Prisma.TeamWhereInput {
+    if (query.cursor__created_at === undefined || query.cursor__id === undefined) {
+      return {};
+    }
+
+    const cursorCreatedAt = new Date(query.cursor__created_at);
+    const cursorOperator = query.order__created_at === 'asc' ? 'gt' : 'lt';
+
+    return {
+      OR: [
+        { createdAt: { [cursorOperator]: cursorCreatedAt } },
+        {
+          createdAt: cursorCreatedAt,
+          id: { [cursorOperator]: query.cursor__id },
+        },
+      ],
+    };
+  }
+
+  private createTeamMembersCursorWhere(query: GetTeamMembersQuery): Prisma.TeamMemberWhereInput {
+    if (query.cursor__joined_at === undefined || query.cursor__id === undefined) {
+      return {};
+    }
+
+    const cursorJoinedAt = new Date(query.cursor__joined_at);
+    const cursorOperator = query.order__joined_at === 'asc' ? 'gt' : 'lt';
+
+    return {
+      OR: [
+        { joinedAt: { [cursorOperator]: cursorJoinedAt } },
+        {
+          joinedAt: cursorJoinedAt,
+          id: { [cursorOperator]: query.cursor__id },
+        },
+      ],
+    };
+  }
+
+  private createMyTeamsCursorWhere(query: GetMyTeamsQuery): Prisma.TeamMemberWhereInput {
+    if (query.cursor__joined_at === undefined || query.cursor__id === undefined) {
+      return {};
+    }
+
+    const cursorJoinedAt = new Date(query.cursor__joined_at);
+    const cursorOperator = query.order__joined_at === 'asc' ? 'gt' : 'lt';
+
+    return {
+      OR: [
+        { joinedAt: { [cursorOperator]: cursorJoinedAt } },
+        {
+          joinedAt: cursorJoinedAt,
+          id: { [cursorOperator]: query.cursor__id },
+        },
+      ],
+    };
+  }
+}

--- a/backend/src/modules/teams/repositories/teams.prisma-repository.ts
+++ b/backend/src/modules/teams/repositories/teams.prisma-repository.ts
@@ -143,10 +143,12 @@ export class TeamsPrismaRepository implements TeamsRepository {
         },
       },
       orderBy,
-      take: query.take,
+      take: query.take + 1,
     });
 
-    const items: BandTeamListItem[] = teams.map(team => ({
+    const hasNext = teams.length > query.take;
+    const rows = hasNext ? teams.slice(0, query.take) : teams;
+    const items: BandTeamListItem[] = rows.map(team => ({
       teamId: team.id,
       name: team.name,
       description: team.description,
@@ -163,13 +165,13 @@ export class TeamsPrismaRepository implements TeamsRepository {
     }));
 
     const count = items.length;
-    const cursor = count > 0 ? { createdAt: items[0].createdAt, id: teams[0].id } : null;
+    const cursor = count > 0 ? { createdAt: items[0].createdAt, id: rows[0].id } : null;
     const lastItem = items[count - 1];
     const next =
-      count === query.take && lastItem
+      hasNext && lastItem
         ? buildNextPath(`/bands/${bandId}/teams`, {
             cursor__created_at: lastItem.createdAt,
-            cursor__id: teams[count - 1].id,
+            cursor__id: rows[count - 1].id,
             take: query.take,
             order__created_at: query.order__created_at,
             order__id: query.order__id,
@@ -369,10 +371,12 @@ export class TeamsPrismaRepository implements TeamsRepository {
         },
       },
       orderBy,
-      take: query.take,
+      take: query.take + 1,
     });
 
-    const items: TeamMemberListItem[] = teamMembers.map(member => ({
+    const hasNext = teamMembers.length > query.take;
+    const rows = hasNext ? teamMembers.slice(0, query.take) : teamMembers;
+    const items: TeamMemberListItem[] = rows.map(member => ({
       teamMemberId: member.id,
       bandMemberId: member.bandMemberId,
       user: {
@@ -385,13 +389,13 @@ export class TeamsPrismaRepository implements TeamsRepository {
     }));
 
     const count = items.length;
-    const cursor = count > 0 ? { joinedAt: items[0].joinedAt, id: teamMembers[0].id } : null;
+    const cursor = count > 0 ? { joinedAt: items[0].joinedAt, id: rows[0].id } : null;
     const lastItem = items[count - 1];
     const next =
-      count === query.take && lastItem
+      hasNext && lastItem
         ? buildNextPath(`/teams/${teamId}/members`, {
             cursor__joined_at: lastItem.joinedAt,
-            cursor__id: teamMembers[count - 1].id,
+            cursor__id: rows[count - 1].id,
             take: query.take,
             order__joined_at: query.order__joined_at,
             order__id: query.order__id,
@@ -521,10 +525,12 @@ export class TeamsPrismaRepository implements TeamsRepository {
         },
       },
       orderBy,
-      take: query.take,
+      take: query.take + 1,
     });
 
-    const items: MyTeamListItem[] = myTeamMembers.map(member => ({
+    const hasNext = myTeamMembers.length > query.take;
+    const rows = hasNext ? myTeamMembers.slice(0, query.take) : myTeamMembers;
+    const items: MyTeamListItem[] = rows.map(member => ({
       teamId: member.team.id,
       bandId: member.team.bandId,
       bandName: member.team.band.name ?? '',
@@ -545,13 +551,13 @@ export class TeamsPrismaRepository implements TeamsRepository {
     }));
 
     const count = items.length;
-    const cursor = count > 0 ? { joinedAt: items[0].joinedAt, id: myTeamMembers[0].id } : null;
+    const cursor = count > 0 ? { joinedAt: items[0].joinedAt, id: rows[0].id } : null;
     const lastItem = items[count - 1];
     const next =
-      count === query.take && lastItem
+      hasNext && lastItem
         ? buildNextPath(`/teams/me`, {
             cursor__joined_at: lastItem.joinedAt,
-            cursor__id: myTeamMembers[count - 1].id,
+            cursor__id: rows[count - 1].id,
             take: query.take,
             order__joined_at: query.order__joined_at,
             order__id: query.order__id,

--- a/backend/src/modules/teams/repositories/teams.prisma-repository.ts
+++ b/backend/src/modules/teams/repositories/teams.prisma-repository.ts
@@ -631,14 +631,15 @@ export class TeamsPrismaRepository implements TeamsRepository {
     }
 
     const cursorCreatedAt = new Date(query.cursor__created_at);
-    const cursorOperator = query.order__created_at === 'asc' ? 'gt' : 'lt';
+    const tsOp = query.order__created_at === 'asc' ? 'gt' : 'lt';
+    const idOp = query.order__id === 'asc' ? 'gt' : 'lt';
 
     return {
       OR: [
-        { createdAt: { [cursorOperator]: cursorCreatedAt } },
+        { createdAt: { [tsOp]: cursorCreatedAt } },
         {
           createdAt: cursorCreatedAt,
-          id: { [cursorOperator]: query.cursor__id },
+          id: { [idOp]: query.cursor__id },
         },
       ],
     };
@@ -650,14 +651,15 @@ export class TeamsPrismaRepository implements TeamsRepository {
     }
 
     const cursorJoinedAt = new Date(query.cursor__joined_at);
-    const cursorOperator = query.order__joined_at === 'asc' ? 'gt' : 'lt';
+    const tsOp = query.order__joined_at === 'asc' ? 'gt' : 'lt';
+    const idOp = query.order__id === 'asc' ? 'gt' : 'lt';
 
     return {
       OR: [
-        { joinedAt: { [cursorOperator]: cursorJoinedAt } },
+        { joinedAt: { [tsOp]: cursorJoinedAt } },
         {
           joinedAt: cursorJoinedAt,
-          id: { [cursorOperator]: query.cursor__id },
+          id: { [idOp]: query.cursor__id },
         },
       ],
     };
@@ -669,14 +671,15 @@ export class TeamsPrismaRepository implements TeamsRepository {
     }
 
     const cursorJoinedAt = new Date(query.cursor__joined_at);
-    const cursorOperator = query.order__joined_at === 'asc' ? 'gt' : 'lt';
+    const tsOp = query.order__joined_at === 'asc' ? 'gt' : 'lt';
+    const idOp = query.order__id === 'asc' ? 'gt' : 'lt';
 
     return {
       OR: [
-        { joinedAt: { [cursorOperator]: cursorJoinedAt } },
+        { joinedAt: { [tsOp]: cursorJoinedAt } },
         {
           joinedAt: cursorJoinedAt,
-          id: { [cursorOperator]: query.cursor__id },
+          id: { [idOp]: query.cursor__id },
         },
       ],
     };

--- a/backend/src/modules/teams/repositories/teams.repository.ts
+++ b/backend/src/modules/teams/repositories/teams.repository.ts
@@ -1,0 +1,108 @@
+import type { Prisma } from '../../../generated/prisma';
+import type { CreateTeamInput } from '../dto/create-team.dto';
+import type { GetBandTeamsQuery } from '../dto/get-band-teams-query.dto';
+import type { GetMyTeamsQuery } from '../dto/get-my-teams-query.dto';
+import type { GetTeamMembersQuery } from '../dto/get-team-members-query.dto';
+import type { UpdateTeamInput } from '../dto/update-team.dto';
+import type { AddTeamMemberResult } from '../types/add-team-member-result.type';
+import type { ChangeTeamLeaderResult } from '../types/change-team-leader-result.type';
+import type { CreateTeamResult } from '../types/create-team-result.type';
+import type { DeleteTeamResult } from '../types/delete-team-result.type';
+import type { GetBandTeamsResult } from '../types/get-band-teams-result.type';
+import type { GetMyTeamsResult } from '../types/get-my-teams-result.type';
+import type { GetTeamMembersResult } from '../types/get-team-members-result.type';
+import type { GetTeamResult } from '../types/get-team-result.type';
+import type { RemoveTeamMemberResult } from '../types/remove-team-member-result.type';
+import type { UpdateTeamResult } from '../types/update-team-result.type';
+
+export const TEAMS_REPOSITORY = Symbol('TEAMS_REPOSITORY');
+
+export interface CreateTeamRepositoryInput extends CreateTeamInput {
+  bandId: string;
+  teamLeaderBandMemberId: string;
+  teamLeaderUserId: string;
+}
+
+export interface TeamsRepository {
+  /** 삭제되지 않은 밴드 존재 여부 확인 */
+  findBandById(bandId: string, tx?: Prisma.TransactionClient): Promise<{ id: string } | null>;
+
+  /** 밴드 멤버 존재 여부 확인 */
+  findBandMemberByBandIdAndUserId(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+  } | null>;
+
+  /** 밴드 멤버 단건 조회 (팀 멤버 추가 시 밴드 멤버 검증) */
+  findBandMemberById(
+    bandMemberId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    bandId: string;
+  } | null>;
+
+  /** 팀 생성 (팀 리더 TeamMember 동시 생성) */
+  createTeam(input: CreateTeamRepositoryInput, tx?: Prisma.TransactionClient): Promise<CreateTeamResult>;
+
+  /** 밴드 팀 목록 조회 (커서 페이지네이션) */
+  findBandTeams(bandId: string, query: GetBandTeamsQuery, tx?: Prisma.TransactionClient): Promise<GetBandTeamsResult>;
+
+  /** 팀 상세 조회 */
+  findTeamById(teamId: string, tx?: Prisma.TransactionClient): Promise<GetTeamResult | null>;
+
+  /** 팀 존재 여부 및 권한 체크용 조회 */
+  findTeamForUpdate(
+    teamId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    bandId: string;
+    teamLeaderBandMemberId: string | null;
+  } | null>;
+
+  /** 팀 멤버십 확인 (팀 내 특정 밴드 멤버 조회) */
+  findTeamMemberByTeamAndBandMember(
+    teamId: string,
+    bandMemberId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    teamRole: string;
+  } | null>;
+
+  /** 팀 멤버 단건 조회 */
+  findTeamMemberById(
+    teamMemberId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+    teamId: string;
+    bandMemberId: string;
+    teamRole: string;
+  } | null>;
+
+  /** 팀 정보 수정 */
+  updateTeam(teamId: string, input: UpdateTeamInput, tx?: Prisma.TransactionClient): Promise<UpdateTeamResult>;
+
+  /** 팀 멤버 목록 조회 (커서 페이지네이션) */
+  findTeamMembers(teamId: string, query: GetTeamMembersQuery, tx?: Prisma.TransactionClient): Promise<GetTeamMembersResult>;
+
+  /** 팀 리더 변경 */
+  changeTeamLeader(teamId: string, newLeaderTeamMemberId: string, tx?: Prisma.TransactionClient): Promise<ChangeTeamLeaderResult>;
+
+  /** 팀 멤버 제거 */
+  removeTeamMember(teamMemberId: string, teamId: string, tx?: Prisma.TransactionClient): Promise<RemoveTeamMemberResult>;
+
+  /** 내 팀 목록 조회 (커서 페이지네이션) */
+  findMyTeams(userId: string, query: GetMyTeamsQuery, tx?: Prisma.TransactionClient): Promise<GetMyTeamsResult>;
+
+  /** 팀 멤버 추가 */
+  addTeamMember(teamId: string, bandMemberId: string, tx?: Prisma.TransactionClient): Promise<AddTeamMemberResult>;
+
+  /** 팀 삭제 (hard delete, TeamMember cascade) */
+  deleteTeam(teamId: string, tx?: Prisma.TransactionClient): Promise<DeleteTeamResult>;
+}

--- a/backend/src/modules/teams/teams.controller.ts
+++ b/backend/src/modules/teams/teams.controller.ts
@@ -1,0 +1,191 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query, Req, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
+import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
+import type { AuthUser } from '../users/repositoreis/user.repository';
+
+import { AddTeamMemberBodyDto } from './dto/add-team-member.dto';
+import { ChangeTeamLeaderBodyDto } from './dto/change-team-leader.dto';
+import { CreateTeamBodyDto } from './dto/create-team.dto';
+import { GetBandTeamsQueryDto } from './dto/get-band-teams-query.dto';
+import { GetMyTeamsQueryDto } from './dto/get-my-teams-query.dto';
+import { GetTeamMembersQueryDto } from './dto/get-team-members-query.dto';
+import { UpdateTeamBodyDto } from './dto/update-team.dto';
+import type { AddTeamMemberResult } from './types/add-team-member-result.type';
+import type { ChangeTeamLeaderResult } from './types/change-team-leader-result.type';
+import type { CreateTeamResult } from './types/create-team-result.type';
+import type { DeleteTeamResult } from './types/delete-team-result.type';
+import type { GetBandTeamsResult } from './types/get-band-teams-result.type';
+import type { GetMyTeamsResult } from './types/get-my-teams-result.type';
+import type { GetTeamMembersResult } from './types/get-team-members-result.type';
+import type { GetTeamResult } from './types/get-team-result.type';
+import type { RemoveTeamMemberResult } from './types/remove-team-member-result.type';
+import type { UpdateTeamResult } from './types/update-team-result.type';
+import { TeamsService } from './teams.service';
+
+interface AuthenticatedRequest {
+  user: AuthUser;
+}
+
+@ApiTags('밴드 - 팀')
+@Controller('bands')
+export class BandTeamsController {
+  constructor(private readonly teamsService: TeamsService) {}
+
+  @Post(':bandId/teams')
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '#53 팀 생성' })
+  @ApiParam({ name: 'bandId', description: '밴드 ID (UUID)', type: String })
+  @ApiResponse({ status: 201, description: '팀 생성 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 요청' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  @ApiResponse({ status: 403, description: '밴드 멤버가 아님' })
+  async createTeam(
+    @Req() request: AuthenticatedRequest,
+    @Param('bandId') bandId: string,
+    @Body() input: CreateTeamBodyDto,
+  ): Promise<ApiSuccessResponse<CreateTeamResult>> {
+    const result = await this.teamsService.createTeam(request.user.id, bandId, input);
+    return createSuccessResponse('팀 생성 성공', result);
+  }
+
+  @Get(':bandId/teams')
+  @ApiOperation({ summary: '#54 밴드 팀 목록 조회' })
+  @ApiParam({ name: 'bandId', description: '밴드 ID (UUID)', type: String })
+  @ApiResponse({ status: 200, description: '밴드 팀 목록 조회 성공' })
+  @ApiResponse({ status: 404, description: '밴드를 찾을 수 없음' })
+  async getBandTeams(@Param('bandId') bandId: string, @Query() query: GetBandTeamsQueryDto): Promise<ApiSuccessResponse<GetBandTeamsResult>> {
+    const result = await this.teamsService.getBandTeams(bandId, query);
+    return createSuccessResponse('밴드 팀 목록 조회 성공', result);
+  }
+}
+
+@ApiTags('팀')
+@Controller('teams')
+export class TeamsController {
+  constructor(private readonly teamsService: TeamsService) {}
+
+  @Get('me')
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '#55 내 팀 목록 조회' })
+  @ApiResponse({ status: 200, description: '내 팀 목록 조회 성공' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  async getMyTeams(@Req() request: AuthenticatedRequest, @Query() query: GetMyTeamsQueryDto): Promise<ApiSuccessResponse<GetMyTeamsResult>> {
+    const result = await this.teamsService.getMyTeams(request.user.id, query);
+    return createSuccessResponse('내 팀 목록 조회 성공', result);
+  }
+
+  @Get(':teamId')
+  @ApiOperation({ summary: '#60 팀 상세 조회' })
+  @ApiParam({ name: 'teamId', description: '팀 ID (UUID)', type: String })
+  @ApiResponse({ status: 200, description: '팀 상세 조회 성공' })
+  @ApiResponse({ status: 404, description: '팀을 찾을 수 없음' })
+  async getTeam(@Param('teamId') teamId: string): Promise<ApiSuccessResponse<GetTeamResult>> {
+    const result = await this.teamsService.getTeam(teamId);
+    return createSuccessResponse('팀 상세 조회 성공', result);
+  }
+
+  @Patch(':teamId')
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '#61 팀 정보 수정' })
+  @ApiParam({ name: 'teamId', description: '팀 ID (UUID)', type: String })
+  @ApiResponse({ status: 200, description: '팀 정보 수정 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 요청' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  @ApiResponse({ status: 403, description: '팀 리더 권한 필요' })
+  @ApiResponse({ status: 404, description: '팀을 찾을 수 없음' })
+  async updateTeam(
+    @Req() request: AuthenticatedRequest,
+    @Param('teamId') teamId: string,
+    @Body() input: UpdateTeamBodyDto,
+  ): Promise<ApiSuccessResponse<UpdateTeamResult>> {
+    const result = await this.teamsService.updateTeam(request.user.id, teamId, input);
+    return createSuccessResponse('팀 정보 수정 성공', result);
+  }
+
+  @Get(':teamId/members')
+  @ApiOperation({ summary: '#62 팀 멤버 목록 조회' })
+  @ApiParam({ name: 'teamId', description: '팀 ID (UUID)', type: String })
+  @ApiResponse({ status: 200, description: '팀 멤버 목록 조회 성공' })
+  @ApiResponse({ status: 404, description: '팀을 찾을 수 없음' })
+  async getTeamMembers(@Param('teamId') teamId: string, @Query() query: GetTeamMembersQueryDto): Promise<ApiSuccessResponse<GetTeamMembersResult>> {
+    const result = await this.teamsService.getTeamMembers(teamId, query);
+    return createSuccessResponse('팀 멤버 목록 조회 성공', result);
+  }
+
+  @Patch(':teamId/leader')
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '#63 팀 리더 변경' })
+  @ApiParam({ name: 'teamId', description: '팀 ID (UUID)', type: String })
+  @ApiResponse({ status: 200, description: '팀 리더 변경 성공' })
+  @ApiResponse({ status: 400, description: '이미 팀 리더 / 잘못된 요청' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  @ApiResponse({ status: 403, description: '팀 리더 권한 필요' })
+  @ApiResponse({ status: 404, description: '팀 또는 팀 멤버를 찾을 수 없음' })
+  async changeTeamLeader(
+    @Req() request: AuthenticatedRequest,
+    @Param('teamId') teamId: string,
+    @Body() input: ChangeTeamLeaderBodyDto,
+  ): Promise<ApiSuccessResponse<ChangeTeamLeaderResult>> {
+    const result = await this.teamsService.changeTeamLeader(request.user.id, teamId, input);
+    return createSuccessResponse('팀 리더 변경 성공', result);
+  }
+
+  @Delete(':teamId/members/:teamMemberId')
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '#64 팀 멤버 제거' })
+  @ApiParam({ name: 'teamId', description: '팀 ID (UUID)', type: String })
+  @ApiParam({ name: 'teamMemberId', description: '팀 멤버 ID (UUID)', type: String })
+  @ApiResponse({ status: 200, description: '팀 멤버 제거 성공' })
+  @ApiResponse({ status: 400, description: '팀 리더는 자기 자신을 제거할 수 없음' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  @ApiResponse({ status: 403, description: '팀 리더 권한 필요' })
+  @ApiResponse({ status: 404, description: '팀 또는 팀 멤버를 찾을 수 없음' })
+  async removeTeamMember(
+    @Req() request: AuthenticatedRequest,
+    @Param('teamId') teamId: string,
+    @Param('teamMemberId') teamMemberId: string,
+  ): Promise<ApiSuccessResponse<RemoveTeamMemberResult>> {
+    const result = await this.teamsService.removeTeamMember(request.user.id, teamId, teamMemberId);
+    return createSuccessResponse('팀 멤버 제거 성공', result);
+  }
+
+  @Post(':teamId/members')
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '#65 팀 멤버 추가' })
+  @ApiParam({ name: 'teamId', description: '팀 ID (UUID)', type: String })
+  @ApiResponse({ status: 201, description: '팀 멤버 추가 성공' })
+  @ApiResponse({ status: 400, description: '이미 팀 멤버 / 다른 밴드 멤버' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  @ApiResponse({ status: 403, description: '팀 리더 권한 필요' })
+  @ApiResponse({ status: 404, description: '팀 또는 밴드 멤버를 찾을 수 없음' })
+  async addTeamMember(
+    @Req() request: AuthenticatedRequest,
+    @Param('teamId') teamId: string,
+    @Body() input: AddTeamMemberBodyDto,
+  ): Promise<ApiSuccessResponse<AddTeamMemberResult>> {
+    const result = await this.teamsService.addTeamMember(request.user.id, teamId, input.bandMemberId);
+    return createSuccessResponse('팀 멤버 추가 성공', result);
+  }
+
+  @Delete(':teamId')
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '#66 팀 삭제' })
+  @ApiParam({ name: 'teamId', description: '팀 ID (UUID)', type: String })
+  @ApiResponse({ status: 200, description: '팀 삭제 성공' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  @ApiResponse({ status: 403, description: '팀 리더 권한 필요' })
+  @ApiResponse({ status: 404, description: '팀을 찾을 수 없음' })
+  async deleteTeam(@Req() request: AuthenticatedRequest, @Param('teamId') teamId: string): Promise<ApiSuccessResponse<DeleteTeamResult>> {
+    const result = await this.teamsService.deleteTeam(request.user.id, teamId);
+    return createSuccessResponse('팀 삭제 성공', result);
+  }
+}

--- a/backend/src/modules/teams/teams.controller.ts
+++ b/backend/src/modules/teams/teams.controller.ts
@@ -42,6 +42,7 @@ export class BandTeamsController {
   @ApiResponse({ status: 400, description: '잘못된 요청' })
   @ApiResponse({ status: 401, description: '인증 실패' })
   @ApiResponse({ status: 403, description: '밴드 멤버가 아님' })
+  @ApiResponse({ status: 404, description: '밴드를 찾을 수 없음' })
   async createTeam(
     @Req() request: AuthenticatedRequest,
     @Param('bandId') bandId: string,

--- a/backend/src/modules/teams/teams.module.ts
+++ b/backend/src/modules/teams/teams.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+
+import { AuthModule } from '../../auth/auth.module';
+import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
+
+import { TeamsPrismaRepository } from './repositories/teams.prisma-repository';
+import { TEAMS_REPOSITORY } from './repositories/teams.repository';
+import { BandTeamsController, TeamsController } from './teams.controller';
+import { TeamsService } from './teams.service';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [BandTeamsController, TeamsController],
+  providers: [
+    AccessTokenGuard,
+    TeamsService,
+    TeamsPrismaRepository,
+    {
+      provide: TEAMS_REPOSITORY,
+      useExisting: TeamsPrismaRepository,
+    },
+  ],
+})
+export class TeamsModule {}

--- a/backend/src/modules/teams/teams.service.spec.ts
+++ b/backend/src/modules/teams/teams.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import type { PrismaService } from 'src/database/prisma';
+import { Prisma } from 'src/generated/prisma';
 
 import type { GetBandTeamsQuery } from './dto/get-band-teams-query.dto';
 import type { GetMyTeamsQuery } from './dto/get-my-teams-query.dto';
@@ -692,6 +693,20 @@ describe('TeamsService', () => {
         }),
         createPrismaServiceStub(),
       );
+
+      await expect(service.addTeamMember(USER_ID, TEAM_ID, OTHER_BAND_MEMBER_ID)).rejects.toThrow(ConflictException);
+    });
+
+    it('동시 요청으로 P2002가 발생하면 ConflictException으로 변환한다', async () => {
+      const p2002 = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', { code: 'P2002', clientVersion: '0' });
+      const repository = createTeamsRepositoryStub({
+        bandMemberById: otherBandMemberRecord,
+        onAddTeamMember: () => {
+          throw p2002;
+        },
+      });
+
+      const service = new TeamsService(repository, createPrismaServiceStub());
 
       await expect(service.addTeamMember(USER_ID, TEAM_ID, OTHER_BAND_MEMBER_ID)).rejects.toThrow(ConflictException);
     });

--- a/backend/src/modules/teams/teams.service.spec.ts
+++ b/backend/src/modules/teams/teams.service.spec.ts
@@ -273,11 +273,20 @@ describe('TeamsService', () => {
       capturedTransactions.forEach(tx => expect(tx).toBe(firstTx));
     });
 
-    it('외부 tx가 있으면 새 $transaction을 열지 않는다', async () => {
+    it('외부 tx가 있으면 새 $transaction을 열지 않고 mutation에 externalTx를 전달한다', async () => {
       const externalTx = { transactionClient: true };
-      const service = new TeamsService(createTeamsRepositoryStub(), createPrismaServiceFailingTransactionStub());
+      let capturedTx: unknown;
+      const service = new TeamsService(
+        createTeamsRepositoryStub({
+          onCreateTeam: (_input, tx) => {
+            capturedTx = tx;
+          },
+        }),
+        createPrismaServiceFailingTransactionStub(),
+      );
 
       await expect(service.createTeam(USER_ID, BAND_ID, { name: '보컬팀' }, externalTx as never)).resolves.toBeDefined();
+      expect(capturedTx).toBe(externalTx);
     });
   });
 
@@ -354,11 +363,20 @@ describe('TeamsService', () => {
       capturedTransactions.forEach(tx => expect(tx).toBe(firstTx));
     });
 
-    it('외부 tx가 있으면 새 $transaction을 열지 않는다', async () => {
+    it('외부 tx가 있으면 새 $transaction을 열지 않고 mutation에 externalTx를 전달한다', async () => {
       const externalTx = { transactionClient: true };
-      const service = new TeamsService(createTeamsRepositoryStub(), createPrismaServiceFailingTransactionStub());
+      let capturedTx: unknown;
+      const service = new TeamsService(
+        createTeamsRepositoryStub({
+          onUpdateTeam: (_teamId, _input, tx) => {
+            capturedTx = tx;
+          },
+        }),
+        createPrismaServiceFailingTransactionStub(),
+      );
 
       await expect(service.updateTeam(USER_ID, TEAM_ID, { name: '새 이름' }, externalTx as never)).resolves.toBeDefined();
+      expect(capturedTx).toBe(externalTx);
     });
   });
 
@@ -446,14 +464,21 @@ describe('TeamsService', () => {
       capturedTransactions.forEach(tx => expect(tx).toBe(firstTx));
     });
 
-    it('외부 tx가 있으면 새 $transaction을 열지 않는다', async () => {
+    it('외부 tx가 있으면 새 $transaction을 열지 않고 mutation에 externalTx를 전달한다', async () => {
       const externalTx = { transactionClient: true };
+      let capturedTx: unknown;
       const service = new TeamsService(
-        createTeamsRepositoryStub({ teamMemberById: newLeaderTeamMember }),
+        createTeamsRepositoryStub({
+          teamMemberById: newLeaderTeamMember,
+          onChangeTeamLeader: (_teamId, _newLeaderId, tx) => {
+            capturedTx = tx;
+          },
+        }),
         createPrismaServiceFailingTransactionStub(),
       );
 
       await expect(service.changeTeamLeader(USER_ID, TEAM_ID, { teamMemberId: OTHER_TEAM_MEMBER_ID }, externalTx as never)).resolves.toBeDefined();
+      expect(capturedTx).toBe(externalTx);
     });
   });
 
@@ -526,11 +551,21 @@ describe('TeamsService', () => {
       capturedTransactions.forEach(tx => expect(tx).toBe(firstTx));
     });
 
-    it('외부 tx가 있으면 새 $transaction을 열지 않는다', async () => {
+    it('외부 tx가 있으면 새 $transaction을 열지 않고 mutation에 externalTx를 전달한다', async () => {
       const externalTx = { transactionClient: true };
-      const service = new TeamsService(createTeamsRepositoryStub({ teamMemberById: targetMember }), createPrismaServiceFailingTransactionStub());
+      let capturedTx: unknown;
+      const service = new TeamsService(
+        createTeamsRepositoryStub({
+          teamMemberById: targetMember,
+          onRemoveTeamMember: (_teamMemberId, _teamId, tx) => {
+            capturedTx = tx;
+          },
+        }),
+        createPrismaServiceFailingTransactionStub(),
+      );
 
       await expect(service.removeTeamMember(USER_ID, TEAM_ID, OTHER_TEAM_MEMBER_ID, externalTx as never)).resolves.toBeDefined();
+      expect(capturedTx).toBe(externalTx);
     });
   });
 
@@ -623,14 +658,21 @@ describe('TeamsService', () => {
       capturedTransactions.forEach(tx => expect(tx).toBe(firstTx));
     });
 
-    it('외부 tx가 있으면 새 $transaction을 열지 않는다', async () => {
+    it('외부 tx가 있으면 새 $transaction을 열지 않고 mutation에 externalTx를 전달한다', async () => {
       const externalTx = { transactionClient: true };
+      let capturedTx: unknown;
       const service = new TeamsService(
-        createTeamsRepositoryStub({ bandMemberById: otherBandMemberRecord }),
+        createTeamsRepositoryStub({
+          bandMemberById: otherBandMemberRecord,
+          onAddTeamMember: (_teamId, _bandMemberId, tx) => {
+            capturedTx = tx;
+          },
+        }),
         createPrismaServiceFailingTransactionStub(),
       );
 
       await expect(service.addTeamMember(USER_ID, TEAM_ID, OTHER_BAND_MEMBER_ID, externalTx as never)).resolves.toBeDefined();
+      expect(capturedTx).toBe(externalTx);
     });
   });
 
@@ -677,11 +719,20 @@ describe('TeamsService', () => {
       capturedTransactions.forEach(tx => expect(tx).toBe(firstTx));
     });
 
-    it('외부 tx가 있으면 새 $transaction을 열지 않는다', async () => {
+    it('외부 tx가 있으면 새 $transaction을 열지 않고 mutation에 externalTx를 전달한다', async () => {
       const externalTx = { transactionClient: true };
-      const service = new TeamsService(createTeamsRepositoryStub(), createPrismaServiceFailingTransactionStub());
+      let capturedTx: unknown;
+      const service = new TeamsService(
+        createTeamsRepositoryStub({
+          onDeleteTeam: (_teamId, tx) => {
+            capturedTx = tx;
+          },
+        }),
+        createPrismaServiceFailingTransactionStub(),
+      );
 
       await expect(service.deleteTeam(USER_ID, TEAM_ID, externalTx as never)).resolves.toBeDefined();
+      expect(capturedTx).toBe(externalTx);
     });
   });
 });

--- a/backend/src/modules/teams/teams.service.spec.ts
+++ b/backend/src/modules/teams/teams.service.spec.ts
@@ -303,6 +303,26 @@ describe('TeamsService', () => {
 
       await expect(service.getBandTeams(BAND_ID, BASE_BAND_TEAMS_QUERY)).rejects.toThrow(NotFoundException);
     });
+
+    it('외부 tx를 findBandById와 findBandTeams에 전달한다', async () => {
+      const externalTx = { transactionClient: true };
+      const capturedTransactions: unknown[] = [];
+      const repository = createTeamsRepositoryStub();
+      repository.findBandById = async (_bandId, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_BAND;
+      };
+      repository.findBandTeams = async (_bandId, _query, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_BAND_TEAMS_RESULT;
+      };
+
+      const service = new TeamsService(repository, createPrismaServiceStub());
+      await service.getBandTeams(BAND_ID, BASE_BAND_TEAMS_QUERY, externalTx as never);
+
+      expect(capturedTransactions.length).toBeGreaterThan(0);
+      capturedTransactions.forEach(tx => expect(tx).toBe(externalTx));
+    });
   });
 
   describe('getTeam', () => {
@@ -317,6 +337,21 @@ describe('TeamsService', () => {
       const service = new TeamsService(createTeamsRepositoryStub({ teamById: null }), createPrismaServiceStub());
 
       await expect(service.getTeam(TEAM_ID)).rejects.toThrow(NotFoundException);
+    });
+
+    it('외부 tx를 findTeamById에 전달한다', async () => {
+      const externalTx = { transactionClient: true };
+      let capturedTx: unknown;
+      const repository = createTeamsRepositoryStub();
+      repository.findTeamById = async (_teamId, tx) => {
+        capturedTx = tx;
+        return DEFAULT_GET_TEAM_RESULT;
+      };
+
+      const service = new TeamsService(repository, createPrismaServiceStub());
+      await service.getTeam(TEAM_ID, externalTx as never);
+
+      expect(capturedTx).toBe(externalTx);
     });
   });
 
@@ -392,6 +427,26 @@ describe('TeamsService', () => {
       const service = new TeamsService(createTeamsRepositoryStub({ teamForUpdate: null }), createPrismaServiceStub());
 
       await expect(service.getTeamMembers(TEAM_ID, BASE_TEAM_MEMBERS_QUERY)).rejects.toThrow(NotFoundException);
+    });
+
+    it('외부 tx를 findTeamForUpdate와 findTeamMembers에 전달한다', async () => {
+      const externalTx = { transactionClient: true };
+      const capturedTransactions: unknown[] = [];
+      const repository = createTeamsRepositoryStub();
+      repository.findTeamForUpdate = async (_teamId, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_TEAM_FOR_UPDATE;
+      };
+      repository.findTeamMembers = async (_teamId, _query, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_TEAM_MEMBERS_RESULT;
+      };
+
+      const service = new TeamsService(repository, createPrismaServiceStub());
+      await service.getTeamMembers(TEAM_ID, BASE_TEAM_MEMBERS_QUERY, externalTx as never);
+
+      expect(capturedTransactions.length).toBeGreaterThan(0);
+      capturedTransactions.forEach(tx => expect(tx).toBe(externalTx));
     });
   });
 
@@ -575,6 +630,21 @@ describe('TeamsService', () => {
       const result = await service.getMyTeams(USER_ID, BASE_MY_TEAMS_QUERY);
 
       expect(result.meta.count).toBe(0);
+    });
+
+    it('외부 tx를 findMyTeams에 전달한다', async () => {
+      const externalTx = { transactionClient: true };
+      let capturedTx: unknown;
+      const repository = createTeamsRepositoryStub();
+      repository.findMyTeams = async (_userId, _query, tx) => {
+        capturedTx = tx;
+        return DEFAULT_MY_TEAMS_RESULT;
+      };
+
+      const service = new TeamsService(repository, createPrismaServiceStub());
+      await service.getMyTeams(USER_ID, BASE_MY_TEAMS_QUERY, externalTx as never);
+
+      expect(capturedTx).toBe(externalTx);
     });
   });
 

--- a/backend/src/modules/teams/teams.service.spec.ts
+++ b/backend/src/modules/teams/teams.service.spec.ts
@@ -1,0 +1,687 @@
+import { BadRequestException, ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import type { PrismaService } from 'src/database/prisma';
+
+import type { GetBandTeamsQuery } from './dto/get-band-teams-query.dto';
+import type { GetMyTeamsQuery } from './dto/get-my-teams-query.dto';
+import type { GetTeamMembersQuery } from './dto/get-team-members-query.dto';
+import type { TeamsRepository } from './repositories/teams.repository';
+import type { AddTeamMemberResult } from './types/add-team-member-result.type';
+import type { ChangeTeamLeaderResult } from './types/change-team-leader-result.type';
+import type { CreateTeamResult } from './types/create-team-result.type';
+import type { DeleteTeamResult } from './types/delete-team-result.type';
+import type { GetBandTeamsResult } from './types/get-band-teams-result.type';
+import type { GetMyTeamsResult } from './types/get-my-teams-result.type';
+import type { GetTeamMembersResult } from './types/get-team-members-result.type';
+import type { GetTeamResult } from './types/get-team-result.type';
+import type { RemoveTeamMemberResult } from './types/remove-team-member-result.type';
+import type { UpdateTeamResult } from './types/update-team-result.type';
+import { TeamsService } from './teams.service';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const BAND_ID = '22222222-2222-4222-8222-222222222222';
+const TEAM_ID = '33333333-3333-4333-8333-333333333333';
+const BAND_MEMBER_ID = '44444444-4444-4444-8444-444444444444';
+const TEAM_MEMBER_ID = '55555555-5555-4555-8555-555555555555';
+const OTHER_BAND_MEMBER_ID = '66666666-6666-4666-8666-666666666666';
+const OTHER_TEAM_MEMBER_ID = '77777777-7777-4777-8777-777777777777';
+
+const DEFAULT_BAND_MEMBER = { id: BAND_MEMBER_ID };
+const DEFAULT_BAND_MEMBER_RECORD = { id: BAND_MEMBER_ID, bandId: BAND_ID };
+
+const DEFAULT_TEAM_FOR_UPDATE = {
+  id: TEAM_ID,
+  bandId: BAND_ID,
+  teamLeaderBandMemberId: BAND_MEMBER_ID,
+};
+
+const DEFAULT_TEAM_MEMBER = {
+  id: TEAM_MEMBER_ID,
+  teamId: TEAM_ID,
+  bandMemberId: BAND_MEMBER_ID,
+  teamRole: 'MEMBER' as const,
+};
+
+const DEFAULT_CREATE_RESULT: CreateTeamResult = {
+  teamId: TEAM_ID,
+  bandId: BAND_ID,
+  name: '보컬팀',
+  description: null,
+  status: 'ACTIVE',
+  teamLeaderUserId: USER_ID,
+  teamCoverUrl: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+const DEFAULT_GET_TEAM_RESULT: GetTeamResult = {
+  teamId: TEAM_ID,
+  bandId: BAND_ID,
+  name: '보컬팀',
+  description: null,
+  status: 'ACTIVE',
+  teamCoverUrl: null,
+  teamLeader: { userId: USER_ID, nickname: '리더' },
+  memberCount: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const DEFAULT_UPDATE_RESULT: UpdateTeamResult = {
+  teamId: TEAM_ID,
+  bandId: BAND_ID,
+  name: '보컬팀',
+  description: null,
+  status: 'ACTIVE',
+  teamCoverUrl: null,
+  teamLeader: { userId: USER_ID, nickname: '리더' },
+  memberCount: 1,
+  updatedAt: '2026-01-02T00:00:00.000Z',
+};
+
+const DEFAULT_BAND_TEAMS_RESULT: GetBandTeamsResult = {
+  bandId: BAND_ID,
+  items: [],
+  meta: { count: 0, take: 20, cursor: null, next: null },
+};
+
+const DEFAULT_TEAM_MEMBERS_RESULT: GetTeamMembersResult = {
+  teamId: TEAM_ID,
+  items: [],
+  meta: { count: 0, take: 20, cursor: null, next: null },
+};
+
+const DEFAULT_MY_TEAMS_RESULT: GetMyTeamsResult = {
+  items: [],
+  meta: { count: 0, take: 20, cursor: null, next: null },
+};
+
+const DEFAULT_CHANGE_LEADER_RESULT: ChangeTeamLeaderResult = {
+  teamId: TEAM_ID,
+  teamLeader: { userId: '99999999-9999-4999-8999-999999999999', nickname: '새 리더' },
+};
+
+const DEFAULT_REMOVE_RESULT: RemoveTeamMemberResult = {
+  teamMemberId: OTHER_TEAM_MEMBER_ID,
+  removed: true,
+};
+
+const DEFAULT_ADD_MEMBER_RESULT: AddTeamMemberResult = {
+  teamMemberId: OTHER_TEAM_MEMBER_ID,
+  teamId: TEAM_ID,
+  bandMemberId: OTHER_BAND_MEMBER_ID,
+  user: { userId: USER_ID, nickname: '새 멤버', profileImageUrl: null },
+  teamRole: 'MEMBER',
+  joinedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const DEFAULT_DELETE_RESULT: DeleteTeamResult = {
+  teamId: TEAM_ID,
+  deleted: true,
+};
+
+function createPrismaServiceStub(): PrismaService {
+  const tx = { transactionClient: true };
+  return {
+    async $transaction(callback: (tx: unknown) => Promise<unknown>) {
+      return callback(tx);
+    },
+  } as PrismaService;
+}
+
+function createPrismaServiceFailingTransactionStub(): PrismaService {
+  return {
+    async $transaction() {
+      throw new Error('외부 tx가 있으면 새 transaction을 열지 않아야 합니다.');
+    },
+  } as unknown as PrismaService;
+}
+
+const DEFAULT_BAND = { id: BAND_ID };
+
+function createTeamsRepositoryStub(options?: {
+  band?: { id: string } | null;
+  bandMemberByBandAndUser?: { id: string } | null;
+  bandMemberById?: { id: string; bandId: string } | null;
+  teamForUpdate?: { id: string; bandId: string; teamLeaderBandMemberId: string | null } | null;
+  teamById?: GetTeamResult | null;
+  teamMemberById?: { id: string; teamId: string; bandMemberId: string; teamRole: string } | null;
+  teamMemberByTeamAndBandMember?: { id: string; teamRole: string } | null;
+  onCreateTeam?: (input: unknown, tx: unknown) => void;
+  onUpdateTeam?: (teamId: string, input: unknown, tx: unknown) => void;
+  onChangeTeamLeader?: (teamId: string, newLeaderTeamMemberId: string, tx: unknown) => void;
+  onRemoveTeamMember?: (teamMemberId: string, teamId: string, tx: unknown) => void;
+  onAddTeamMember?: (teamId: string, bandMemberId: string, tx: unknown) => void;
+  onDeleteTeam?: (teamId: string, tx: unknown) => void;
+}): TeamsRepository {
+  return {
+    async findBandById(_bandId, _tx) {
+      return options?.band !== undefined ? options.band : DEFAULT_BAND;
+    },
+    async findBandMemberByBandIdAndUserId(_bandId, _userId, _tx) {
+      return options?.bandMemberByBandAndUser !== undefined ? options.bandMemberByBandAndUser : DEFAULT_BAND_MEMBER;
+    },
+    async findBandMemberById(_bandMemberId, _tx) {
+      return options?.bandMemberById !== undefined ? options.bandMemberById : DEFAULT_BAND_MEMBER_RECORD;
+    },
+    async createTeam(input, tx) {
+      options?.onCreateTeam?.(input, tx);
+      return DEFAULT_CREATE_RESULT;
+    },
+    async findBandTeams(_bandId, _query, _tx) {
+      return DEFAULT_BAND_TEAMS_RESULT;
+    },
+    async findTeamById(_teamId, _tx) {
+      return options?.teamById !== undefined ? options.teamById : DEFAULT_GET_TEAM_RESULT;
+    },
+    async findTeamForUpdate(_teamId, _tx) {
+      return options?.teamForUpdate !== undefined ? options.teamForUpdate : DEFAULT_TEAM_FOR_UPDATE;
+    },
+    async findTeamMemberByTeamAndBandMember(_teamId, _bandMemberId, _tx) {
+      return options?.teamMemberByTeamAndBandMember !== undefined ? options.teamMemberByTeamAndBandMember : null;
+    },
+    async findTeamMemberById(_teamMemberId, _tx) {
+      return options?.teamMemberById !== undefined ? options.teamMemberById : DEFAULT_TEAM_MEMBER;
+    },
+    async updateTeam(teamId, input, tx) {
+      options?.onUpdateTeam?.(teamId, input, tx);
+      return DEFAULT_UPDATE_RESULT;
+    },
+    async findTeamMembers(_teamId, _query, _tx) {
+      return DEFAULT_TEAM_MEMBERS_RESULT;
+    },
+    async changeTeamLeader(teamId, newLeaderTeamMemberId, tx) {
+      options?.onChangeTeamLeader?.(teamId, newLeaderTeamMemberId, tx);
+      return DEFAULT_CHANGE_LEADER_RESULT;
+    },
+    async removeTeamMember(teamMemberId, teamId, tx) {
+      options?.onRemoveTeamMember?.(teamMemberId, teamId, tx);
+      return DEFAULT_REMOVE_RESULT;
+    },
+    async findMyTeams(_userId, _query, _tx) {
+      return DEFAULT_MY_TEAMS_RESULT;
+    },
+    async addTeamMember(teamId, bandMemberId, tx) {
+      options?.onAddTeamMember?.(teamId, bandMemberId, tx);
+      return DEFAULT_ADD_MEMBER_RESULT;
+    },
+    async deleteTeam(teamId, tx) {
+      options?.onDeleteTeam?.(teamId, tx);
+      return DEFAULT_DELETE_RESULT;
+    },
+  };
+}
+
+const BASE_BAND_TEAMS_QUERY: GetBandTeamsQuery = {
+  take: 20,
+  order__created_at: 'desc',
+  order__id: 'desc',
+};
+
+const BASE_TEAM_MEMBERS_QUERY: GetTeamMembersQuery = {
+  take: 20,
+  order__joined_at: 'desc',
+  order__id: 'desc',
+};
+
+const BASE_MY_TEAMS_QUERY: GetMyTeamsQuery = {
+  take: 20,
+  order__joined_at: 'desc',
+  order__id: 'desc',
+};
+
+describe('TeamsService', () => {
+  describe('createTeam', () => {
+    it('팀을 성공적으로 생성한다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub(), createPrismaServiceStub());
+      const result = await service.createTeam(USER_ID, BAND_ID, { name: '보컬팀' });
+
+      expect(result.teamId).toBe(TEAM_ID);
+      expect(result.bandId).toBe(BAND_ID);
+    });
+
+    it('밴드가 없으면 NotFoundException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ band: null }), createPrismaServiceStub());
+
+      await expect(service.createTeam(USER_ID, BAND_ID, { name: '보컬팀' })).rejects.toThrow(NotFoundException);
+    });
+
+    it('밴드 멤버가 아니면 ForbiddenException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ bandMemberByBandAndUser: null }), createPrismaServiceStub());
+
+      await expect(service.createTeam(USER_ID, BAND_ID, { name: '보컬팀' })).rejects.toThrow(ForbiddenException);
+    });
+
+    it('tx가 있으면 같은 tx를 Repository에 전달한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      const repository = createTeamsRepositoryStub({
+        onCreateTeam: (_input, tx) => capturedTransactions.push(tx),
+      });
+
+      repository.findBandById = async (_bandId, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_BAND;
+      };
+      repository.findBandMemberByBandIdAndUserId = async (_bandId, _userId, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_BAND_MEMBER;
+      };
+
+      const service = new TeamsService(repository, createPrismaServiceStub());
+      await service.createTeam(USER_ID, BAND_ID, { name: '보컬팀' });
+
+      expect(capturedTransactions.length).toBeGreaterThan(0);
+      const firstTx = capturedTransactions[0];
+      capturedTransactions.forEach(tx => expect(tx).toBe(firstTx));
+    });
+
+    it('외부 tx가 있으면 새 $transaction을 열지 않는다', async () => {
+      const externalTx = { transactionClient: true };
+      const service = new TeamsService(createTeamsRepositoryStub(), createPrismaServiceFailingTransactionStub());
+
+      await expect(service.createTeam(USER_ID, BAND_ID, { name: '보컬팀' }, externalTx as never)).resolves.toBeDefined();
+    });
+  });
+
+  describe('getBandTeams', () => {
+    it('밴드 팀 목록을 성공적으로 조회한다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub(), createPrismaServiceStub());
+      const result = await service.getBandTeams(BAND_ID, BASE_BAND_TEAMS_QUERY);
+
+      expect(result.bandId).toBe(BAND_ID);
+    });
+
+    it('밴드가 없으면 NotFoundException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ band: null }), createPrismaServiceStub());
+
+      await expect(service.getBandTeams(BAND_ID, BASE_BAND_TEAMS_QUERY)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getTeam', () => {
+    it('팀 상세를 성공적으로 조회한다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub(), createPrismaServiceStub());
+      const result = await service.getTeam(TEAM_ID);
+
+      expect(result.teamId).toBe(TEAM_ID);
+    });
+
+    it('팀이 없으면 NotFoundException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ teamById: null }), createPrismaServiceStub());
+
+      await expect(service.getTeam(TEAM_ID)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('updateTeam', () => {
+    it('팀 리더가 팀 정보를 성공적으로 수정한다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub(), createPrismaServiceStub());
+      const result = await service.updateTeam(USER_ID, TEAM_ID, { name: '새 이름' });
+
+      expect(result.teamId).toBe(TEAM_ID);
+    });
+
+    it('팀이 없으면 NotFoundException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ teamForUpdate: null }), createPrismaServiceStub());
+
+      await expect(service.updateTeam(USER_ID, TEAM_ID, { name: '새 이름' })).rejects.toThrow(NotFoundException);
+    });
+
+    it('팀 리더가 아니면 ForbiddenException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ bandMemberByBandAndUser: { id: 'different-id' } }), createPrismaServiceStub());
+
+      await expect(service.updateTeam(USER_ID, TEAM_ID, { name: '새 이름' })).rejects.toThrow(ForbiddenException);
+    });
+
+    it('tx가 있으면 같은 tx를 Repository에 전달한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      const repository = createTeamsRepositoryStub({
+        onUpdateTeam: (_teamId, _input, tx) => capturedTransactions.push(tx),
+      });
+
+      repository.findTeamForUpdate = async (_teamId, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_TEAM_FOR_UPDATE;
+      };
+      repository.findBandMemberByBandIdAndUserId = async (_bandId, _userId, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_BAND_MEMBER;
+      };
+
+      const service = new TeamsService(repository, createPrismaServiceStub());
+      await service.updateTeam(USER_ID, TEAM_ID, { name: '새 이름' });
+
+      expect(capturedTransactions.length).toBeGreaterThan(0);
+      const firstTx = capturedTransactions[0];
+      capturedTransactions.forEach(tx => expect(tx).toBe(firstTx));
+    });
+
+    it('외부 tx가 있으면 새 $transaction을 열지 않는다', async () => {
+      const externalTx = { transactionClient: true };
+      const service = new TeamsService(createTeamsRepositoryStub(), createPrismaServiceFailingTransactionStub());
+
+      await expect(service.updateTeam(USER_ID, TEAM_ID, { name: '새 이름' }, externalTx as never)).resolves.toBeDefined();
+    });
+  });
+
+  describe('getTeamMembers', () => {
+    it('팀 멤버 목록을 성공적으로 조회한다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub(), createPrismaServiceStub());
+      const result = await service.getTeamMembers(TEAM_ID, BASE_TEAM_MEMBERS_QUERY);
+
+      expect(result.teamId).toBe(TEAM_ID);
+    });
+
+    it('팀이 없으면 NotFoundException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ teamForUpdate: null }), createPrismaServiceStub());
+
+      await expect(service.getTeamMembers(TEAM_ID, BASE_TEAM_MEMBERS_QUERY)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('changeTeamLeader', () => {
+    const newLeaderTeamMember = {
+      id: OTHER_TEAM_MEMBER_ID,
+      teamId: TEAM_ID,
+      bandMemberId: OTHER_BAND_MEMBER_ID,
+      teamRole: 'MEMBER' as const,
+    };
+
+    it('팀 리더를 성공적으로 변경한다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ teamMemberById: newLeaderTeamMember }), createPrismaServiceStub());
+      const result = await service.changeTeamLeader(USER_ID, TEAM_ID, { teamMemberId: OTHER_TEAM_MEMBER_ID });
+
+      expect(result.teamId).toBe(TEAM_ID);
+    });
+
+    it('팀이 없으면 NotFoundException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ teamForUpdate: null }), createPrismaServiceStub());
+
+      await expect(service.changeTeamLeader(USER_ID, TEAM_ID, { teamMemberId: OTHER_TEAM_MEMBER_ID })).rejects.toThrow(NotFoundException);
+    });
+
+    it('팀 리더가 아니면 ForbiddenException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ bandMemberByBandAndUser: { id: 'different-id' } }), createPrismaServiceStub());
+
+      await expect(service.changeTeamLeader(USER_ID, TEAM_ID, { teamMemberId: OTHER_TEAM_MEMBER_ID })).rejects.toThrow(ForbiddenException);
+    });
+
+    it('대상 팀 멤버가 팀에 없으면 NotFoundException을 던진다', async () => {
+      const memberInOtherTeam = { ...newLeaderTeamMember, teamId: 'other-team-id' };
+      const service = new TeamsService(createTeamsRepositoryStub({ teamMemberById: memberInOtherTeam }), createPrismaServiceStub());
+
+      await expect(service.changeTeamLeader(USER_ID, TEAM_ID, { teamMemberId: OTHER_TEAM_MEMBER_ID })).rejects.toThrow(NotFoundException);
+    });
+
+    it('대상이 이미 팀 리더이면 BadRequestException을 던진다', async () => {
+      const alreadyLeader = { ...newLeaderTeamMember, teamRole: 'LEADER' as const };
+      const service = new TeamsService(createTeamsRepositoryStub({ teamMemberById: alreadyLeader }), createPrismaServiceStub());
+
+      await expect(service.changeTeamLeader(USER_ID, TEAM_ID, { teamMemberId: OTHER_TEAM_MEMBER_ID })).rejects.toThrow(BadRequestException);
+    });
+
+    it('tx가 있으면 같은 tx를 Repository에 전달한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      const repository = createTeamsRepositoryStub({
+        teamMemberById: newLeaderTeamMember,
+        onChangeTeamLeader: (_teamId, _newLeaderId, tx) => capturedTransactions.push(tx),
+      });
+
+      repository.findTeamForUpdate = async (_teamId, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_TEAM_FOR_UPDATE;
+      };
+      repository.findBandMemberByBandIdAndUserId = async (_bandId, _userId, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_BAND_MEMBER;
+      };
+      repository.findTeamMemberById = async (_teamMemberId, tx) => {
+        capturedTransactions.push(tx);
+        return newLeaderTeamMember;
+      };
+
+      const service = new TeamsService(repository, createPrismaServiceStub());
+      await service.changeTeamLeader(USER_ID, TEAM_ID, { teamMemberId: OTHER_TEAM_MEMBER_ID });
+
+      expect(capturedTransactions.length).toBeGreaterThan(0);
+      const firstTx = capturedTransactions[0];
+      capturedTransactions.forEach(tx => expect(tx).toBe(firstTx));
+    });
+
+    it('외부 tx가 있으면 새 $transaction을 열지 않는다', async () => {
+      const externalTx = { transactionClient: true };
+      const service = new TeamsService(
+        createTeamsRepositoryStub({ teamMemberById: newLeaderTeamMember }),
+        createPrismaServiceFailingTransactionStub(),
+      );
+
+      await expect(service.changeTeamLeader(USER_ID, TEAM_ID, { teamMemberId: OTHER_TEAM_MEMBER_ID }, externalTx as never)).resolves.toBeDefined();
+    });
+  });
+
+  describe('removeTeamMember', () => {
+    const targetMember = {
+      id: OTHER_TEAM_MEMBER_ID,
+      teamId: TEAM_ID,
+      bandMemberId: OTHER_BAND_MEMBER_ID,
+      teamRole: 'MEMBER' as const,
+    };
+
+    it('팀 리더가 팀 멤버를 성공적으로 제거한다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ teamMemberById: targetMember }), createPrismaServiceStub());
+      const result = await service.removeTeamMember(USER_ID, TEAM_ID, OTHER_TEAM_MEMBER_ID);
+
+      expect(result.removed).toBe(true);
+    });
+
+    it('팀이 없으면 NotFoundException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ teamForUpdate: null }), createPrismaServiceStub());
+
+      await expect(service.removeTeamMember(USER_ID, TEAM_ID, OTHER_TEAM_MEMBER_ID)).rejects.toThrow(NotFoundException);
+    });
+
+    it('팀 리더가 아니면 ForbiddenException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ bandMemberByBandAndUser: { id: 'different-id' } }), createPrismaServiceStub());
+
+      await expect(service.removeTeamMember(USER_ID, TEAM_ID, OTHER_TEAM_MEMBER_ID)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('대상 팀 멤버가 팀에 없으면 NotFoundException을 던진다', async () => {
+      const memberInOtherTeam = { ...targetMember, teamId: 'other-team-id' };
+      const service = new TeamsService(createTeamsRepositoryStub({ teamMemberById: memberInOtherTeam }), createPrismaServiceStub());
+
+      await expect(service.removeTeamMember(USER_ID, TEAM_ID, OTHER_TEAM_MEMBER_ID)).rejects.toThrow(NotFoundException);
+    });
+
+    it('팀 리더는 자신을 제거할 수 없다 (BadRequestException)', async () => {
+      const leaderMember = { ...targetMember, teamRole: 'LEADER' as const };
+      const service = new TeamsService(createTeamsRepositoryStub({ teamMemberById: leaderMember }), createPrismaServiceStub());
+
+      await expect(service.removeTeamMember(USER_ID, TEAM_ID, OTHER_TEAM_MEMBER_ID)).rejects.toThrow(BadRequestException);
+    });
+
+    it('tx가 있으면 같은 tx를 Repository에 전달한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      const repository = createTeamsRepositoryStub({
+        teamMemberById: targetMember,
+        onRemoveTeamMember: (_teamMemberId, _teamId, tx) => capturedTransactions.push(tx),
+      });
+
+      repository.findTeamForUpdate = async (_teamId, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_TEAM_FOR_UPDATE;
+      };
+      repository.findBandMemberByBandIdAndUserId = async (_bandId, _userId, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_BAND_MEMBER;
+      };
+      repository.findTeamMemberById = async (_teamMemberId, tx) => {
+        capturedTransactions.push(tx);
+        return targetMember;
+      };
+
+      const service = new TeamsService(repository, createPrismaServiceStub());
+      await service.removeTeamMember(USER_ID, TEAM_ID, OTHER_TEAM_MEMBER_ID);
+
+      expect(capturedTransactions.length).toBeGreaterThan(0);
+      const firstTx = capturedTransactions[0];
+      capturedTransactions.forEach(tx => expect(tx).toBe(firstTx));
+    });
+
+    it('외부 tx가 있으면 새 $transaction을 열지 않는다', async () => {
+      const externalTx = { transactionClient: true };
+      const service = new TeamsService(createTeamsRepositoryStub({ teamMemberById: targetMember }), createPrismaServiceFailingTransactionStub());
+
+      await expect(service.removeTeamMember(USER_ID, TEAM_ID, OTHER_TEAM_MEMBER_ID, externalTx as never)).resolves.toBeDefined();
+    });
+  });
+
+  describe('getMyTeams', () => {
+    it('내 팀 목록을 성공적으로 조회한다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub(), createPrismaServiceStub());
+      const result = await service.getMyTeams(USER_ID, BASE_MY_TEAMS_QUERY);
+
+      expect(result.meta.count).toBe(0);
+    });
+  });
+
+  describe('addTeamMember', () => {
+    const otherBandMemberRecord = { id: OTHER_BAND_MEMBER_ID, bandId: BAND_ID };
+
+    it('팀 리더가 밴드 멤버를 팀에 추가한다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ bandMemberById: otherBandMemberRecord }), createPrismaServiceStub());
+      const result = await service.addTeamMember(USER_ID, TEAM_ID, OTHER_BAND_MEMBER_ID);
+
+      expect(result.teamId).toBe(TEAM_ID);
+    });
+
+    it('팀이 없으면 NotFoundException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ teamForUpdate: null }), createPrismaServiceStub());
+
+      await expect(service.addTeamMember(USER_ID, TEAM_ID, OTHER_BAND_MEMBER_ID)).rejects.toThrow(NotFoundException);
+    });
+
+    it('팀 리더가 아니면 ForbiddenException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ bandMemberByBandAndUser: { id: 'different-id' } }), createPrismaServiceStub());
+
+      await expect(service.addTeamMember(USER_ID, TEAM_ID, OTHER_BAND_MEMBER_ID)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('추가 대상 밴드 멤버가 없으면 NotFoundException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ bandMemberById: null }), createPrismaServiceStub());
+
+      await expect(service.addTeamMember(USER_ID, TEAM_ID, OTHER_BAND_MEMBER_ID)).rejects.toThrow(NotFoundException);
+    });
+
+    it('다른 밴드 멤버이면 BadRequestException을 던진다', async () => {
+      const otherBandMember = { id: OTHER_BAND_MEMBER_ID, bandId: 'other-band-id' };
+      const service = new TeamsService(createTeamsRepositoryStub({ bandMemberById: otherBandMember }), createPrismaServiceStub());
+
+      await expect(service.addTeamMember(USER_ID, TEAM_ID, OTHER_BAND_MEMBER_ID)).rejects.toThrow(BadRequestException);
+    });
+
+    it('이미 팀 멤버이면 ConflictException을 던진다', async () => {
+      const existingMember = { id: TEAM_MEMBER_ID, teamRole: 'MEMBER' };
+      const service = new TeamsService(
+        createTeamsRepositoryStub({
+          bandMemberById: otherBandMemberRecord,
+          teamMemberByTeamAndBandMember: existingMember,
+        }),
+        createPrismaServiceStub(),
+      );
+
+      await expect(service.addTeamMember(USER_ID, TEAM_ID, OTHER_BAND_MEMBER_ID)).rejects.toThrow(ConflictException);
+    });
+
+    it('tx가 있으면 같은 tx를 Repository에 전달한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      const repository = createTeamsRepositoryStub({
+        bandMemberById: otherBandMemberRecord,
+        onAddTeamMember: (_teamId, _bandMemberId, tx) => capturedTransactions.push(tx),
+      });
+
+      repository.findTeamForUpdate = async (_teamId, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_TEAM_FOR_UPDATE;
+      };
+      repository.findBandMemberByBandIdAndUserId = async (_bandId, _userId, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_BAND_MEMBER;
+      };
+      repository.findBandMemberById = async (_bandMemberId, tx) => {
+        capturedTransactions.push(tx);
+        return otherBandMemberRecord;
+      };
+      repository.findTeamMemberByTeamAndBandMember = async (_teamId, _bandMemberId, tx) => {
+        capturedTransactions.push(tx);
+        return null;
+      };
+
+      const service = new TeamsService(repository, createPrismaServiceStub());
+      await service.addTeamMember(USER_ID, TEAM_ID, OTHER_BAND_MEMBER_ID);
+
+      expect(capturedTransactions.length).toBeGreaterThan(0);
+      const firstTx = capturedTransactions[0];
+      capturedTransactions.forEach(tx => expect(tx).toBe(firstTx));
+    });
+
+    it('외부 tx가 있으면 새 $transaction을 열지 않는다', async () => {
+      const externalTx = { transactionClient: true };
+      const service = new TeamsService(
+        createTeamsRepositoryStub({ bandMemberById: otherBandMemberRecord }),
+        createPrismaServiceFailingTransactionStub(),
+      );
+
+      await expect(service.addTeamMember(USER_ID, TEAM_ID, OTHER_BAND_MEMBER_ID, externalTx as never)).resolves.toBeDefined();
+    });
+  });
+
+  describe('deleteTeam', () => {
+    it('팀 리더가 팀을 성공적으로 삭제한다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub(), createPrismaServiceStub());
+      const result = await service.deleteTeam(USER_ID, TEAM_ID);
+
+      expect(result.deleted).toBe(true);
+    });
+
+    it('팀이 없으면 NotFoundException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ teamForUpdate: null }), createPrismaServiceStub());
+
+      await expect(service.deleteTeam(USER_ID, TEAM_ID)).rejects.toThrow(NotFoundException);
+    });
+
+    it('팀 리더가 아니면 ForbiddenException을 던진다', async () => {
+      const service = new TeamsService(createTeamsRepositoryStub({ bandMemberByBandAndUser: { id: 'different-id' } }), createPrismaServiceStub());
+
+      await expect(service.deleteTeam(USER_ID, TEAM_ID)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('tx가 있으면 같은 tx를 Repository에 전달한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      const repository = createTeamsRepositoryStub({
+        onDeleteTeam: (_teamId, tx) => capturedTransactions.push(tx),
+      });
+
+      repository.findTeamForUpdate = async (_teamId, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_TEAM_FOR_UPDATE;
+      };
+      repository.findBandMemberByBandIdAndUserId = async (_bandId, _userId, tx) => {
+        capturedTransactions.push(tx);
+        return DEFAULT_BAND_MEMBER;
+      };
+
+      const service = new TeamsService(repository, createPrismaServiceStub());
+      await service.deleteTeam(USER_ID, TEAM_ID);
+
+      expect(capturedTransactions.length).toBeGreaterThan(0);
+      const firstTx = capturedTransactions[0];
+      capturedTransactions.forEach(tx => expect(tx).toBe(firstTx));
+    });
+
+    it('외부 tx가 있으면 새 $transaction을 열지 않는다', async () => {
+      const externalTx = { transactionClient: true };
+      const service = new TeamsService(createTeamsRepositoryStub(), createPrismaServiceFailingTransactionStub());
+
+      await expect(service.deleteTeam(USER_ID, TEAM_ID, externalTx as never)).resolves.toBeDefined();
+    });
+  });
+});

--- a/backend/src/modules/teams/teams.service.ts
+++ b/backend/src/modules/teams/teams.service.ts
@@ -1,0 +1,301 @@
+import { BadRequestException, ConflictException, ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+
+import { PrismaService } from '../../database/prisma';
+import type { Prisma } from '../../generated/prisma';
+
+import type { ChangeTeamLeaderBodyDto } from './dto/change-team-leader.dto';
+import type { CreateTeamInput } from './dto/create-team.dto';
+import type { GetBandTeamsQuery } from './dto/get-band-teams-query.dto';
+import type { GetMyTeamsQuery } from './dto/get-my-teams-query.dto';
+import type { GetTeamMembersQuery } from './dto/get-team-members-query.dto';
+import type { UpdateTeamInput } from './dto/update-team.dto';
+import { TEAMS_REPOSITORY, type TeamsRepository } from './repositories/teams.repository';
+import type { AddTeamMemberResult } from './types/add-team-member-result.type';
+import type { ChangeTeamLeaderResult } from './types/change-team-leader-result.type';
+import type { CreateTeamResult } from './types/create-team-result.type';
+import type { DeleteTeamResult } from './types/delete-team-result.type';
+import type { GetBandTeamsResult } from './types/get-band-teams-result.type';
+import type { GetMyTeamsResult } from './types/get-my-teams-result.type';
+import type { GetTeamMembersResult } from './types/get-team-members-result.type';
+import type { GetTeamResult } from './types/get-team-result.type';
+import type { RemoveTeamMemberResult } from './types/remove-team-member-result.type';
+import type { UpdateTeamResult } from './types/update-team-result.type';
+
+@Injectable()
+export class TeamsService {
+  constructor(
+    @Inject(TEAMS_REPOSITORY) private readonly teamsRepository: TeamsRepository,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  /**
+   * 밴드 멤버가 팀을 생성한다. 생성자가 자동으로 팀 리더가 된다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} bandId - 팀을 생성할 밴드 ID
+   * @param {CreateTeamInput} input - 팀 생성 입력값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<CreateTeamResult>} 생성된 팀 정보
+   */
+  async createTeam(userId: string, bandId: string, input: CreateTeamInput, tx?: Prisma.TransactionClient): Promise<CreateTeamResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<CreateTeamResult> => {
+      const band = await this.teamsRepository.findBandById(bandId, client);
+      if (!band) {
+        throw new NotFoundException('밴드를 찾을 수 없습니다.');
+      }
+
+      const bandMember = await this.teamsRepository.findBandMemberByBandIdAndUserId(bandId, userId, client);
+      if (!bandMember) {
+        throw new ForbiddenException('해당 밴드의 멤버만 팀을 생성할 수 있습니다.');
+      }
+
+      return this.teamsRepository.createTeam(
+        {
+          ...input,
+          bandId,
+          teamLeaderBandMemberId: bandMember.id,
+          teamLeaderUserId: userId,
+        },
+        client,
+      );
+    };
+
+    return tx ? run(tx) : this.prisma.$transaction(run);
+  }
+
+  /**
+   * 밴드에 속한 팀 목록을 조회한다.
+   *
+   * @param {string} bandId - 대상 밴드 ID
+   * @param {GetBandTeamsQuery} query - 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetBandTeamsResult>} 밴드 팀 목록
+   */
+  async getBandTeams(bandId: string, query: GetBandTeamsQuery, tx?: Prisma.TransactionClient): Promise<GetBandTeamsResult> {
+    const band = await this.teamsRepository.findBandById(bandId, tx);
+    if (!band) {
+      throw new NotFoundException('밴드를 찾을 수 없습니다.');
+    }
+    return this.teamsRepository.findBandTeams(bandId, query, tx);
+  }
+
+  /**
+   * 팀 상세 정보를 조회한다.
+   *
+   * @param {string} teamId - 조회할 팀 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetTeamResult>} 팀 상세 정보
+   */
+  async getTeam(teamId: string, tx?: Prisma.TransactionClient): Promise<GetTeamResult> {
+    const team = await this.teamsRepository.findTeamById(teamId, tx);
+    if (!team) {
+      throw new NotFoundException('팀을 찾을 수 없습니다.');
+    }
+    return team;
+  }
+
+  /**
+   * 팀 리더만 팀 정보를 수정할 수 있다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} teamId - 수정할 팀 ID
+   * @param {UpdateTeamInput} input - 수정 입력값
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<UpdateTeamResult>} 수정된 팀 정보
+   */
+  async updateTeam(userId: string, teamId: string, input: UpdateTeamInput, tx?: Prisma.TransactionClient): Promise<UpdateTeamResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<UpdateTeamResult> => {
+      const team = await this.teamsRepository.findTeamForUpdate(teamId, client);
+      if (!team) {
+        throw new NotFoundException('팀을 찾을 수 없습니다.');
+      }
+
+      await this.assertTeamLeader(userId, team.bandId, team.teamLeaderBandMemberId, client);
+
+      return this.teamsRepository.updateTeam(teamId, input, client);
+    };
+
+    return tx ? run(tx) : this.prisma.$transaction(run);
+  }
+
+  /**
+   * 팀 멤버 목록을 조회한다.
+   *
+   * @param {string} teamId - 대상 팀 ID
+   * @param {GetTeamMembersQuery} query - 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetTeamMembersResult>} 팀 멤버 목록
+   */
+  async getTeamMembers(teamId: string, query: GetTeamMembersQuery, tx?: Prisma.TransactionClient): Promise<GetTeamMembersResult> {
+    const team = await this.teamsRepository.findTeamForUpdate(teamId, tx);
+    if (!team) {
+      throw new NotFoundException('팀을 찾을 수 없습니다.');
+    }
+    return this.teamsRepository.findTeamMembers(teamId, query, tx);
+  }
+
+  /**
+   * 팀 리더만 팀 리더를 변경할 수 있다. 새 리더는 이미 팀 멤버여야 한다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} teamId - 대상 팀 ID
+   * @param {ChangeTeamLeaderBodyDto} input - 새 리더 TeamMember ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<ChangeTeamLeaderResult>} 변경된 팀 리더 정보
+   */
+  async changeTeamLeader(
+    userId: string,
+    teamId: string,
+    input: ChangeTeamLeaderBodyDto,
+    tx?: Prisma.TransactionClient,
+  ): Promise<ChangeTeamLeaderResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<ChangeTeamLeaderResult> => {
+      const team = await this.teamsRepository.findTeamForUpdate(teamId, client);
+      if (!team) {
+        throw new NotFoundException('팀을 찾을 수 없습니다.');
+      }
+
+      await this.assertTeamLeader(userId, team.bandId, team.teamLeaderBandMemberId, client);
+
+      const newLeaderMember = await this.teamsRepository.findTeamMemberById(input.teamMemberId, client);
+      if (!newLeaderMember || newLeaderMember.teamId !== teamId) {
+        throw new NotFoundException('해당 팀에서 대상 멤버를 찾을 수 없습니다.');
+      }
+
+      if (newLeaderMember.teamRole === 'LEADER') {
+        throw new BadRequestException('이미 팀 리더입니다.');
+      }
+
+      return this.teamsRepository.changeTeamLeader(teamId, input.teamMemberId, client);
+    };
+
+    return tx ? run(tx) : this.prisma.$transaction(run);
+  }
+
+  /**
+   * 팀 리더만 팀 멤버를 제거할 수 있다. 리더 자신은 제거할 수 없다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} teamId - 대상 팀 ID
+   * @param {string} teamMemberId - 제거할 TeamMember ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<RemoveTeamMemberResult>} 제거 결과
+   */
+  async removeTeamMember(userId: string, teamId: string, teamMemberId: string, tx?: Prisma.TransactionClient): Promise<RemoveTeamMemberResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<RemoveTeamMemberResult> => {
+      const team = await this.teamsRepository.findTeamForUpdate(teamId, client);
+      if (!team) {
+        throw new NotFoundException('팀을 찾을 수 없습니다.');
+      }
+
+      await this.assertTeamLeader(userId, team.bandId, team.teamLeaderBandMemberId, client);
+
+      const targetMember = await this.teamsRepository.findTeamMemberById(teamMemberId, client);
+      if (!targetMember || targetMember.teamId !== teamId) {
+        throw new NotFoundException('해당 팀에서 대상 멤버를 찾을 수 없습니다.');
+      }
+
+      if (targetMember.teamRole === 'LEADER') {
+        throw new BadRequestException('팀 리더는 자기 자신을 제거할 수 없습니다. 리더 변경 후 제거하세요.');
+      }
+
+      return this.teamsRepository.removeTeamMember(teamMemberId, teamId, client);
+    };
+
+    return tx ? run(tx) : this.prisma.$transaction(run);
+  }
+
+  /**
+   * 인증된 사용자가 속한 팀 목록을 조회한다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {GetMyTeamsQuery} query - 커서 기반 목록 조회 조건
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetMyTeamsResult>} 내 팀 목록
+   */
+  async getMyTeams(userId: string, query: GetMyTeamsQuery, tx?: Prisma.TransactionClient): Promise<GetMyTeamsResult> {
+    return this.teamsRepository.findMyTeams(userId, query, tx);
+  }
+
+  /**
+   * 팀 리더만 밴드 멤버를 팀에 추가할 수 있다.
+   * 추가 대상은 같은 밴드의 멤버여야 하며 이미 팀에 없어야 한다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} teamId - 대상 팀 ID
+   * @param {string} bandMemberId - 추가할 밴드 멤버 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<AddTeamMemberResult>} 추가된 팀 멤버 정보
+   */
+  async addTeamMember(userId: string, teamId: string, bandMemberId: string, tx?: Prisma.TransactionClient): Promise<AddTeamMemberResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<AddTeamMemberResult> => {
+      const team = await this.teamsRepository.findTeamForUpdate(teamId, client);
+      if (!team) {
+        throw new NotFoundException('팀을 찾을 수 없습니다.');
+      }
+
+      await this.assertTeamLeader(userId, team.bandId, team.teamLeaderBandMemberId, client);
+
+      const targetBandMember = await this.teamsRepository.findBandMemberById(bandMemberId, client);
+      if (!targetBandMember) {
+        throw new NotFoundException('해당 밴드 멤버를 찾을 수 없습니다.');
+      }
+
+      if (targetBandMember.bandId !== team.bandId) {
+        throw new BadRequestException('같은 밴드의 멤버만 팀에 추가할 수 있습니다.');
+      }
+
+      const existing = await this.teamsRepository.findTeamMemberByTeamAndBandMember(teamId, bandMemberId, client);
+      if (existing) {
+        throw new ConflictException('이미 팀 멤버입니다.');
+      }
+
+      return this.teamsRepository.addTeamMember(teamId, bandMemberId, client);
+    };
+
+    return tx ? run(tx) : this.prisma.$transaction(run);
+  }
+
+  /**
+   * 팀 리더만 팀을 삭제할 수 있다. 팀 멤버는 cascade로 함께 삭제된다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} teamId - 삭제할 팀 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<DeleteTeamResult>} 삭제 결과
+   */
+  async deleteTeam(userId: string, teamId: string, tx?: Prisma.TransactionClient): Promise<DeleteTeamResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<DeleteTeamResult> => {
+      const team = await this.teamsRepository.findTeamForUpdate(teamId, client);
+      if (!team) {
+        throw new NotFoundException('팀을 찾을 수 없습니다.');
+      }
+
+      await this.assertTeamLeader(userId, team.bandId, team.teamLeaderBandMemberId, client);
+
+      return this.teamsRepository.deleteTeam(teamId, client);
+    };
+
+    return tx ? run(tx) : this.prisma.$transaction(run);
+  }
+
+  /**
+   * 사용자가 해당 팀의 리더인지 검증한다.
+   * teamLeaderBandMemberId가 없거나 사용자의 BandMember.id와 일치하지 않으면 403을 던진다.
+   */
+  private async assertTeamLeader(
+    userId: string,
+    bandId: string,
+    teamLeaderBandMemberId: string | null,
+    tx?: Prisma.TransactionClient,
+  ): Promise<void> {
+    if (!teamLeaderBandMemberId) {
+      throw new ForbiddenException('팀 리더 권한이 필요합니다.');
+    }
+
+    const myBandMember = await this.teamsRepository.findBandMemberByBandIdAndUserId(bandId, userId, tx);
+    if (!myBandMember || myBandMember.id !== teamLeaderBandMemberId) {
+      throw new ForbiddenException('팀 리더 권한이 필요합니다.');
+    }
+  }
+}

--- a/backend/src/modules/teams/teams.service.ts
+++ b/backend/src/modules/teams/teams.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, ConflictException, ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 
 import { PrismaService } from '../../database/prisma';
-import type { Prisma } from '../../generated/prisma';
+import { Prisma } from '../../generated/prisma';
 
 import type { ChangeTeamLeaderBodyDto } from './dto/change-team-leader.dto';
 import type { CreateTeamInput } from './dto/create-team.dto';
@@ -250,7 +250,14 @@ export class TeamsService {
         throw new ConflictException('이미 팀 멤버입니다.');
       }
 
-      return this.teamsRepository.addTeamMember(teamId, bandMemberId, client);
+      try {
+        return await this.teamsRepository.addTeamMember(teamId, bandMemberId, client);
+      } catch (e) {
+        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+          throw new ConflictException('이미 팀 멤버입니다.');
+        }
+        throw e;
+      }
     };
 
     return tx ? run(tx) : this.prisma.$transaction(run);

--- a/backend/src/modules/teams/types/add-team-member-result.type.ts
+++ b/backend/src/modules/teams/types/add-team-member-result.type.ts
@@ -1,0 +1,10 @@
+import type { TeamMemberUserInfo } from './get-team-members-result.type';
+
+export interface AddTeamMemberResult {
+  teamMemberId: string;
+  teamId: string;
+  bandMemberId: string;
+  user: TeamMemberUserInfo;
+  teamRole: string;
+  joinedAt: string;
+}

--- a/backend/src/modules/teams/types/change-team-leader-result.type.ts
+++ b/backend/src/modules/teams/types/change-team-leader-result.type.ts
@@ -1,0 +1,6 @@
+import type { TeamLeaderInfo } from './get-band-teams-result.type';
+
+export interface ChangeTeamLeaderResult {
+  teamId: string;
+  teamLeader: TeamLeaderInfo;
+}

--- a/backend/src/modules/teams/types/create-team-result.type.ts
+++ b/backend/src/modules/teams/types/create-team-result.type.ts
@@ -1,0 +1,10 @@
+export interface CreateTeamResult {
+  teamId: string;
+  bandId: string;
+  name: string;
+  description: string | null;
+  status: string;
+  teamLeaderUserId: string;
+  teamCoverUrl: string | null;
+  createdAt: string;
+}

--- a/backend/src/modules/teams/types/delete-team-result.type.ts
+++ b/backend/src/modules/teams/types/delete-team-result.type.ts
@@ -1,0 +1,4 @@
+export interface DeleteTeamResult {
+  teamId: string;
+  deleted: boolean;
+}

--- a/backend/src/modules/teams/types/get-band-teams-result.type.ts
+++ b/backend/src/modules/teams/types/get-band-teams-result.type.ts
@@ -1,0 +1,31 @@
+export interface TeamLeaderInfo {
+  userId: string;
+  nickname: string;
+}
+
+export interface BandTeamListItem {
+  teamId: string;
+  name: string;
+  description: string | null;
+  status: string;
+  teamCoverUrl: string | null;
+  memberCount: number;
+  teamLeader: TeamLeaderInfo | null;
+  createdAt: string;
+}
+
+export interface BandTeamListCursor {
+  createdAt: string;
+  id: string;
+}
+
+export interface GetBandTeamsResult {
+  bandId: string;
+  items: BandTeamListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: BandTeamListCursor | null;
+    next: string | null;
+  };
+}

--- a/backend/src/modules/teams/types/get-my-teams-result.type.ts
+++ b/backend/src/modules/teams/types/get-my-teams-result.type.ts
@@ -1,0 +1,31 @@
+import type { TeamLeaderInfo } from './get-band-teams-result.type';
+
+export interface MyTeamListItem {
+  teamId: string;
+  bandId: string;
+  bandName: string;
+  name: string;
+  description: string | null;
+  status: string;
+  teamCoverUrl: string | null;
+  myTeamRole: string;
+  memberCount: number;
+  teamLeader: TeamLeaderInfo | null;
+  joinedAt: string;
+  createdAt: string;
+}
+
+export interface MyTeamListCursor {
+  joinedAt: string;
+  id: string;
+}
+
+export interface GetMyTeamsResult {
+  items: MyTeamListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: MyTeamListCursor | null;
+    next: string | null;
+  };
+}

--- a/backend/src/modules/teams/types/get-team-members-result.type.ts
+++ b/backend/src/modules/teams/types/get-team-members-result.type.ts
@@ -1,0 +1,29 @@
+export interface TeamMemberUserInfo {
+  userId: string;
+  nickname: string;
+  profileImageUrl: string | null;
+}
+
+export interface TeamMemberListItem {
+  teamMemberId: string;
+  bandMemberId: string;
+  user: TeamMemberUserInfo;
+  teamRole: string;
+  joinedAt: string;
+}
+
+export interface TeamMemberListCursor {
+  joinedAt: string;
+  id: string;
+}
+
+export interface GetTeamMembersResult {
+  teamId: string;
+  items: TeamMemberListItem[];
+  meta: {
+    count: number;
+    take: number;
+    cursor: TeamMemberListCursor | null;
+    next: string | null;
+  };
+}

--- a/backend/src/modules/teams/types/get-team-result.type.ts
+++ b/backend/src/modules/teams/types/get-team-result.type.ts
@@ -1,0 +1,14 @@
+import type { TeamLeaderInfo } from './get-band-teams-result.type';
+
+export interface GetTeamResult {
+  teamId: string;
+  bandId: string;
+  name: string;
+  description: string | null;
+  status: string;
+  teamCoverUrl: string | null;
+  teamLeader: TeamLeaderInfo | null;
+  memberCount: number;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/backend/src/modules/teams/types/remove-team-member-result.type.ts
+++ b/backend/src/modules/teams/types/remove-team-member-result.type.ts
@@ -1,0 +1,4 @@
+export interface RemoveTeamMemberResult {
+  teamMemberId: string;
+  removed: boolean;
+}

--- a/backend/src/modules/teams/types/update-team-result.type.ts
+++ b/backend/src/modules/teams/types/update-team-result.type.ts
@@ -1,0 +1,13 @@
+import type { TeamLeaderInfo } from './get-band-teams-result.type';
+
+export interface UpdateTeamResult {
+  teamId: string;
+  bandId: string;
+  name: string;
+  description: string | null;
+  status: string;
+  teamCoverUrl: string | null;
+  teamLeader: TeamLeaderInfo | null;
+  memberCount: number;
+  updatedAt: string;
+}


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 30~40분 (신규 모듈 23파일, 비즈니스 로직 검토 필요)

<br/>

## 📌 작업 요약

팀 생성·조회·수정·삭제 및 팀 멤버 관리 API 10개를 구현하고, 테스트 44개를 추가한다.

<br/>

## 📝 작업 내용

1. `#53 POST /bands/:bandId/teams` — 팀 생성 (밴드 멤버만 가능, 생성자가 팀 리더)
2. `#54 GET /bands/:bandId/teams` — 밴드 팀 목록 조회 (공개, 커서 페이지네이션)
3. `#55 GET /teams/me` — 내 팀 목록 조회 (커서 페이지네이션)
4. `#60 GET /teams/:teamId` — 팀 상세 조회 (공개)
5. `#61 PATCH /teams/:teamId` — 팀 정보 수정 (팀 리더 전용)
6. `#62 GET /teams/:teamId/members` — 팀 멤버 목록 조회 (공개, 커서 페이지네이션)
7. `#63 PATCH /teams/:teamId/leader` — 팀 리더 변경 (팀 리더 전용)
8. `#64 DELETE /teams/:teamId/members/:teamMemberId` — 팀 멤버 제거 (팀 리더 전용, 리더 자기 자신 제거 불가)
9. `#65 POST /teams/:teamId/members` — 팀 멤버 추가 (팀 리더 전용, 같은 밴드 멤버만 추가 가능)
10. `#66 DELETE /teams/:teamId` — 팀 삭제 (팀 리더 전용, TeamMember cascade)

<br/>

## 🚨 주요 고민 및 해결 과정

### 문제 1: 두 컨트롤러 분리 (URL prefix 충돌)

`/bands/:bandId/teams`와 `/teams/:teamId` URL prefix가 달라 하나의 컨트롤러로 처리 불가.

### 해결 과정

`BandTeamsController` (`/bands` prefix)와 `TeamsController` (`/teams` prefix)로 분리해 같은 `TeamsService`를 공유한다. `GET /teams/me`를 `GET /teams/:teamId`보다 먼저 선언해 라우트 섀도잉을 방지한다.

### 문제 2: 팀 리더 자기 자신 제거 처리

팀 리더가 `removeTeamMember`로 자신의 TeamMember를 제거하면 팀에 리더가 없어지는 정합성 문제 발생.

### 해결 과정

Service에서 `targetMember.teamRole === 'LEADER'`이면 400 BadRequest를 던진다. 리더 제거 전 `changeTeamLeader`로 리더를 먼저 변경하도록 에러 메시지에 안내한다.

<br/>

## 📑 참고 문서/ ADR

- API 명세: `docs/backend/api-docs/teams.md`
- 설계 문서: `docs/backend/designs/teams/teams-module.md`

<br/>

## 💬 리뷰 요구사항

- `changeTeamLeader` 트랜잭션 내부에서 `updateMany` → `update` → `findUnique` → `update` 4쿼리 순서가 안전한지 확인 부탁드립니다.
- `#54, #60, #62`를 공개(인증 불필요)로 지정한 것이 API 명세 의도에 맞는지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 밴드별 팀 생성·목록 조회, 내 팀 목록 조회, 팀 상세·멤버 조회가 추가되었습니다.
  * 팀 정보 수정, 팀 리더 변경, 멤버 추가·제거, 팀 삭제 기능이 제공됩니다.
  * 목록은 정렬 및 커서 기반 페이지네이션을 지원합니다.

* **Documentation**
  * Teams API 문서 및 Teams 모듈 설계 문서가 추가/정리되어 요청/응답 예시와 권한·오류 조건을 확인할 수 있습니다.

* **Tests**
  * 팀 서비스에 대한 테스트가 추가되어 주요 시나리오와 예외 처리가 검증됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->