### PR TITLE
[feat] #70 GET /bands/:bandId 밴드 단건 조회 API 구현

### DIFF
--- a/backend/docs/backend/api-docs/band-invitation.md
+++ b/backend/docs/backend/api-docs/band-invitation.md
@@ -1,9 +1,11 @@
 # band-invitation API
 
-> 최종 동기화: 2026-06-26
+> 최종 동기화: 2026-07-02
 >
 > ⚠️ 변환 노트:
-> - Notion 원본 응답 형식이 `{ status, error, message, data }` 구조이나, 프로젝트 컨벤션(`ApiSuccessResponse<T>`)에 맞게 `{ data, success }` 형식으로 표기함.
+> - Notion 원본 응답 형식이 `{ status, error, message, data }` 또는 `{ data, success }` 혼재하나, 하네스 컨벤션(`ApiSuccessResponse<T>`)에 맞게 `{ data, success }` 형식으로 통일.
+> - #14: Notion properties의 `body: false`와 달리 req 섹션에 body 필드가 명시되어 있어 body 있음으로 처리.
+> - #14: `자기 자신에게 초대 불가` 400 에러 조건 추가 (Notion 원본 명시).
 > - [설계자 보완 2026-06-26] 인증 여부 → "필요 (JWT Bearer)"로 수정; #14 권한 명시, 409 에러 코드 추가; #15/#16 409 에러 코드 추가; `count` 쿼리 파라미터를 boolean 타입으로 보완; `message` 필드 optional 명시; `next` 타입을 `string | null`로 수정; `meta.totalCount` 필드 추가.
 
 ---
@@ -34,9 +36,9 @@
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:----:|------|
 | inviteeUserId | string (UUID) | ✅ | 초대 대상 사용자 ID |
-| message | string | ❌ | 초대 메시지 (optional) |
+| message | string | ❌ | 초대 메시지 (최대 500자) |
 
-### Response 201
+### Response 200
 
 ```json
 {
@@ -52,21 +54,21 @@
 }
 ```
 
-### Error Responses
+### Error
 
 | 코드 | 조건 |
 |------|------|
-| 400 | 잘못된 입력 |
-| 401 | 인증 실패 |
-| 403 | 권한 없음 (BM 또는 ADMIN 아님) |
-| 404 | 밴드 또는 대상 유저 없음 |
-| 409 | 이미 밴드 멤버인 사용자 / 이미 초대가 존재함 / 차단된 사용자 |
+| 400 | 잘못된 입력 / 자기 자신에게 초대 불가 |
+| 401 | 인증 실패 (JWT 없음 또는 만료) |
+| 403 | 권한 없음 (BM/ADMIN 아님) / 차단된 사용자 초대 불가 |
+| 404 | 밴드 또는 초대 대상 유저 없음 |
+| 409 | 이미 밴드 멤버 / 이미 초대가 존재함 |
 
 ---
 
 ## #15 POST /invitations/{inviteId}/accept
 
-**설명:** 초대를 받은 유저가 초대를 수락한다.
+**설명:** 초대를 받은 유저가 초대를 수락한다. 본인이 받은 초대만 수락 가능.
 **인증:** 필요 (JWT Bearer)
 
 ### Request
@@ -77,7 +79,7 @@
 |---------|------|:----:|------|
 | inviteId | string (UUID) | ✅ | 수락할 초대 ID |
 
-### Response 201
+### Response 200
 
 ```json
 {
@@ -92,20 +94,20 @@
 }
 ```
 
-### Error Responses
+### Error
 
 | 코드 | 조건 |
 |------|------|
-| 401 | 인증 실패 |
+| 401 | 인증 실패 (JWT 없음 또는 만료) |
 | 403 | 권한 없음 (본인 초대가 아님) |
 | 404 | 초대 없음 |
-| 409 | 이미 처리된 초대 (PENDING 상태가 아님) |
+| 409 | 이미 처리된 초대 (PENDING 상태가 아님) / 이미 밴드 멤버 |
 
 ---
 
 ## #16 POST /invitations/{inviteId}/decline
 
-**설명:** 초대를 받은 유저가 초대를 거절한다.
+**설명:** 초대를 받은 유저가 초대를 거절한다. 본인이 받은 초대만 거절 가능.
 **인증:** 필요 (JWT Bearer)
 
 ### Request
@@ -116,7 +118,7 @@
 |---------|------|:----:|------|
 | inviteId | string (UUID) | ✅ | 거절할 초대 ID |
 
-### Response 201
+### Response 200
 
 ```json
 {
@@ -131,11 +133,11 @@
 }
 ```
 
-### Error Responses
+### Error
 
 | 코드 | 조건 |
 |------|------|
-| 401 | 인증 실패 |
+| 401 | 인증 실패 (JWT 없음 또는 만료) |
 | 403 | 권한 없음 (본인 초대가 아님) |
 | 404 | 초대 없음 |
 | 409 | 이미 처리된 초대 (PENDING 상태가 아님) |
@@ -144,7 +146,7 @@
 
 ## #17 DELETE /invitations/{inviteId}
 
-**설명:** 초대를 보낸 사람이 초대를 취소한다.
+**설명:** 초대를 보낸 사람이 초대를 취소한다. 본인이 보낸 PENDING 상태 초대만 취소 가능.
 **인증:** 필요 (JWT Bearer)
 
 ### Request
@@ -167,11 +169,11 @@
 }
 ```
 
-### Error Responses
+### Error
 
 | 코드 | 조건 |
 |------|------|
-| 401 | 인증 실패 |
+| 401 | 인증 실패 (JWT 없음 또는 만료) |
 | 403 | 권한 없음 (본인이 보낸 초대가 아님) |
 | 404 | 초대 없음 |
 
@@ -179,7 +181,7 @@
 
 ## #18 GET /invitations/received
 
-**설명:** 내가 받은 초대 목록을 조회한다. (Notion 원본 경로: `/invitations/recevied` — 오타)
+**설명:** 내가 받은 초대 목록을 커서 기반 페이지네이션으로 조회한다.
 **인증:** 필요 (JWT Bearer)
 
 ### Request
@@ -190,10 +192,10 @@
 |---------|------|:----:|:-----:|------|
 | count | boolean | ❌ | false | true이면 meta.totalCount에 전체 개수 포함 |
 | take | number | ❌ | 20 | 페이지당 항목 수 |
-| order__created_at | string | ❌ | desc | createdAt 정렬 방향 |
-| order__id | string | ❌ | desc | id 정렬 방향 |
-| cursor__id | string (UUID) | ❌ | - | 커서 ID |
-| where__invitation_status | string | ❌ | PENDING | 초대 상태 필터 |
+| order__created_at | string | ❌ | desc | 생성일 정렬 방향 (`asc` / `desc`) |
+| order__id | string | ❌ | desc | ID 정렬 방향 (`asc` / `desc`) |
+| cursor__id | string (UUID) | ❌ | — | 커서 ID (다음 페이지 조회 시 사용) |
+| where__invitation_status | string | ❌ | PENDING | 초대 상태 필터 (`PENDING` / `ACCEPTED` / `DECLINED` / `EXPIRED`) |
 
 ### Response 200
 
@@ -218,32 +220,31 @@
       }
     ],
     "meta": {
-      "count": 10,
+      "count": 1,
       "take": 20,
       "totalCount": 42,
-      "cursor": {
-        "id": "uuid"
-      },
-      "next": "/invitations/received?take=20&cursor__id=uuid&order__created_at=desc&order__id=desc"
+      "cursor": { "id": "uuid" },
+      "next": "/invitations/received?where__invitation_status=PENDING&order__created_at=desc&order__id=desc&take=20&cursor__id=uuid"
     }
   },
   "success": true
 }
 ```
 
-> `meta.totalCount`: `count=true`이면 전체 개수(COUNT 쿼리 결과), `count=false` 또는 미전달이면 `null`.
+> `meta.totalCount`: `count=true`이면 전체 건수(COUNT 쿼리), `count=false` 또는 미전달이면 `null`.
+> `meta.next`: 다음 페이지가 없으면 `null`.
 
-### Error Responses
+### Error
 
 | 코드 | 조건 |
 |------|------|
-| 401 | 인증 실패 |
+| 401 | 인증 실패 (JWT 없음 또는 만료) |
 
 ---
 
 ## #19 GET /invitations/sent
 
-**설명:** 내가 보낸 초대 목록을 조회한다.
+**설명:** 내가 보낸 초대 목록을 커서 기반 페이지네이션으로 조회한다.
 **인증:** 필요 (JWT Bearer)
 
 ### Request
@@ -254,10 +255,10 @@
 |---------|------|:----:|:-----:|------|
 | count | boolean | ❌ | false | true이면 meta.totalCount에 전체 개수 포함 |
 | take | number | ❌ | 20 | 페이지당 항목 수 |
-| order__created_at | string | ❌ | desc | createdAt 정렬 방향 |
-| order__id | string | ❌ | desc | id 정렬 방향 |
-| cursor__id | string (UUID) | ❌ | - | 커서 ID |
-| where__invitation_status | string | ❌ | PENDING | 초대 상태 필터 |
+| order__created_at | string | ❌ | desc | 생성일 정렬 방향 (`asc` / `desc`) |
+| order__id | string | ❌ | desc | ID 정렬 방향 (`asc` / `desc`) |
+| cursor__id | string (UUID) | ❌ | — | 커서 ID (다음 페이지 조회 시 사용) |
+| where__invitation_status | string | ❌ | PENDING | 초대 상태 필터 (`PENDING` / `ACCEPTED` / `DECLINED` / `EXPIRED`) |
 
 ### Response 200
 
@@ -285,12 +286,10 @@
       }
     ],
     "meta": {
-      "count": 2,
+      "count": 1,
       "take": 20,
       "totalCount": null,
-      "cursor": {
-        "id": "c9d2e4f5-..."
-      },
+      "cursor": { "id": "b8f1c3d2-..." },
       "next": null
     }
   },
@@ -298,10 +297,11 @@
 }
 ```
 
-> `meta.totalCount`: `count=true`이면 전체 개수(COUNT 쿼리 결과), `count=false` 또는 미전달이면 `null`.
+> `meta.totalCount`: `count=true`이면 전체 건수(COUNT 쿼리), `count=false` 또는 미전달이면 `null`.
+> `meta.next`: 다음 페이지가 없으면 `null`.
 
-### Error Responses
+### Error
 
 | 코드 | 조건 |
 |------|------|
-| 401 | 인증 실패 |
+| 401 | 인증 실패 (JWT 없음 또는 만료) |

--- a/backend/docs/backend/api-docs/band-join-request.md
+++ b/backend/docs/backend/api-docs/band-join-request.md
@@ -6,14 +6,14 @@
 > - Notion 원본 응답 형식이 `{ status, error, message, data }` 구조이나, 하네스 컨벤션(`ApiSuccessResponse<T>`)에 맞게 `{ data, success }` 형식으로 변환.
 > - #20: Notion properties에 `body: false`, `header: false`로 표기되어 있으나, req 섹션에 `message` body 필드가 명시되어 있어 body 있음으로 처리.
 > - #20, #21, #22(조회): 에러 코드 미명시 — 사용자 확인 필요.
-> - #22(승인), #23: 인증 여부 Notion 원본 미명시 (header: false) — BM/ADMIN 권한 필요할 것으로 추정되나 사용자 확인 필요.
+> - #20, #21, #22(GET/승인/거절), #23: Notion 원본 `header: false`이나 코드 기준 전 엔드포인트 `AccessTokenGuard` 확인 → 인증 필요로 정정.
 
 ---
 
 ## #20 POST /bands/{bandId}/join-requests
 
 **설명:** 유저가 특정 밴드에 가입을 요청한다.
-**인증:** 불필요 (Notion 원본 `header: false`) — 사용자 확인 필요
+**인증:** 필요 (JWT Bearer) — 컨트롤러 `AccessTokenGuard` 확인
 
 ### Request
 
@@ -55,7 +55,7 @@
 ## #21 GET /join-requests/sent
 
 **설명:** 내가 보낸 밴드 가입 요청 목록을 조회한다.
-**인증:** 불필요 (Notion 원본 `header: false`) — 사용자 확인 필요
+**인증:** 필요 (JWT Bearer) — 컨트롤러 `AccessTokenGuard` 확인
 
 ### Request
 
@@ -124,7 +124,7 @@
 ## #22 GET /bands/{bandId}/join-requests
 
 **설명:** 밴드에 요청 온 모든 가입 요청 목록을 조회한다.
-**인증:** 불필요 (Notion 원본 `header: false`) — 사용자 확인 필요
+**인증:** 필요 (JWT Bearer) — 컨트롤러 `AccessTokenGuard` 확인
 
 ### Request
 
@@ -186,7 +186,7 @@
 > ⚠️ Notion 원본에 #22 번호가 중복 사용됨 (GET /bands/{bandId}/join-requests와 동일 번호).
 
 **설명:** 밴드 관리자가 가입 요청을 승인한다.
-**인증:** 불필요 (Notion 원본 `header: false`) — BM/ADMIN 권한 필요 여부 사용자 확인 필요
+**인증:** 필요 (JWT Bearer) — 컨트롤러 `AccessTokenGuard` 확인
 
 ### Request
 
@@ -220,7 +220,7 @@
 ## #23 POST /join-requests/{joinRequestId}/reject
 
 **설명:** 밴드 관리자가 가입 요청을 거절한다.
-**인증:** 불필요 (Notion 원본 `header: false`) — BM/ADMIN 권한 필요 여부 사용자 확인 필요
+**인증:** 필요 (JWT Bearer) — 컨트롤러 `AccessTokenGuard` 확인
 
 ### Request
 

--- a/backend/docs/backend/api-docs/band-join-request.md
+++ b/backend/docs/backend/api-docs/band-join-request.md
@@ -1,0 +1,250 @@
+# band-join-request API
+
+> 최종 동기화: 2026-07-02
+>
+> ⚠️ 변환 노트:
+> - Notion 원본 응답 형식이 `{ status, error, message, data }` 구조이나, 하네스 컨벤션(`ApiSuccessResponse<T>`)에 맞게 `{ data, success }` 형식으로 변환.
+> - #20: Notion properties에 `body: false`, `header: false`로 표기되어 있으나, req 섹션에 `message` body 필드가 명시되어 있어 body 있음으로 처리.
+> - #20, #21, #22(조회): 에러 코드 미명시 — 사용자 확인 필요.
+> - #22(승인), #23: 인증 여부 Notion 원본 미명시 (header: false) — BM/ADMIN 권한 필요할 것으로 추정되나 사용자 확인 필요.
+
+---
+
+## #20 POST /bands/{bandId}/join-requests
+
+**설명:** 유저가 특정 밴드에 가입을 요청한다.
+**인증:** 불필요 (Notion 원본 `header: false`) — 사용자 확인 필요
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| bandId | string (UUID) | ✅ | 가입 요청할 밴드 ID |
+
+**Body**
+
+```json
+{
+  "message": "기타로 합류하고 싶습니다!"
+}
+```
+
+### Response 200
+
+```json
+{
+  "data": {
+    "joinRequestId": "uuid",
+    "bandId": "uuid",
+    "userId": "uuid",
+    "joinRequestStatus": "PENDING",
+    "createdAt": "2026-04-30T10:00:00.000Z"
+  },
+  "success": true
+}
+```
+
+### Error
+
+> Notion 원본 에러 코드 미명시 — 사용자 확인 필요.
+
+---
+
+## #21 GET /join-requests/sent
+
+**설명:** 내가 보낸 밴드 가입 요청 목록을 조회한다.
+**인증:** 불필요 (Notion 원본 `header: false`) — 사용자 확인 필요
+
+### Request
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|---------|------|:----:|:-----:|------|
+| count | string | ❌ | — | 전체 개수 포함 여부 |
+| take | number | ❌ | 20 | 페이지당 항목 수 |
+| order__created_at | string | ❌ | desc | 생성일 정렬 방향 |
+| order__id | string | ❌ | desc | ID 정렬 방향 |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "items": [
+      {
+        "joinRequestId": "8a8a8a8a-1111-2222-3333-444444444444",
+        "band": {
+          "bandId": "a8c6b7b1-0f0a-4e3a-8a0c-4f6ef3d2d9c1",
+          "name": "Rocking Stars",
+          "description": "주 1회 합주 밴드",
+          "visibility": true
+        },
+        "message": "기타로 참여하고 싶습니다.",
+        "joinRequestStatus": "PENDING",
+        "createdAt": "2026-04-10T12:00:00Z",
+        "respondedAt": null
+      },
+      {
+        "joinRequestId": "9b9b9b9b-1111-2222-3333-555555555555",
+        "band": {
+          "bandId": "c9d7e8f1-aaaa-bbbb-cccc-dddddddddddd",
+          "name": "Indie Wave",
+          "description": null,
+          "visibility": true
+        },
+        "message": "보컬 지원합니다.",
+        "joinRequestStatus": "REJECTED",
+        "createdAt": "2026-04-09T18:00:00Z",
+        "respondedAt": "2026-04-09T20:00:00Z"
+      }
+    ],
+    "meta": {
+      "count": 2,
+      "take": 20,
+      "cursor": {
+        "createdAt": "2026-04-09T18:00:00Z",
+        "id": "9b9b9b9b-1111-2222-3333-555555555555"
+      },
+      "next": null
+    }
+  },
+  "success": true
+}
+```
+
+### Error
+
+> Notion 원본 에러 코드 미명시 — 사용자 확인 필요.
+
+---
+
+## #22 GET /bands/{bandId}/join-requests
+
+**설명:** 밴드에 요청 온 모든 가입 요청 목록을 조회한다.
+**인증:** 불필요 (Notion 원본 `header: false`) — 사용자 확인 필요
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| bandId | string (UUID) | ✅ | 조회할 밴드 ID |
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|---------|------|:----:|:-----:|------|
+| count | string | ❌ | — | 전체 개수 포함 여부 |
+| take | number | ❌ | 20 | 페이지당 항목 수 |
+| order__created_at | string | ❌ | desc | 생성일 정렬 방향 |
+| order__id | string | ❌ | desc | ID 정렬 방향 |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "items": [
+      {
+        "joinRequestId": "uuid",
+        "requester": {
+          "userId": "uuid",
+          "nickname": "Jun",
+          "avatarUrl": "https://..."
+        },
+        "message": "보컬로 참여하고 싶습니다.",
+        "joinRequestStatus": "PENDING",
+        "createdAt": "2026-04-30T10:00:00.000Z"
+      }
+    ],
+    "meta": {
+      "count": 1,
+      "take": 20,
+      "cursor": {
+        "createdAt": "2026-04-30T10:00:00.000Z",
+        "id": "uuid"
+      },
+      "next": "/bands/uuid/join-requests?take=20&cursor__created_at=2026-04-30T10:00:00.000Z&cursor__id=uuid"
+    }
+  },
+  "success": true
+}
+```
+
+### Error
+
+> Notion 원본 에러 코드 미명시 — 사용자 확인 필요.
+
+---
+
+## #22 POST /join-requests/{joinRequestId}/approve
+
+> ⚠️ Notion 원본에 #22 번호가 중복 사용됨 (GET /bands/{bandId}/join-requests와 동일 번호).
+
+**설명:** 밴드 관리자가 가입 요청을 승인한다.
+**인증:** 불필요 (Notion 원본 `header: false`) — BM/ADMIN 권한 필요 여부 사용자 확인 필요
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| joinRequestId | string (UUID) | ✅ | 승인할 가입 요청 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "joinRequestId": "uuid",
+    "bandId": "uuid",
+    "userId": "uuid",
+    "joinRequestStatus": "APPROVED",
+    "joinedAt": "2026-04-30T10:00:00.000Z"
+  },
+  "success": true
+}
+```
+
+### Error
+
+> Notion 원본 에러 코드 미명시 — 사용자 확인 필요.
+
+---
+
+## #23 POST /join-requests/{joinRequestId}/reject
+
+**설명:** 밴드 관리자가 가입 요청을 거절한다.
+**인증:** 불필요 (Notion 원본 `header: false`) — BM/ADMIN 권한 필요 여부 사용자 확인 필요
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| joinRequestId | string (UUID) | ✅ | 거절할 가입 요청 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "joinRequestId": "uuid",
+    "bandId": "uuid",
+    "userId": "uuid",
+    "joinRequestStatus": "REJECTED",
+    "respondedAt": "2026-04-30T10:00:00.000Z"
+  },
+  "success": true
+}
+```
+
+### Error
+
+> Notion 원본 에러 코드 미명시 — 사용자 확인 필요.

--- a/backend/docs/backend/api-docs/band.md
+++ b/backend/docs/backend/api-docs/band.md
@@ -1,16 +1,17 @@
 # Band API
 
-> 최종 동기화: 2026-05-20
+> 최종 동기화: 2026-07-02
 >
 > ⚠️ 변환 노트:
 > - Notion 원본의 응답 형식은 `{ "status": "success", "error": null, "message": "...", "data": { ... } }` 구조이나, 하네스 컨벤션인 `{ "data": ..., "success": true }` 형태로 변환하였다.
-> - #12 밴드 검색하기: Notion 원본에서 `req` 블록에 응답 JSON이 기재되어 있어, 실제 응답으로 간주하여 변환하였다. 요청 바디는 없음(Query Parameter로 처리).
+> - #12 밴드 검색하기: Notion 원본에서 `req` 블록에 응답 JSON이 기재되어 있어, 실제 응답으로 간주하여 변환하였다. 요청 바디는 없음(Query Parameter로 처리). 검색 파라미터 이름은 Notion 원본 예시 URL 기준 `where__name__contains`로 수정.
 > - [설계자 보완 2026-06-26] #8 DELETE /bands/{bandId}: 코드(`bands.controller.ts`)에 `@UseGuards(AccessTokenGuard)` 데코레이터 확인 → 인증 필요로 확정.
 > - [설계자 보완 2026-06-26] #12 GET /bands/search: 코드(`bands.controller.ts`)에 Guards 없음 → 비인증 공개 확정.
 > - [설계자 보완 2026-06-26] #13 PATCH /bands/{bandId}: 코드(`bands.controller.ts`)에 `@UseGuards(AccessTokenGuard)` 확인 → 인증 필요 확정. Body 필드(name, description, visibility, coverImgUrl) 모두 선택이며 하나라도 입력해야 함(코드 `validateUpdateBandInput` 기준). `bmId` 필드는 MVP에서 지원하지 않으므로 명세에서 제거.
 > - [설계자 보완 2026-06-26] #10, #11, #12 응답 `meta.next`: 현재 코드는 커서 객체(`{ createdAt, id }` 등)를 반환하나, User 모듈 패턴(`buildNextPath`) 적용 후 `string | null`(URL 경로)로 변환 예정.
 > - [코드 기반 보완 2026-06-26] 에러 코드 전체 갱신: 서비스/컨트롤러 코드 기준으로 실제 throw 조건 명시. #11 인증 요구사항 수정(컨트롤러 Guard 없음 → 공개 API).
 > - [코드 기반 보완 2026-06-26] `Error Responses` → `Error`, 헤더 `조건` → `사유`로 User API 형식 통일.
+> - [설계자 보완 2026-07-02] #70 GET /bands/{bandId}: Notion 원본에 없는 신규 API. 전체 api-docs 최대 번호 #69 기준으로 #70 부여.
 
 ---
 
@@ -331,14 +332,14 @@
 
 | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
 |---------|------|:----:|:-----:|------|
-| where__name__contain | string | 선택 | — | 밴드 이름 검색 키워드 |
+| where__name__contains | string | 선택 | — | 밴드 이름 검색 키워드 |
 | take | number | 선택 | 20 | 가져올 밴드 수 |
 | order__created_at | string | 선택 | `desc` | 생성일 정렬 방향 (`asc` / `desc`) |
 | order__id | string | 선택 | `desc` | ID 정렬 방향 (`asc` / `desc`) |
 | cursor__created_at | string | 선택 | — | 커서: 생성일 |
 | cursor__id | string | 선택 | — | 커서: 밴드 ID |
 
-> 요청 예시: `GET /bands/search?where__name__contain=rock&take=20`
+> 요청 예시: `GET /bands/search?where__name__contains=rock&take=20`
 
 ### Response 200
 
@@ -367,7 +368,7 @@
         "createdAt": "2026-04-10T00:00:00.000Z",
         "id": "a8c6b7b1-0f0a-4e3a-8a0c-4f6ef3d2d9c1"
       },
-      "next": "/bands/search?cursor__created_at=2026-04-10T00%3A00%3A00.000Z&cursor__id=a8c6b7b1-0f0a-4e3a-8a0c-4f6ef3d2d9c1&take=20&order__created_at=desc&order__id=desc&where__name__contain=rock"
+      "next": "/bands/search?cursor__created_at=2026-04-10T00%3A00%3A00.000Z&cursor__id=a8c6b7b1-0f0a-4e3a-8a0c-4f6ef3d2d9c1&take=20&order__created_at=desc&order__id=desc&where__name__contains=rock"
     }
   },
   "success": true
@@ -432,3 +433,49 @@
 | 401 | 인증 실패 |
 | 403 | 밴드 마스터 아님 |
 | 404 | 밴드 없음 |
+
+---
+
+## #70 GET /bands/{bandId}
+
+**설명:** 밴드 ID로 삭제되지 않은 밴드의 상세 정보를 조회한다.
+**인증:** 불필요 (공개 API)
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| bandId | string (UUID) | ✅ | 조회할 밴드 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "band": {
+      "id": "a8c6b7b1-0f0a-4e3a-8a0c-4f6ef3d2d9c1",
+      "name": "합주하자",
+      "description": "주 1회 합주하는 밴드입니다.",
+      "visibility": true,
+      "coverImgUrl": "https://cdn.example.com/bands/cover.png",
+      "bandMasterUserId": "11111111-1111-1111-1111-111111111111",
+      "genres": [
+        { "id": "0f0a4e3a-8a0c-4f6e-9d2d-9c1a8c6b7b1a", "name": "rock" },
+        { "id": "3f2a4e3a-8a0c-4f6e-9d2d-9c1a8c6b7b2b", "name": "jazz" }
+      ],
+      "memberCount": 5,
+      "createdAt": "2026-03-03T18:20:10.123Z"
+    }
+  },
+  "success": true
+}
+```
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 400 | `bandId`가 UUID 형식이 아님 |
+| 404 | 밴드 없음 (삭제된 밴드 포함) |

--- a/backend/docs/backend/designs/bands/get-band.md
+++ b/backend/docs/backend/designs/bands/get-band.md
@@ -1,0 +1,113 @@
+# 설계: #70 GET /bands/{bandId} — 밴드 단건 조회
+
+## API 번호
+
+**#70 GET /bands/{bandId}** — 새 API (전체 api-docs 최대 #69 기준)
+
+---
+
+## 작업 범위
+
+```
+신규: src/modules/bands/types/get-band-result.type.ts
+수정: src/modules/bands/repositories/bands.repository.ts     (findBandDetail 메서드 추가)
+      src/modules/bands/repositories/bands.prisma-repository.ts (findBandDetail 구현 추가)
+      src/modules/bands/bands.service.ts                      (getBand 메서드 추가)
+      src/modules/bands/bands.service.spec.ts                 (getBand 테스트 추가)
+      src/modules/bands/bands.controller.ts                   (getBand 핸들러 추가)
+      docs/backend/api-docs/band.md                           (#70 섹션 추가)
+```
+
+---
+
+## API 명세
+
+**인증:** 불필요 (공개 API — #11, #12와 동일하게 가입 전 미리보기 허용)
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| bandId | string (UUID) | ✅ | 조회할 밴드 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "band": {
+      "id": "a8c6b7b1-0f0a-4e3a-8a0c-4f6ef3d2d9c1",
+      "name": "합주하자",
+      "description": "주 1회 합주하는 밴드입니다.",
+      "visibility": true,
+      "coverImgUrl": "https://cdn.example.com/bands/cover.png",
+      "bandMasterUserId": "11111111-1111-1111-1111-111111111111",
+      "genres": [
+        { "id": "0f0a4e3a-8a0c-4f6e-9d2d-9c1a8c6b7b1a", "name": "rock" },
+        { "id": "3f2a4e3a-8a0c-4f6e-9d2d-9c1a8c6b7b2b", "name": "jazz" }
+      ],
+      "memberCount": 5,
+      "createdAt": "2026-03-03T18:20:10.123Z"
+    }
+  },
+  "success": true
+}
+```
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 400 | `bandId`가 UUID 형식이 아님 |
+| 404 | 밴드 없음 (삭제된 밴드 포함) |
+
+---
+
+## Repository 인터페이스 변경
+
+`bands.repository.ts`에 추가:
+
+```typescript
+/**
+ * bandId로 삭제되지 않은 밴드 상세 정보를 조회한다.
+ */
+findBandDetail(
+  bandId: string,
+  tx?: Prisma.TransactionClient,
+): Promise<GetBandResult['band'] | null>;
+```
+
+---
+
+## Service 비즈니스 규칙
+
+```
+getBand(bandId, tx?):
+1. bandsRepository.findBandDetail(bandId, tx) 호출
+2. null이면 → NotFoundException('요청한 밴드를 찾을 수 없습니다.')
+3. { band } 형태로 반환
+```
+
+---
+
+## 트랜잭션 경계
+
+단순 단건 조회이므로 `$transaction` 불필요. 하네스 규칙에 따라 `tx?: Prisma.TransactionClient`는 유지하고 직접 전달한다.
+
+---
+
+## 테스트 계획
+
+| 메서드 | 케이스 | 패턴 |
+|--------|--------|------|
+| getBand | happy path | findBandDetail이 밴드 반환 → `{ band }` 그대로 반환 |
+| getBand | 밴드 없음 | findBandDetail이 null → NotFoundException |
+| getBand | 외부 tx 전달 | tx 인자가 findBandDetail에 전달되는지 toBe 단언 |
+
+---
+
+## 미결 사항
+
+없음

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -21,6 +21,7 @@ import type { CreateBandInvitationResult } from './types/create-band-invitation-
 import type { CreateBandJoinRequestResult } from './types/create-band-join-request-result.type';
 import type { CreateBandResult } from './types/create-band-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
+import type { GetBandResult } from './types/get-band-result.type';
 import type { LeaveBandResult } from './types/leave-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
 import type { UpdateBandMemberRoleResult } from './types/update-band-member-role-result.type';
@@ -177,6 +178,18 @@ export class BandsController {
     const updatedBand = await this.bandsService.updateBand(request.user.id, bandId, input);
 
     return createSuccessResponse('밴드 정보 수정 완료', updatedBand);
+  }
+
+  @Get(':bandId')
+  @ApiOperation({ summary: '밴드 단건 조회' })
+  @ApiParam({ name: 'bandId', description: '밴드 ID (UUID)', type: String })
+  @ApiResponse({ status: 200, description: '밴드 조회 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 bandId 형식' })
+  @ApiResponse({ status: 404, description: '밴드를 찾을 수 없음' })
+  async getBand(@Param('bandId') bandId: string): Promise<ApiSuccessResponse<GetBandResult>> {
+    const band = await this.bandsService.getBand(bandId);
+
+    return createSuccessResponse('밴드 조회 성공', band);
   }
 
   @Get(':bandId/users')

--- a/backend/src/modules/bands/bands.controller.ts
+++ b/backend/src/modules/bands/bands.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Query, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, ParseUUIDPipe, Patch, Post, Query, Req, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
@@ -186,7 +186,7 @@ export class BandsController {
   @ApiResponse({ status: 200, description: '밴드 조회 성공' })
   @ApiResponse({ status: 400, description: '잘못된 bandId 형식' })
   @ApiResponse({ status: 404, description: '밴드를 찾을 수 없음' })
-  async getBand(@Param('bandId') bandId: string): Promise<ApiSuccessResponse<GetBandResult>> {
+  async getBand(@Param('bandId', ParseUUIDPipe) bandId: string): Promise<ApiSuccessResponse<GetBandResult>> {
     const band = await this.bandsService.getBand(bandId);
 
     return createSuccessResponse('밴드 조회 성공', band);

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -106,6 +106,18 @@ function createBandsRepositoryStub(options?: {
   onSearchBands?: (query: SearchBandsQuery, tx: unknown) => void;
   onUpdateBand?: (bandId: string, input: UpdateBandInput, tx: unknown) => void;
   onUpdateBandMemberRole?: (bandMemberId: string, role: BandMemberRole, tx: unknown) => void;
+  bandDetail?: {
+    id: string;
+    name: string;
+    description: string | null;
+    visibility: boolean;
+    coverImgUrl: string | null;
+    bandMasterUserId: string;
+    genres: { id: string; name: string }[];
+    memberCount: number;
+    createdAt: string;
+  } | null;
+  onFindBandDetail?: (bandId: string, tx: unknown) => void;
 }): BandsRepository {
   return {
     async acceptBandInvitation(invitationId, bandId, userId, respondedAt, tx) {
@@ -592,6 +604,25 @@ function createBandsRepositoryStub(options?: {
           userId: 'target-user-001',
           role: input.role,
         },
+      };
+    },
+    async findBandDetail(bandId, tx) {
+      options?.onFindBandDetail?.(bandId, tx);
+
+      if (options?.bandDetail !== undefined) {
+        return options.bandDetail;
+      }
+
+      return {
+        id: bandId,
+        name: '합주하자',
+        description: '주 1회 합주하는 밴드입니다.',
+        visibility: true,
+        coverImgUrl: null,
+        bandMasterUserId: BAND_MASTER_USER_ID,
+        genres: [{ id: ROCK_GENRE_ID, name: 'rock' }],
+        memberCount: 5,
+        createdAt: '2026-03-03T09:20:10.123Z',
       };
     },
   };
@@ -2602,6 +2633,41 @@ describe('BandsService', () => {
       expect(capturedTransactions[0]).toBe(externalTx);
       expect(capturedTransactions[1]).toBe(externalTx);
       expect(capturedTransactions[2]).toBe(externalTx);
+    });
+  });
+
+  describe('getBand', () => {
+    it('밴드가 존재하면 상세 정보를 반환한다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.getBand('band-001');
+
+      expect(result.band.id).toBe('band-001');
+      expect(result.band.name).toBe('합주하자');
+      expect(result.band.memberCount).toBe(5);
+    });
+
+    it('밴드가 없으면 NotFoundException을 던진다', async () => {
+      const repository = createBandsRepositoryStub({ bandDetail: null });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.getBand('band-001')).rejects.toThrow(NotFoundException);
+    });
+
+    it('외부 tx가 있으면 findBandDetail에 그대로 전달한다', async () => {
+      const externalTx = { externalTransaction: true };
+      let capturedTx: unknown;
+      const repository = createBandsRepositoryStub({
+        onFindBandDetail(_bandId, tx) {
+          capturedTx = tx;
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.getBand('band-001', externalTx as never);
+
+      expect(capturedTx).toBe(externalTx);
     });
   });
 });

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -28,6 +28,7 @@ import type { CreateBandInvitationFailedItem, CreateBandResult } from './types/c
 import type { DeclineBandInvitationResult } from './types/decline-band-invitation-result.type';
 import type { DeleteBandInvitationResult } from './types/delete-band-invitation-result.type';
 import type { DeleteBandResult } from './types/delete-band-result.type';
+import type { GetBandResult } from './types/get-band-result.type';
 import type { LeaveBandResult } from './types/leave-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
 import type { GetReceivedBandInvitationsResult } from './types/received-band-invitation-list.type';
@@ -680,6 +681,23 @@ export class BandsService {
     }
 
     return this.bandsRepository.findBandMembers(bandId, query, tx);
+  }
+
+  /**
+   * 삭제되지 않은 밴드를 ID로 단건 조회한다.
+   *
+   * @param {string} bandId - 조회할 밴드 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetBandResult>} 밴드 상세 정보
+   */
+  async getBand(bandId: string, tx?: Prisma.TransactionClient): Promise<GetBandResult> {
+    const band = await this.bandsRepository.findBandDetail(bandId, tx);
+
+    if (band === null) {
+      throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
+    }
+
+    return { band };
   }
 
   /**

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -24,6 +24,7 @@ import type { BandGenreItem, CreateBandInvitationSuccessItem } from '../types/cr
 import type { DeclineBandInvitationResult } from '../types/decline-band-invitation-result.type';
 import type { DeleteBandInvitationResult } from '../types/delete-band-invitation-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
+import type { GetBandResult } from '../types/get-band-result.type';
 import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult, MyBandListItem } from '../types/my-band-list.type';
 import type { GetReceivedBandInvitationsResult, ReceivedBandInvitationListItem } from '../types/received-band-invitation-list.type';
@@ -1848,6 +1849,52 @@ export class BandsPrismaRepository implements BandsRepository {
       message: joinRequest.message,
       joinRequestStatus: joinRequest.status,
       createdAt: joinRequest.createdAt.toISOString(),
+    };
+  }
+
+  /**
+   * bandId로 삭제되지 않은 밴드 상세 정보를 장르·멤버 수와 함께 조회한다.
+   *
+   * @param {string} bandId - 조회할 밴드 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<GetBandResult['band'] | null>} 밴드 상세 정보, 없으면 null
+   */
+  async findBandDetail(bandId: string, tx?: Prisma.TransactionClient): Promise<GetBandResult['band'] | null> {
+    const client = tx ?? this.prisma;
+
+    const band = await client.band.findFirst({
+      where: { id: bandId, deletedAt: null },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        visibility: true,
+        coverImgUrl: true,
+        bandMasterUserId: true,
+        createdAt: true,
+        bandGenres: {
+          select: {
+            genre: { select: { id: true, name: true } },
+          },
+        },
+        _count: { select: { members: true } },
+      },
+    });
+
+    if (band === null) {
+      return null;
+    }
+
+    return {
+      id: band.id,
+      name: band.name,
+      description: band.description,
+      visibility: band.visibility,
+      coverImgUrl: band.coverImgUrl,
+      bandMasterUserId: band.bandMasterUserId,
+      genres: band.bandGenres.map(bg => bg.genre),
+      memberCount: band._count.members,
+      createdAt: band.createdAt.toISOString(),
     };
   }
 

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -22,6 +22,7 @@ import type { CreateBandInvitationSuccessItem, CreateBandResult } from '../types
 import type { DeclineBandInvitationResult } from '../types/decline-band-invitation-result.type';
 import type { DeleteBandInvitationResult } from '../types/delete-band-invitation-result.type';
 import type { DeleteBandResult } from '../types/delete-band-result.type';
+import type { GetBandResult } from '../types/get-band-result.type';
 import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult } from '../types/my-band-list.type';
 import type { GetReceivedBandInvitationsResult } from '../types/received-band-invitation-list.type';
@@ -179,4 +180,5 @@ export interface BandsRepository {
   findExistingGenreIds(genreIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;
   findExistingUserIds(userIds: string[], tx?: Prisma.TransactionClient): Promise<string[]>;
   updateBandMemberRole(bandMemberId: string, input: UpdateBandMemberRoleInput, tx?: Prisma.TransactionClient): Promise<UpdateBandMemberRoleResult>;
+  findBandDetail(bandId: string, tx?: Prisma.TransactionClient): Promise<GetBandResult['band'] | null>;
 }

--- a/backend/src/modules/bands/types/get-band-result.type.ts
+++ b/backend/src/modules/bands/types/get-band-result.type.ts
@@ -1,0 +1,18 @@
+export interface GetBandGenreItem {
+  id: string;
+  name: string;
+}
+
+export interface GetBandResult {
+  band: {
+    id: string;
+    name: string;
+    description: string | null;
+    visibility: boolean;
+    coverImgUrl: string | null;
+    bandMasterUserId: string;
+    genres: GetBandGenreItem[];
+    memberCount: number;
+    createdAt: string;
+  };
+}


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 10분

<br/>

## 📌 작업 요약

band ID로 밴드 상세 정보를 조회하는 공개 API (#70 GET /bands/:bandId)를 구현한다.

<br/>

## 📝 작업 내용

1. 📝 Notion band API 명세 동기화 (band-invitation, band-join-request)
   - `band-invitation.md`: 동기화 날짜 갱신, #14 body 처리 및 에러 조건 보완
   - `band-join-request.md`: 신규 파일 (#20~#23 가입 요청 API)
2. ✨ #70 GET /bands/:bandId 밴드 단건 조회 API 구현
   - `BandsRepository`에 `findBandDetail` 인터페이스 추가
   - `BandsPrismaRepository`에 `findBandDetail` 구현 (장르·멤버 수 포함)
   - `BandsService`에 `getBand` 추가 — 밴드 없으면 `NotFoundException`
   - `BandsController`에 `GET :bandId` 핸들러 추가 (공개 API, 인증 불필요)
   - `bands.service.spec.ts`에 `getBand` 테스트 3개 추가 (happy path / NotFoundException / 외부 tx 전달)

<br/>

## 🚨 주요 고민 및 해결 과정

### 문제
API 번호를 band 모듈 내 최대값(#13)이 아닌 전체 api-docs 파일 기준 최대값으로 부여해야 중복이 없다.

### 해결 과정
모든 api-docs 파일을 스캔하여 전체 최대 번호 #69 확인 후 #70 부여.
`@Get(':bandId')` 핸들러는 `@Get('me')`, `@Get('search')` 이후에 선언하여 NestJS 정적 경로 우선 매칭을 보장.

<br/>

## 📑 참고 문서/ ADR

<br/>

## 💬 리뷰 요구사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 공개 밴드 단건 조회 API(`GET /bands/{bandId}`)가 추가되어, 밴드 상세 정보를 바로 확인할 수 있습니다.
* **Documentation**
  * 밴드 가입 요청/밴드 초대 관련 API 문서가 전반적으로 동기화되며, 응답 래핑/페이지네이션(`meta`) 규격이 더 명확해졌습니다.
* **Bug Fixes**
  * 밴드 검색 조건 파라미터의 표기 오타가 수정되었고, `meta.next`의 쿼리 반영 방식도 문서에 맞게 정리되었습니다.
* **Tests**
  * 밴드 단건 조회 동작에 대한 테스트가 추가/보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->