### PR TITLE
합주 공간 일정 조회·필터 개선 및 알림 발신자 표시

### DIFF
--- a/backend/prisma/migrations/20260705120000_add_notification_reference/migration.sql
+++ b/backend/prisma/migrations/20260705120000_add_notification_reference/migration.sql
@@ -1,0 +1,7 @@
+-- CreateEnum
+CREATE TYPE "NotificationReferenceType" AS ENUM ('BAND_INVITATION');
+
+-- AlterTable
+ALTER TABLE "notifications"
+ADD COLUMN "reference_type" "NotificationReferenceType",
+ADD COLUMN "reference_id" UUID;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -72,16 +72,18 @@ model ProfileMusic {
 }
 
 model Notification {
-  id          String           @id @default(uuid()) @db.Uuid
-  userId      String           @map("user_id") @db.Uuid
-  type        NotificationType
-  title       String           @db.VarChar(120)
-  description String?
-  targetPath  String?          @map("target_path")
-  isRead      Boolean          @default(false) @map("is_read")
-  remindsAt   DateTime?        @map("reminds_at") @db.Timestamptz(6)
-  createdAt   DateTime?        @default(now()) @map("created_at") @db.Timestamptz(6)
-  user        User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id            String                     @id @default(uuid()) @db.Uuid
+  userId        String                     @map("user_id") @db.Uuid
+  type          NotificationType
+  title         String                     @db.VarChar(120)
+  description   String?
+  targetPath    String?                    @map("target_path")
+  referenceType NotificationReferenceType? @map("reference_type")
+  referenceId   String?                    @map("reference_id") @db.Uuid
+  isRead        Boolean                    @default(false) @map("is_read")
+  remindsAt     DateTime?                  @map("reminds_at") @db.Timestamptz(6)
+  createdAt     DateTime?                  @default(now()) @map("created_at") @db.Timestamptz(6)
+  user          User                       @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, isRead])
   @@index([userId, isRead, type])
@@ -487,6 +489,10 @@ enum NotificationType {
   INVITE
   NOTICE
   REMINDER
+}
+
+enum NotificationReferenceType {
+  BAND_INVITATION
 }
 
 enum AttendanceStatus {

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, ConflictException, ForbiddenException, Inject, Injectable, NotFoundException, Optional } from '@nestjs/common';
 
 import { PrismaService } from '../../database/prisma';
-import { BandMemberRole, NotificationType, type Prisma } from '../../generated/prisma';
+import { BandMemberRole, NotificationReferenceType, NotificationType, type Prisma } from '../../generated/prisma';
 import { NotificationsService } from '../notifications/notifications.service';
 
 import type { CreateBandInput } from './dto/create-band.dto';
@@ -175,6 +175,8 @@ export class BandsService {
           title: '밴드 초대가 도착했습니다.',
           description: '새 밴드 초대가 도착했습니다.',
           targetPath: `/invitations/received?invitationId=${result.invitationId}`,
+          referenceType: NotificationReferenceType.BAND_INVITATION,
+          referenceId: result.invitationId,
         },
         client,
       );
@@ -818,6 +820,8 @@ export class BandsService {
       title: string;
       description: string;
       targetPath: string;
+      referenceType?: NotificationReferenceType;
+      referenceId?: string;
     },
     tx: Prisma.TransactionClient,
   ): Promise<void> {
@@ -832,6 +836,8 @@ export class BandsService {
         title: input.title,
         description: input.description,
         targetPath: input.targetPath,
+        referenceType: input.referenceType,
+        referenceId: input.referenceId,
       },
       tx,
     );

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
@@ -647,14 +647,14 @@ describe('BandsPrismaRepository', () => {
   });
 
   describe('acceptBandInvitation', () => {
-    it('밴드 멤버를 생성하고 수락한 초대 row를 삭제한다', async () => {
+    it('밴드 멤버를 생성하고 초대 상태를 ACCEPTED로 변경한다', async () => {
       const prisma = createPrismaMock();
       prisma.bandMember.create.mockResolvedValue({
         joinedAt: new Date('2026-04-30T10:00:00.000Z'),
       });
-      prisma.bandInvitation.delete.mockResolvedValue(undefined);
-      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
       const respondedAt = new Date('2026-04-30T09:59:00.000Z');
+      prisma.bandInvitation.update.mockResolvedValue({ status: 'ACCEPTED', respondedAt });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
 
       const result = await repository.acceptBandInvitation('invitation-001', 'band-001', 'user-002', respondedAt);
 
@@ -668,12 +668,20 @@ describe('BandsPrismaRepository', () => {
           joinedAt: true,
         },
       });
-      expect(prisma.bandInvitation.delete).toHaveBeenCalledWith({
+      expect(prisma.bandInvitation.update).toHaveBeenCalledWith({
         where: {
           id: 'invitation-001',
         },
+        data: {
+          status: 'ACCEPTED',
+          respondedAt,
+        },
+        select: {
+          status: true,
+          respondedAt: true,
+        },
       });
-      expect(prisma.bandInvitation.update).not.toHaveBeenCalled();
+      expect(prisma.bandInvitation.delete).not.toHaveBeenCalled();
       expect(result).toEqual({
         invitationId: 'invitation-001',
         bandId: 'band-001',
@@ -689,15 +697,15 @@ describe('BandsPrismaRepository', () => {
       tx.bandMember.create.mockResolvedValue({
         joinedAt: new Date('2026-04-30T10:00:00.000Z'),
       });
-      tx.bandInvitation.delete.mockResolvedValue(undefined);
+      tx.bandInvitation.update.mockResolvedValue({ status: 'ACCEPTED', respondedAt: new Date('2026-04-30T09:59:00.000Z') });
       const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
 
       await repository.acceptBandInvitation('invitation-001', 'band-001', 'user-002', new Date('2026-04-30T09:59:00.000Z'), tx as never);
 
       expect(tx.bandMember.create).toHaveBeenCalled();
-      expect(tx.bandInvitation.delete).toHaveBeenCalled();
+      expect(tx.bandInvitation.update).toHaveBeenCalled();
       expect(prisma.bandMember.create).not.toHaveBeenCalled();
-      expect(prisma.bandInvitation.delete).not.toHaveBeenCalled();
+      expect(prisma.bandInvitation.update).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -52,7 +52,7 @@ export class BandsPrismaRepository implements BandsRepository {
    * @param {string} invitationId - 수락할 초대 ID
    * @param {string} bandId - 가입할 밴드 ID
    * @param {string} userId - 가입할 사용자 ID
-   * @param {Date} _respondedAt - 기존 인터페이스 호환을 위해 받지만 초대 삭제 정책에서는 저장하지 않는 응답 시각
+   * @param {Date} respondedAt - 초대 응답 시각
    * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
    * @returns {Promise<AcceptBandInvitationResult>} 수락 처리 결과
    */
@@ -60,7 +60,7 @@ export class BandsPrismaRepository implements BandsRepository {
     invitationId: string,
     bandId: string,
     userId: string,
-    _respondedAt: Date,
+    respondedAt: Date,
     tx?: Prisma.TransactionClient,
   ): Promise<AcceptBandInvitationResult> {
     const client = tx ?? this.prisma;
@@ -76,9 +76,17 @@ export class BandsPrismaRepository implements BandsRepository {
       },
     });
 
-    await client.bandInvitation.delete({
+    const invitation = await client.bandInvitation.update({
       where: {
         id: invitationId,
+      },
+      data: {
+        status: 'ACCEPTED',
+        respondedAt,
+      },
+      select: {
+        status: true,
+        respondedAt: true,
       },
     });
 
@@ -86,7 +94,7 @@ export class BandsPrismaRepository implements BandsRepository {
       invitationId,
       bandId,
       userId,
-      invitationStatus: 'ACCEPTED',
+      invitationStatus: invitation.status,
       joinedAt: member.joinedAt.toISOString(),
     };
   }

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -811,6 +811,7 @@ export class BandsPrismaRepository implements BandsRepository {
     tx?: Prisma.TransactionClient,
   ): Promise<GetReceivedBandInvitationsResult> {
     const client = tx ?? this.prisma;
+    const { orderBy } = parseToPrismaQuery(query);
 
     const invitations = await client.bandInvitation.findMany({
       where: {
@@ -847,7 +848,7 @@ export class BandsPrismaRepository implements BandsRepository {
           },
         },
       },
-      orderBy: [{ createdAt: query.order__created_at }, { id: query.order__id }],
+      orderBy,
       take: query.take + 1,
       ...(query.cursor__id !== undefined ? { cursor: { id: query.cursor__id }, skip: 1 } : {}),
     });
@@ -896,6 +897,7 @@ export class BandsPrismaRepository implements BandsRepository {
     tx?: Prisma.TransactionClient,
   ): Promise<GetSentBandInvitationsResult> {
     const client = tx ?? this.prisma;
+    const { orderBy } = parseToPrismaQuery(query);
 
     const invitations = await client.bandInvitation.findMany({
       where: {
@@ -931,7 +933,7 @@ export class BandsPrismaRepository implements BandsRepository {
           },
         },
       },
-      orderBy: [{ createdAt: query.order__created_at }, { id: query.order__id }],
+      orderBy,
       take: query.take + 1,
       ...(query.cursor__id !== undefined ? { cursor: { id: query.cursor__id }, skip: 1 } : {}),
     });
@@ -980,6 +982,7 @@ export class BandsPrismaRepository implements BandsRepository {
     tx?: Prisma.TransactionClient,
   ): Promise<GetSentBandJoinRequestsResult> {
     const client = tx ?? this.prisma;
+    const { orderBy } = parseToPrismaQuery(query);
 
     const joinRequests = await client.bandJoinRequest.findMany({
       where: {
@@ -999,7 +1002,7 @@ export class BandsPrismaRepository implements BandsRepository {
           },
         },
       },
-      orderBy: [{ createdAt: query.order__created_at }, { id: query.order__id }],
+      orderBy,
       take: query.take + 1,
       ...(query.cursor__id !== undefined ? { cursor: { id: query.cursor__id }, skip: 1 } : {}),
     });
@@ -1032,6 +1035,7 @@ export class BandsPrismaRepository implements BandsRepository {
    */
   async findBandJoinRequests(bandId: string, query: GetBandJoinRequestsQuery, tx?: Prisma.TransactionClient): Promise<GetBandJoinRequestsResult> {
     const client = tx ?? this.prisma;
+    const { orderBy } = parseToPrismaQuery(query);
 
     const joinRequests = await client.bandJoinRequest.findMany({
       where: {
@@ -1056,7 +1060,7 @@ export class BandsPrismaRepository implements BandsRepository {
           },
         },
       },
-      orderBy: [{ createdAt: query.order__created_at }, { id: query.order__id }],
+      orderBy,
       take: query.take + 1,
       ...(query.cursor__id !== undefined ? { cursor: { id: query.cursor__id }, skip: 1 } : {}),
     });

--- a/backend/src/modules/notifications/notifications.service.spec.ts
+++ b/backend/src/modules/notifications/notifications.service.spec.ts
@@ -21,6 +21,7 @@ const mockListResult: GetNotificationsResult = {
       description: '초대가 도착했습니다.',
       isRead: false,
       targetPath: '/invites/noti-001',
+      reference: null,
       createdAt: '2026-01-01T00:00:00.000Z',
     },
   ],

--- a/backend/src/modules/notifications/repositories/notifications.prisma-repository.spec.ts
+++ b/backend/src/modules/notifications/repositories/notifications.prisma-repository.spec.ts
@@ -10,6 +10,8 @@ const mockNotification = {
   description: '초대가 도착했습니다.',
   isRead: false,
   targetPath: '/invites/noti-001',
+  referenceType: null,
+  referenceId: null,
   createdAt: new Date('2026-01-01T00:00:00.000Z'),
 };
 
@@ -23,6 +25,9 @@ const mockPrisma = {
     updateMany: jest.fn(),
     delete: jest.fn(),
     deleteMany: jest.fn(),
+  },
+  bandInvitation: {
+    findMany: jest.fn(),
   },
   $transaction: jest.fn(),
 };
@@ -51,6 +56,35 @@ describe('NotificationsPrismaRepository', () => {
       );
       expect(result.items).toHaveLength(1);
       expect(result.items[0]?.notificationId).toBe('noti-001');
+    });
+
+    it('BAND_INVITATION 참조 알림에 발신자와 현재 상태를 채운다', async () => {
+      mockPrisma.notification.findMany.mockResolvedValue([{ ...mockNotification, referenceType: 'BAND_INVITATION', referenceId: 'inv-001' }]);
+      mockPrisma.bandInvitation.findMany.mockResolvedValue([
+        {
+          id: 'inv-001',
+          status: 'PENDING',
+          inviterBandMember: { user: { id: 'user-inviter', profile: { nickname: '준혁', avatarUrl: null } } },
+        },
+      ]);
+
+      const result = await repository.findNotifications('user-001', { order__created_at: 'desc', order__id: 'desc', take: 20 });
+
+      expect(result.items[0]?.reference).toEqual({
+        type: 'BAND_INVITATION',
+        id: 'inv-001',
+        status: 'PENDING',
+        sender: { userId: 'user-inviter', nickname: '준혁', avatarUrl: null },
+      });
+    });
+
+    it('참조가 없는 알림의 reference는 null이다', async () => {
+      mockPrisma.notification.findMany.mockResolvedValue([mockNotification]);
+
+      const result = await repository.findNotifications('user-001', { order__created_at: 'desc', order__id: 'desc', take: 20 });
+
+      expect(result.items[0]?.reference).toBeNull();
+      expect(mockPrisma.bandInvitation.findMany).not.toHaveBeenCalled();
     });
 
     it('where__is_read 필터를 적용한다', async () => {

--- a/backend/src/modules/notifications/repositories/notifications.prisma-repository.ts
+++ b/backend/src/modules/notifications/repositories/notifications.prisma-repository.ts
@@ -3,14 +3,14 @@ import { PrismaService } from 'src/database/prisma/prisma.service';
 
 import { parseToPrismaQuery } from '../../../common/query';
 import { buildNextPath } from '../../../common/url';
-import type { NotificationType, Prisma } from '../../../generated/prisma';
+import type { NotificationReferenceType, NotificationType, Prisma } from '../../../generated/prisma';
 import type { GetNotificationsQuery } from '../dto/get-notifications-query.dto';
 import type { DeleteManyNotificationsResult } from '../types/delete-many-notifications-result.type';
 import type { DeleteNotificationResult } from '../types/delete-notification-result.type';
 import type { MarkAllReadResult } from '../types/mark-all-read-result.type';
 import type { MarkManyReadResult } from '../types/mark-many-read-result.type';
 import type { MarkNotificationReadResult } from '../types/mark-notification-read-result.type';
-import type { GetNotificationsResult, NotificationListItem } from '../types/notification-list-item.type';
+import type { GetNotificationsResult, NotificationListItem, NotificationReference } from '../types/notification-list-item.type';
 
 import type { CreateNotificationRepositoryInput, NotificationsRepository } from './notifications.repository';
 
@@ -21,6 +21,8 @@ type NotificationRow = {
   description: string | null;
   isRead: boolean;
   targetPath: string | null;
+  referenceType: NotificationReferenceType | null;
+  referenceId: string | null;
   createdAt: Date | null;
 };
 
@@ -38,6 +40,8 @@ export class NotificationsPrismaRepository implements NotificationsRepository {
         title: input.title,
         description: input.description,
         targetPath: input.targetPath,
+        referenceType: input.referenceType,
+        referenceId: input.referenceId,
         remindsAt: input.remindsAt,
       },
     });
@@ -57,6 +61,8 @@ export class NotificationsPrismaRepository implements NotificationsRepository {
         title: input.title,
         description: input.description,
         targetPath: input.targetPath,
+        referenceType: input.referenceType,
+        referenceId: input.referenceId,
         remindsAt: input.remindsAt,
       })),
     });
@@ -81,6 +87,8 @@ export class NotificationsPrismaRepository implements NotificationsRepository {
         description: true,
         isRead: true,
         targetPath: true,
+        referenceType: true,
+        referenceId: true,
         createdAt: true,
       },
     });
@@ -100,10 +108,63 @@ export class NotificationsPrismaRepository implements NotificationsRepository {
           })
         : null;
 
+    const references = await this.resolveInvitationReferences(notifications, client);
+
     return {
-      items: notifications.map(n => this.mapNotification(n)),
+      items: notifications.map(n => this.mapNotification(n, references)),
       meta: { count, take: query.take, next },
     };
+  }
+
+  /**
+   * BAND_INVITATION 참조를 가진 알림에 대해 초대의 발신자와 현재 상태를 한 번에 조회한다.
+   * 수락된 초대는 삭제되므로 조회되지 않으며, 해당 알림의 reference는 null이 된다.
+   */
+  private async resolveInvitationReferences(
+    notifications: NotificationRow[],
+    client: Prisma.TransactionClient,
+  ): Promise<Map<string, NotificationReference>> {
+    const invitationIds = notifications
+      .filter(n => n.referenceType === 'BAND_INVITATION' && n.referenceId !== null)
+      .map(n => n.referenceId as string);
+
+    if (invitationIds.length === 0) {
+      return new Map();
+    }
+
+    const invitations = await client.bandInvitation.findMany({
+      where: { id: { in: invitationIds } },
+      select: {
+        id: true,
+        status: true,
+        inviterBandMember: {
+          select: {
+            user: {
+              select: {
+                id: true,
+                profile: { select: { nickname: true, avatarUrl: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return new Map(
+      invitations.map(invitation => [
+        invitation.id,
+        {
+          type: 'BAND_INVITATION' as NotificationReferenceType,
+          id: invitation.id,
+          status: invitation.status,
+          sender: {
+            userId: invitation.inviterBandMember.user.id,
+            nickname: invitation.inviterBandMember.user.profile?.nickname ?? '',
+            avatarUrl: invitation.inviterBandMember.user.profile?.avatarUrl ?? null,
+          },
+        },
+      ]),
+    );
   }
 
   async markNotificationAsRead(
@@ -204,7 +265,9 @@ export class NotificationsPrismaRepository implements NotificationsRepository {
     return tx ?? (this.prisma as unknown as Prisma.TransactionClient);
   }
 
-  private mapNotification(notification: NotificationRow): NotificationListItem {
+  private mapNotification(notification: NotificationRow, references: Map<string, NotificationReference>): NotificationListItem {
+    const reference = notification.referenceId !== null ? (references.get(notification.referenceId) ?? null) : null;
+
     return {
       notificationId: notification.id,
       type: notification.type,
@@ -212,6 +275,7 @@ export class NotificationsPrismaRepository implements NotificationsRepository {
       description: notification.description ?? '',
       isRead: notification.isRead,
       targetPath: notification.targetPath ?? '',
+      reference,
       createdAt: notification.createdAt?.toISOString() ?? '',
     };
   }

--- a/backend/src/modules/notifications/repositories/notifications.prisma-repository.ts
+++ b/backend/src/modules/notifications/repositories/notifications.prisma-repository.ts
@@ -118,7 +118,8 @@ export class NotificationsPrismaRepository implements NotificationsRepository {
 
   /**
    * BAND_INVITATION 참조를 가진 알림에 대해 초대의 발신자와 현재 상태를 한 번에 조회한다.
-   * 수락된 초대는 삭제되므로 조회되지 않으며, 해당 알림의 reference는 null이 된다.
+   * 초대 응답은 상태 변경으로 처리되므로 PENDING·ACCEPTED·DECLINED 모두 상태를 반환한다.
+   * 초대가 삭제된 경우에만 reference가 null이 된다.
    */
   private async resolveInvitationReferences(
     notifications: NotificationRow[],

--- a/backend/src/modules/notifications/repositories/notifications.prisma-repository.ts
+++ b/backend/src/modules/notifications/repositories/notifications.prisma-repository.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/database/prisma/prisma.service';
 
+import { parseToPrismaQuery } from '../../../common/query';
+import { buildNextPath } from '../../../common/url';
 import type { NotificationType, Prisma } from '../../../generated/prisma';
 import type { GetNotificationsQuery } from '../dto/get-notifications-query.dto';
 import type { DeleteManyNotificationsResult } from '../types/delete-many-notifications-result.type';
@@ -62,17 +64,14 @@ export class NotificationsPrismaRepository implements NotificationsRepository {
 
   async findNotifications(userId: string, query: GetNotificationsQuery, tx?: Prisma.TransactionClient): Promise<GetNotificationsResult> {
     const client = this.getClient(tx);
-    const where = {
-      userId,
-      isRead: query.where__is_read,
-      type: query.where__type,
-    };
+    const { where, orderBy } = parseToPrismaQuery<Prisma.NotificationWhereInput>(query);
+    where.userId = userId;
 
     const cursorId = query.cursor__id;
 
     const rows = await client.notification.findMany({
       where,
-      orderBy: [{ createdAt: query.order__created_at }, { id: query.order__id }],
+      orderBy,
       take: query.take + 1,
       ...(cursorId ? { cursor: { id: cursorId }, skip: 1 } : {}),
       select: {
@@ -89,7 +88,17 @@ export class NotificationsPrismaRepository implements NotificationsRepository {
     const notifications = hasNext ? rows.slice(0, query.take) : rows;
     const count = notifications.length;
     const lastItem = notifications[count - 1];
-    const next = hasNext && lastItem ? this.buildNextUrl(query, lastItem) : null;
+    const next =
+      hasNext && lastItem
+        ? buildNextPath('/notifications/me', {
+            where__is_read: query.where__is_read,
+            where__type: query.where__type,
+            order__created_at: query.order__created_at,
+            order__id: query.order__id,
+            take: query.take,
+            cursor__id: lastItem.id,
+          })
+        : null;
 
     return {
       items: notifications.map(n => this.mapNotification(n)),
@@ -193,17 +202,6 @@ export class NotificationsPrismaRepository implements NotificationsRepository {
 
   private getClient(tx?: Prisma.TransactionClient): Prisma.TransactionClient {
     return tx ?? (this.prisma as unknown as Prisma.TransactionClient);
-  }
-
-  private buildNextUrl(query: GetNotificationsQuery, lastItem: NotificationRow): string {
-    const params = new URLSearchParams();
-    if (query.where__is_read !== undefined) params.set('where__is_read', String(query.where__is_read));
-    if (query.where__type !== undefined) params.set('where__type', query.where__type);
-    params.set('order__created_at', query.order__created_at);
-    params.set('order__id', query.order__id);
-    params.set('take', String(query.take));
-    params.set('cursor__id', lastItem.id);
-    return `/notifications/me?${params.toString()}`;
   }
 
   private mapNotification(notification: NotificationRow): NotificationListItem {

--- a/backend/src/modules/notifications/repositories/notifications.repository.ts
+++ b/backend/src/modules/notifications/repositories/notifications.repository.ts
@@ -1,4 +1,4 @@
-import type { NotificationType, Prisma } from '../../../generated/prisma';
+import type { NotificationReferenceType, NotificationType, Prisma } from '../../../generated/prisma';
 import type { GetNotificationsQuery } from '../dto/get-notifications-query.dto';
 import type { DeleteManyNotificationsResult } from '../types/delete-many-notifications-result.type';
 import type { DeleteNotificationResult } from '../types/delete-notification-result.type';
@@ -16,6 +16,8 @@ export interface CreateNotificationRepositoryInput {
   description?: string | null;
   targetPath?: string | null;
   remindsAt?: Date | null;
+  referenceType?: NotificationReferenceType | null;
+  referenceId?: string | null;
 }
 
 export interface NotificationsRepository {

--- a/backend/src/modules/notifications/types/notification-list-item.type.ts
+++ b/backend/src/modules/notifications/types/notification-list-item.type.ts
@@ -1,4 +1,17 @@
-import type { NotificationType } from '../../../generated/prisma';
+import type { NotificationReferenceType, NotificationType } from '../../../generated/prisma';
+
+export interface NotificationSender {
+  userId: string;
+  nickname: string;
+  avatarUrl: string | null;
+}
+
+export interface NotificationReference {
+  type: NotificationReferenceType;
+  id: string;
+  status: string;
+  sender: NotificationSender | null;
+}
 
 export interface NotificationListItem {
   notificationId: string;
@@ -7,6 +20,7 @@ export interface NotificationListItem {
   description: string;
   isRead: boolean;
   targetPath: string;
+  reference: NotificationReference | null;
   createdAt: string;
 }
 

--- a/backend/src/modules/schedules/dto/create-schedule.dto.ts
+++ b/backend/src/modules/schedules/dto/create-schedule.dto.ts
@@ -51,6 +51,11 @@ export class CreateScheduleBodyDto {
 
   @IsOptional()
   @IsString({ message: stringValidationMessage })
+  @IsUUID('4', { message: uuidValidationMessage })
+  teamId?: string;
+
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
   memo?: string;
 }
 

--- a/backend/src/modules/schedules/dto/get-schedules-query.dto.ts
+++ b/backend/src/modules/schedules/dto/get-schedules-query.dto.ts
@@ -48,6 +48,11 @@ export class GetSchedulesQueryDto {
 
   @IsOptional()
   @IsString({ message: stringValidationMessage })
+  @IsUUID('4', { message: uuidValidationMessage })
+  where__team_id?: string;
+
+  @IsOptional()
+  @IsString({ message: stringValidationMessage })
   @IsEnum(ScheduleType, { message: enumValidationMessage })
   where__schedule_type?: ScheduleType;
 

--- a/backend/src/modules/schedules/dto/get-schedules-query.dto.ts
+++ b/backend/src/modules/schedules/dto/get-schedules-query.dto.ts
@@ -1,5 +1,7 @@
-import { Type } from 'class-transformer';
-import { IsEnum, IsInt, IsISO8601, IsOptional, IsString, IsUUID, Max, Min } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { IsBoolean, IsEnum, IsInt, IsISO8601, IsOptional, IsString, IsUUID, Max, Min } from 'class-validator';
+import { parseOptionalBooleanValue } from 'src/common/validation/transform.util';
+import { booleanValidationMessage } from 'src/common/validation-message/boolean-validation.message';
 import { enumValidationMessage } from 'src/common/validation-message/enum-validation.message';
 import { intValidationMessage } from 'src/common/validation-message/int-validation.message';
 import { iso8601ValidationMessage } from 'src/common/validation-message/iso8601-validation.message';
@@ -60,6 +62,12 @@ export class GetSchedulesQueryDto {
   @IsString({ message: stringValidationMessage })
   @IsEnum(ScheduleStatus, { message: enumValidationMessage })
   where__status?: ScheduleStatus;
+
+  /** 로그인 사용자가 생성자이거나 참여자인 일정만 조회한다("내가 포함된 일정만 보기"). */
+  @IsOptional()
+  @Transform(parseOptionalBooleanValue)
+  @IsBoolean({ message: booleanValidationMessage })
+  where__is_mine?: boolean;
 }
 
 export type GetSchedulesQuery = GetSchedulesQueryDto;

--- a/backend/src/modules/schedules/repositories/schedules.prisma-repository.ts
+++ b/backend/src/modules/schedules/repositories/schedules.prisma-repository.ts
@@ -58,6 +58,12 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
       });
     }
 
+    if (input.teamId) {
+      await client.scheduleTeam.create({
+        data: { scheduleId: schedule.id, teamId: input.teamId },
+      });
+    }
+
     const songs =
       songIds.length > 0
         ? await client.song.findMany({
@@ -80,9 +86,18 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
       status: schedule.status,
       songs: songs.map(s => ({ songId: s.id, title: s.title, artistName: s.artistName })),
       participantCount,
+      teamId: input.teamId ?? null,
       memo: schedule.memo,
       createdAt: schedule.createdAt.toISOString(),
     };
+  }
+
+  async findTeamInSameBandAsSpace(teamId: string, bandSpaceId: string, tx?: Prisma.TransactionClient): Promise<{ id: string } | null> {
+    const client = tx ?? this.prisma;
+    return client.team.findFirst({
+      where: { id: teamId, band: { bandSpaces: { some: { id: bandSpaceId } } } },
+      select: { id: true },
+    });
   }
 
   async findBandSpaceById(bandSpaceId: string, tx?: Prisma.TransactionClient): Promise<{ id: string } | null> {
@@ -329,6 +344,7 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
         },
       }),
       ...(query.where__place_id && { placeId: query.where__place_id }),
+      ...(query.where__team_id && { scheduleTeams: { some: { teamId: query.where__team_id } } }),
       ...(query.where__schedule_type && { scheduleType: query.where__schedule_type }),
       ...(query.where__status && { status: query.where__status }),
       ...(query.cursor__start_at &&
@@ -343,6 +359,7 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
       take: take + 1,
       include: {
         place: { select: { id: true, name: true } },
+        scheduleTeams: { select: { team: { select: { id: true, name: true } } }, take: 1 },
         scheduleSongs: { include: { song: { select: { id: true, title: true, artistName: true } } } },
         createdByBandMember: { select: { userId: true } },
         participants: {
@@ -378,6 +395,7 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
         startAt: row.startAt?.toISOString() ?? null,
         endAt: row.endAt?.toISOString() ?? null,
         place: row.place ? { placeId: row.place.id, name: row.place.name } : null,
+        team: row.scheduleTeams[0] ? { teamId: row.scheduleTeams[0].team.id, name: row.scheduleTeams[0].team.name } : null,
         songs: row.scheduleSongs.map(ss => ({ songId: ss.song.id, title: ss.song.title, artistName: ss.song.artistName })),
         participantCount: row.participants.length,
         participants: row.participants.map(p => ({

--- a/backend/src/modules/schedules/repositories/schedules.prisma-repository.ts
+++ b/backend/src/modules/schedules/repositories/schedules.prisma-repository.ts
@@ -258,6 +258,30 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
     });
   }
 
+  /**
+   * 일정 목록 조회의 AND 결합 조건을 만든다.
+   * cursor 기반 keyset 조건과 "내가 포함된 일정만"(where__is_mine) 조건을 함께 담아
+   * 최상위 OR 키 충돌 없이 결합한다.
+   */
+  private buildScheduleListAndConditions(query: GetSchedulesQuery, userId: string): Prisma.ScheduleWhereInput[] {
+    const and: Prisma.ScheduleWhereInput[] = [];
+
+    if (query.cursor__start_at && query.cursor__id) {
+      and.push({
+        OR: [{ startAt: { gt: new Date(query.cursor__start_at) } }, { startAt: new Date(query.cursor__start_at), id: { gt: query.cursor__id } }],
+      });
+    }
+
+    // 생성자이거나 참여자이면 본인과 연관된 일정으로 본다. isMine 플래그와 판정 기준이 같다.
+    if (query.where__is_mine) {
+      and.push({
+        OR: [{ createdByBandMember: { userId } }, { participants: { some: { bandMember: { userId } } } }],
+      });
+    }
+
+    return and;
+  }
+
   async findSchedulesByBandId(
     bandId: string,
     query: GetSchedulesQuery,
@@ -266,6 +290,7 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
   ): Promise<GetBandSchedulesResult> {
     const client = tx ?? this.prisma;
     const take = query.take ?? 50;
+    const and = this.buildScheduleListAndConditions(query, userId);
 
     const where: Prisma.ScheduleWhereInput = {
       bandSpace: { bandId, deletedAt: null },
@@ -279,10 +304,7 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
       ...(query.where__place_id && { placeId: query.where__place_id }),
       ...(query.where__schedule_type && { scheduleType: query.where__schedule_type }),
       ...(query.where__status && { status: query.where__status }),
-      ...(query.cursor__start_at &&
-        query.cursor__id && {
-          OR: [{ startAt: { gt: new Date(query.cursor__start_at) } }, { startAt: new Date(query.cursor__start_at), id: { gt: query.cursor__id } }],
-        }),
+      ...(and.length > 0 ? { AND: and } : {}),
     };
 
     const rows = await client.schedule.findMany({
@@ -333,6 +355,7 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
   ): Promise<GetSpaceSchedulesResult> {
     const client = tx ?? this.prisma;
     const take = query.take ?? 50;
+    const and = this.buildScheduleListAndConditions(query, userId);
 
     const where: Prisma.ScheduleWhereInput = {
       bandSpaceId,
@@ -347,10 +370,7 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
       ...(query.where__team_id && { scheduleTeams: { some: { teamId: query.where__team_id } } }),
       ...(query.where__schedule_type && { scheduleType: query.where__schedule_type }),
       ...(query.where__status && { status: query.where__status }),
-      ...(query.cursor__start_at &&
-        query.cursor__id && {
-          OR: [{ startAt: { gt: new Date(query.cursor__start_at) } }, { startAt: new Date(query.cursor__start_at), id: { gt: query.cursor__id } }],
-        }),
+      ...(and.length > 0 ? { AND: and } : {}),
     };
 
     const rows = await client.schedule.findMany({
@@ -364,10 +384,11 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
         createdByBandMember: { select: { userId: true } },
         participants: {
           select: {
+            bandMemberId: true,
             bandMember: {
               select: {
                 userId: true,
-                user: { select: { profile: { select: { avatarUrl: true } } } },
+                user: { select: { profile: { select: { nickname: true, avatarUrl: true } } } },
               },
             },
           },
@@ -399,8 +420,9 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
         songs: row.scheduleSongs.map(ss => ({ songId: ss.song.id, title: ss.song.title, artistName: ss.song.artistName })),
         participantCount: row.participants.length,
         participants: row.participants.map(p => ({
-          userId: p.bandMember.userId,
-          avatarUrl: p.bandMember.user.profile?.avatarUrl ?? null,
+          bandMemberId: p.bandMemberId,
+          nickname: p.bandMember.user.profile?.nickname ?? '',
+          profileImageUrl: p.bandMember.user.profile?.avatarUrl ?? null,
         })),
         memo: row.memo,
         status: row.status,

--- a/backend/src/modules/schedules/repositories/schedules.prisma-repository.ts
+++ b/backend/src/modules/schedules/repositories/schedules.prisma-repository.ts
@@ -117,7 +117,12 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
             bandMemberId: true,
             attendanceStatus: true,
             note: true,
-            bandMember: { select: { userId: true } },
+            bandMember: {
+              select: {
+                userId: true,
+                user: { select: { profile: { select: { nickname: true, avatarUrl: true } } } },
+              },
+            },
           },
         },
       },
@@ -142,6 +147,9 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
         participants: row.participants.map(p => ({
           participantId: p.id,
           bandMemberId: p.bandMemberId,
+          userId: p.bandMember.userId,
+          nickname: p.bandMember.user.profile?.nickname ?? '',
+          avatarUrl: p.bandMember.user.profile?.avatarUrl ?? null,
           attendanceStatus: p.attendanceStatus ?? null,
           note: p.note ?? null,
         })),

--- a/backend/src/modules/schedules/repositories/schedules.prisma-repository.ts
+++ b/backend/src/modules/schedules/repositories/schedules.prisma-repository.ts
@@ -345,8 +345,16 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
         place: { select: { id: true, name: true } },
         scheduleSongs: { include: { song: { select: { id: true, title: true, artistName: true } } } },
         createdByBandMember: { select: { userId: true } },
-        participants: { where: { bandMember: { userId } }, select: { id: true }, take: 1 },
-        _count: { select: { participants: true } },
+        participants: {
+          select: {
+            bandMember: {
+              select: {
+                userId: true,
+                user: { select: { profile: { select: { avatarUrl: true } } } },
+              },
+            },
+          },
+        },
       },
     });
 
@@ -371,10 +379,14 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
         endAt: row.endAt?.toISOString() ?? null,
         place: row.place ? { placeId: row.place.id, name: row.place.name } : null,
         songs: row.scheduleSongs.map(ss => ({ songId: ss.song.id, title: ss.song.title, artistName: ss.song.artistName })),
-        participantCount: row._count.participants,
+        participantCount: row.participants.length,
+        participants: row.participants.map(p => ({
+          userId: p.bandMember.userId,
+          avatarUrl: p.bandMember.user.profile?.avatarUrl ?? null,
+        })),
         memo: row.memo,
         status: row.status,
-        isMine: row.createdByBandMember.userId === userId || row.participants.length > 0,
+        isMine: row.createdByBandMember.userId === userId || row.participants.some(p => p.bandMember.userId === userId),
       })),
       meta,
     };

--- a/backend/src/modules/schedules/repositories/schedules.prisma-repository.ts
+++ b/backend/src/modules/schedules/repositories/schedules.prisma-repository.ts
@@ -102,7 +102,7 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
     return members.map(m => m.bandMember.userId);
   }
 
-  async findScheduleById(scheduleId: string, tx?: Prisma.TransactionClient): Promise<GetScheduleDetailResult | undefined> {
+  async findScheduleById(scheduleId: string, userId?: string, tx?: Prisma.TransactionClient): Promise<GetScheduleDetailResult | undefined> {
     const client = tx ?? this.prisma;
 
     const row = await client.schedule.findUnique({
@@ -110,11 +110,23 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
       include: {
         place: { select: { id: true, name: true, address: true } },
         scheduleSongs: { include: { song: { select: { id: true, title: true, artistName: true } } } },
-        participants: { select: { id: true, bandMemberId: true, attendanceStatus: true, note: true } },
+        createdByBandMember: { select: { userId: true } },
+        participants: {
+          select: {
+            id: true,
+            bandMemberId: true,
+            attendanceStatus: true,
+            note: true,
+            bandMember: { select: { userId: true } },
+          },
+        },
       },
     });
 
     if (!row) return undefined;
+
+    // 로그인 사용자가 생성자이거나 참여자이면 본인과 연관된 일정으로 본다.
+    const isMine = userId !== undefined && (row.createdByBandMember.userId === userId || row.participants.some(p => p.bandMember.userId === userId));
 
     return {
       schedule: {
@@ -135,6 +147,7 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
         })),
         memo: row.memo,
         createdByBandMemberId: row.createdByBandMemberId,
+        isMine,
         createdAt: row.createdAt.toISOString(),
         updatedAt: row.updatedAt.toISOString(),
       },
@@ -222,7 +235,12 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
     });
   }
 
-  async findSchedulesByBandId(bandId: string, query: GetSchedulesQuery, tx?: Prisma.TransactionClient): Promise<GetBandSchedulesResult> {
+  async findSchedulesByBandId(
+    bandId: string,
+    query: GetSchedulesQuery,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetBandSchedulesResult> {
     const client = tx ?? this.prisma;
     const take = query.take ?? 50;
 
@@ -250,6 +268,8 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
       take: take + 1,
       include: {
         bandSpace: { select: { id: true, name: true } },
+        createdByBandMember: { select: { userId: true } },
+        participants: { where: { bandMember: { userId } }, select: { id: true }, take: 1 },
       },
     });
 
@@ -275,13 +295,19 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
           startAt: row.startAt?.toISOString() ?? null,
           endAt: row.endAt?.toISOString() ?? null,
           status: row.status,
+          isMine: row.createdByBandMember.userId === userId || row.participants.length > 0,
         }),
       ),
       meta,
     };
   }
 
-  async findSchedulesBySpaceId(bandSpaceId: string, query: GetSchedulesQuery, tx?: Prisma.TransactionClient): Promise<GetSpaceSchedulesResult> {
+  async findSchedulesBySpaceId(
+    bandSpaceId: string,
+    query: GetSchedulesQuery,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetSpaceSchedulesResult> {
     const client = tx ?? this.prisma;
     const take = query.take ?? 50;
 
@@ -310,6 +336,8 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
       include: {
         place: { select: { id: true, name: true } },
         scheduleSongs: { include: { song: { select: { id: true, title: true, artistName: true } } } },
+        createdByBandMember: { select: { userId: true } },
+        participants: { where: { bandMember: { userId } }, select: { id: true }, take: 1 },
         _count: { select: { participants: true } },
       },
     });
@@ -338,6 +366,7 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
         participantCount: row._count.participants,
         memo: row.memo,
         status: row.status,
+        isMine: row.createdByBandMember.userId === userId || row.participants.length > 0,
       })),
       meta,
     };

--- a/backend/src/modules/schedules/repositories/schedules.repository.ts
+++ b/backend/src/modules/schedules/repositories/schedules.repository.ts
@@ -60,4 +60,7 @@ export interface SchedulesRepository {
 
   /** 밴드 공간 기준으로 특정 사용자의 밴드 멤버 정보를 조회한다. 공간 멤버 여부 검증에 사용한다. */
   findBandMemberByBandSpaceIdAndUserId(bandSpaceId: string, userId: string, tx?: Prisma.TransactionClient): Promise<{ id: string } | null>;
+
+  /** 팀이 해당 공간과 같은 밴드 소속인지 확인한다. 일정 생성 시 teamId 검증에 사용한다. */
+  findTeamInSameBandAsSpace(teamId: string, bandSpaceId: string, tx?: Prisma.TransactionClient): Promise<{ id: string } | null>;
 }

--- a/backend/src/modules/schedules/repositories/schedules.repository.ts
+++ b/backend/src/modules/schedules/repositories/schedules.repository.ts
@@ -29,14 +29,22 @@ export interface SchedulesRepository {
    */
   updateSchedule(scheduleId: string, input: UpdateScheduleInput, tx?: Prisma.TransactionClient): Promise<UpdateScheduleResult>;
 
-  /** 일정 상세 정보를 조회한다. */
-  findScheduleById(scheduleId: string, tx?: Prisma.TransactionClient): Promise<GetScheduleDetailResult | undefined>;
+  /**
+   * 일정 상세 정보를 조회한다.
+   * userId가 주어지면 해당 사용자가 생성자이거나 참여자인지로 isMine을 계산한다.
+   */
+  findScheduleById(scheduleId: string, userId?: string, tx?: Prisma.TransactionClient): Promise<GetScheduleDetailResult | undefined>;
 
   /** 일정을 hard delete한다. */
   deleteSchedule(scheduleId: string, tx?: Prisma.TransactionClient): Promise<void>;
 
-  /** 밴드 공간 기준 일정 목록을 cursor pagination으로 조회한다. */
-  findSchedulesBySpaceId(bandSpaceId: string, query: GetSchedulesQuery, tx?: Prisma.TransactionClient): Promise<GetSpaceSchedulesResult>;
+  /** 밴드 공간 기준 일정 목록을 cursor pagination으로 조회한다. 로그인 사용자 기준 isMine을 함께 계산한다. */
+  findSchedulesBySpaceId(
+    bandSpaceId: string,
+    query: GetSchedulesQuery,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetSpaceSchedulesResult>;
 
   /** 밴드 공간 존재 여부를 확인한다 (deletedAt: null 조건 포함). */
   findBandSpaceById(bandSpaceId: string, tx?: Prisma.TransactionClient): Promise<{ id: string } | null>;
@@ -44,8 +52,8 @@ export interface SchedulesRepository {
   /** 합주 공간 멤버의 userId 목록을 반환한다. 알림 수신자 조회에 사용한다. */
   findSpaceMemberUserIds(bandSpaceId: string, tx?: Prisma.TransactionClient): Promise<string[]>;
 
-  /** 밴드 기준 전체 공간의 일정 목록을 cursor pagination으로 조회한다. */
-  findSchedulesByBandId(bandId: string, query: GetSchedulesQuery, tx?: Prisma.TransactionClient): Promise<GetBandSchedulesResult>;
+  /** 밴드 기준 전체 공간의 일정 목록을 cursor pagination으로 조회한다. 로그인 사용자 기준 isMine을 함께 계산한다. */
+  findSchedulesByBandId(bandId: string, query: GetSchedulesQuery, userId: string, tx?: Prisma.TransactionClient): Promise<GetBandSchedulesResult>;
 
   /** 밴드 존재 여부를 확인한다 (deletedAt: null 조건 포함). */
   findBandById(bandId: string, tx?: Prisma.TransactionClient): Promise<{ id: string } | null>;

--- a/backend/src/modules/schedules/schedules.controller.ts
+++ b/backend/src/modules/schedules/schedules.controller.ts
@@ -49,24 +49,35 @@ export class SchedulesController {
     return createSuccessResponse('합주 일정 삭제 성공', result);
   }
 
+  @UseGuards(AccessTokenGuard)
   @Get('bandspaces/:bandspaceId/schedules')
   async getSpaceSchedules(
+    @Req() request: AuthenticatedRequest,
     @Param('bandspaceId') bandspaceId: string,
     @Query() query: GetSchedulesQueryDto,
   ): Promise<ApiSuccessResponse<GetSpaceSchedulesResult>> {
-    const result = await this.schedulesService.getSpaceSchedules(bandspaceId, query);
+    const result = await this.schedulesService.getSpaceSchedules(bandspaceId, request.user.id, query);
     return createSuccessResponse('합주 일정 목록 조회 성공', result);
   }
 
+  @UseGuards(AccessTokenGuard)
   @Get('schedules/:scheduleId')
-  async getScheduleDetail(@Param('scheduleId') scheduleId: string): Promise<ApiSuccessResponse<GetScheduleDetailResult>> {
-    const result = await this.schedulesService.getScheduleDetail(scheduleId);
+  async getScheduleDetail(
+    @Req() request: AuthenticatedRequest,
+    @Param('scheduleId') scheduleId: string,
+  ): Promise<ApiSuccessResponse<GetScheduleDetailResult>> {
+    const result = await this.schedulesService.getScheduleDetail(scheduleId, request.user.id);
     return createSuccessResponse('합주 일정 상세 조회 성공', result);
   }
 
+  @UseGuards(AccessTokenGuard)
   @Get('bands/:bandId/schedules')
-  async getBandSchedules(@Param('bandId') bandId: string, @Query() query: GetSchedulesQueryDto): Promise<ApiSuccessResponse<GetBandSchedulesResult>> {
-    const result = await this.schedulesService.getBandSchedules(bandId, query);
+  async getBandSchedules(
+    @Req() request: AuthenticatedRequest,
+    @Param('bandId') bandId: string,
+    @Query() query: GetSchedulesQueryDto,
+  ): Promise<ApiSuccessResponse<GetBandSchedulesResult>> {
+    const result = await this.schedulesService.getBandSchedules(bandId, request.user.id, query);
     return createSuccessResponse('밴드 일정 목록 조회 성공', result);
   }
 }

--- a/backend/src/modules/schedules/schedules.service.spec.ts
+++ b/backend/src/modules/schedules/schedules.service.spec.ts
@@ -97,7 +97,7 @@ const spaceSchedulesResult: GetSpaceSchedulesResult = {
       team: null,
       songs: [],
       participantCount: 1,
-      participants: [{ userId: USER_ID, avatarUrl: null }],
+      participants: [{ bandMemberId: BAND_MEMBER_ID, nickname: '준혁', profileImageUrl: null }],
       memo: null,
       status: 'PLANNED',
       isMine: true,

--- a/backend/src/modules/schedules/schedules.service.spec.ts
+++ b/backend/src/modules/schedules/schedules.service.spec.ts
@@ -16,6 +16,7 @@ const BAND_SPACE_ID = '11111111-1111-4111-8111-111111111111';
 const SCHEDULE_ID = '22222222-2222-4222-8222-222222222222';
 const BAND_ID = '33333333-3333-4333-8333-333333333333';
 const BAND_MEMBER_ID = '44444444-4444-4444-8444-444444444444';
+const TEAM_ID = '77777777-7777-4777-8777-777777777777';
 const USER_ID = '66666666-6666-4666-8666-666666666666';
 const SONG_ID = '55555555-5555-4555-8555-555555555555';
 const MEMBER_USER_ID_1 = 'aaaaaaa1-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
@@ -33,6 +34,7 @@ const createScheduleResult: CreateScheduleResult = {
   status: 'PLANNED',
   songs: [],
   participantCount: 0,
+  teamId: null,
   memo: null,
   createdAt: '2026-05-29T00:00:00.000Z',
 };
@@ -92,6 +94,7 @@ const spaceSchedulesResult: GetSpaceSchedulesResult = {
       startAt: '2026-06-01T14:00:00.000Z',
       endAt: '2026-06-01T16:00:00.000Z',
       place: null,
+      team: null,
       songs: [],
       participantCount: 1,
       participants: [{ userId: USER_ID, avatarUrl: null }],
@@ -146,6 +149,9 @@ function createRepositoryStub(overrides?: Partial<SchedulesRepository>): Schedul
     },
     async findBandMemberByBandSpaceIdAndUserId(bandSpaceId, userId) {
       return bandSpaceId === BAND_SPACE_ID && userId === USER_ID ? { id: BAND_MEMBER_ID } : null;
+    },
+    async findTeamInSameBandAsSpace(teamId, bandSpaceId) {
+      return teamId === TEAM_ID && bandSpaceId === BAND_SPACE_ID ? { id: TEAM_ID } : null;
     },
     async findSpaceMemberUserIds() {
       return [MEMBER_USER_ID_1, MEMBER_USER_ID_2];
@@ -240,6 +246,21 @@ describe('SchedulesService', () => {
           status: ScheduleStatus.PLANNED,
         }),
       ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('teamId가 해당 밴드의 팀이 아니면 BadRequestException을 던진다', async () => {
+      const service = new SchedulesService(createRepositoryStub(), createPrismaServiceStub(), createNotificationsServiceMock());
+
+      await expect(
+        service.createSchedule(BAND_SPACE_ID, USER_ID, {
+          title: '합주',
+          scheduleType: ScheduleType.PRACTICE,
+          startAt: '2026-06-01T14:00:00+09:00',
+          endAt: '2026-06-01T16:00:00+09:00',
+          status: ScheduleStatus.PLANNED,
+          teamId: '00000000-0000-4000-8000-000000000000',
+        }),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('endAt이 startAt보다 이전이면 BadRequestException을 던진다', async () => {

--- a/backend/src/modules/schedules/schedules.service.spec.ts
+++ b/backend/src/modules/schedules/schedules.service.spec.ts
@@ -63,7 +63,17 @@ const scheduleDetailResult: GetScheduleDetailResult = {
     status: 'PLANNED',
     place: null,
     songs: [{ songId: SONG_ID, title: '좋은 날', artistName: 'IU' }],
-    participants: [{ participantId: 'p-001', bandMemberId: BAND_MEMBER_ID, attendanceStatus: 'PENDING', note: null }],
+    participants: [
+      {
+        participantId: 'p-001',
+        bandMemberId: BAND_MEMBER_ID,
+        userId: USER_ID,
+        nickname: '준혁',
+        avatarUrl: null,
+        attendanceStatus: 'PENDING',
+        note: null,
+      },
+    ],
     memo: null,
     createdByBandMemberId: BAND_MEMBER_ID,
     isMine: true,

--- a/backend/src/modules/schedules/schedules.service.spec.ts
+++ b/backend/src/modules/schedules/schedules.service.spec.ts
@@ -66,6 +66,7 @@ const scheduleDetailResult: GetScheduleDetailResult = {
     participants: [{ participantId: 'p-001', bandMemberId: BAND_MEMBER_ID, attendanceStatus: 'PENDING', note: null }],
     memo: null,
     createdByBandMemberId: BAND_MEMBER_ID,
+    isMine: true,
     createdAt: '2026-05-29T00:00:00.000Z',
     updatedAt: '2026-05-29T00:00:00.000Z',
   },
@@ -85,6 +86,7 @@ const spaceSchedulesResult: GetSpaceSchedulesResult = {
       participantCount: 1,
       memo: null,
       status: 'PLANNED',
+      isMine: true,
     },
   ],
   meta: { count: 1, take: 50, cursor: { startAt: '2026-06-01T14:00:00.000Z', id: SCHEDULE_ID }, next: null },
@@ -101,6 +103,7 @@ const bandSchedulesResult: GetBandSchedulesResult = {
       startAt: '2026-06-01T14:00:00.000Z',
       endAt: '2026-06-01T16:00:00.000Z',
       status: 'PLANNED',
+      isMine: false,
     },
   ],
   meta: { count: 1, take: 50, cursor: { startAt: '2026-06-01T14:00:00.000Z', id: SCHEDULE_ID }, next: null },
@@ -319,7 +322,7 @@ describe('SchedulesService', () => {
     it('updateSchedule 내부 호출이 같은 tx로 처리된다', async () => {
       const capturedTransactions: unknown[] = [];
       const stub = createRepositoryStub({
-        async findScheduleById(id, tx) {
+        async findScheduleById(id, _userId, tx) {
           capturedTransactions.push(tx);
           return id === SCHEDULE_ID ? scheduleDetailResult : undefined;
         },
@@ -379,7 +382,7 @@ describe('SchedulesService', () => {
     it('items와 meta를 반환한다', async () => {
       const service = new SchedulesService(createRepositoryStub(), createPrismaServiceStub(), createNotificationsServiceMock());
 
-      const result = await service.getSpaceSchedules(BAND_SPACE_ID, {});
+      const result = await service.getSpaceSchedules(BAND_SPACE_ID, USER_ID, {});
 
       expect(result.items).toHaveLength(1);
       expect(result.meta.cursor).toBeDefined();
@@ -388,7 +391,7 @@ describe('SchedulesService', () => {
     it('밴드 공간이 없으면 NotFoundException을 던진다', async () => {
       const service = new SchedulesService(createRepositoryStub(), createPrismaServiceStub(), createNotificationsServiceMock());
 
-      await expect(service.getSpaceSchedules('missing-space-id', {})).rejects.toThrow(NotFoundException);
+      await expect(service.getSpaceSchedules('missing-space-id', USER_ID, {})).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -396,7 +399,7 @@ describe('SchedulesService', () => {
     it('items와 meta를 반환한다', async () => {
       const service = new SchedulesService(createRepositoryStub(), createPrismaServiceStub(), createNotificationsServiceMock());
 
-      const result = await service.getBandSchedules(BAND_ID, {});
+      const result = await service.getBandSchedules(BAND_ID, USER_ID, {});
 
       expect(result.items).toHaveLength(1);
       expect(result.items[0]?.space).toBeDefined();
@@ -405,7 +408,7 @@ describe('SchedulesService', () => {
     it('밴드가 없으면 NotFoundException을 던진다', async () => {
       const service = new SchedulesService(createRepositoryStub(), createPrismaServiceStub(), createNotificationsServiceMock());
 
-      await expect(service.getBandSchedules('missing-band-id', {})).rejects.toThrow(NotFoundException);
+      await expect(service.getBandSchedules('missing-band-id', USER_ID, {})).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -413,7 +416,7 @@ describe('SchedulesService', () => {
     it('schedule 상세를 반환한다', async () => {
       const service = new SchedulesService(createRepositoryStub(), createPrismaServiceStub(), createNotificationsServiceMock());
 
-      const result = await service.getScheduleDetail(SCHEDULE_ID);
+      const result = await service.getScheduleDetail(SCHEDULE_ID, USER_ID);
 
       expect(result.schedule.scheduleId).toBe(SCHEDULE_ID);
       expect(result.schedule.participants).toHaveLength(1);
@@ -423,7 +426,7 @@ describe('SchedulesService', () => {
     it('일정이 없으면 NotFoundException을 던진다', async () => {
       const service = new SchedulesService(createRepositoryStub(), createPrismaServiceStub(), createNotificationsServiceMock());
 
-      await expect(service.getScheduleDetail('missing-schedule-id')).rejects.toThrow(NotFoundException);
+      await expect(service.getScheduleDetail('missing-schedule-id', USER_ID)).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/backend/src/modules/schedules/schedules.service.spec.ts
+++ b/backend/src/modules/schedules/schedules.service.spec.ts
@@ -94,6 +94,7 @@ const spaceSchedulesResult: GetSpaceSchedulesResult = {
       place: null,
       songs: [],
       participantCount: 1,
+      participants: [{ userId: USER_ID, avatarUrl: null }],
       memo: null,
       status: 'PLANNED',
       isMine: true,

--- a/backend/src/modules/schedules/schedules.service.ts
+++ b/backend/src/modules/schedules/schedules.service.ts
@@ -70,7 +70,7 @@ export class SchedulesService {
   /** 일정을 수정한다. 기존 값과 합산하여 시간 범위를 검증한다. */
   async updateSchedule(scheduleId: string, input: UpdateScheduleInput, tx?: Prisma.TransactionClient): Promise<UpdateScheduleResult> {
     const run = async (client: Prisma.TransactionClient): Promise<UpdateScheduleResult> => {
-      const existing = await this.schedulesRepository.findScheduleById(scheduleId, client);
+      const existing = await this.schedulesRepository.findScheduleById(scheduleId, undefined, client);
       if (!existing) throw new NotFoundException('요청한 일정을 찾을 수 없습니다.');
 
       const startAt = input.startAt ? new Date(input.startAt) : existing.schedule.startAt ? new Date(existing.schedule.startAt) : null;
@@ -88,7 +88,7 @@ export class SchedulesService {
 
   /** 일정을 삭제한다. hard delete이며 deletedAt은 서비스 레이어에서 생성한다. */
   async deleteSchedule(scheduleId: string, tx?: Prisma.TransactionClient): Promise<DeleteScheduleResult> {
-    const existing = await this.schedulesRepository.findScheduleById(scheduleId, tx);
+    const existing = await this.schedulesRepository.findScheduleById(scheduleId, undefined, tx);
     if (!existing) throw new NotFoundException('요청한 일정을 찾을 수 없습니다.');
 
     const { spaceId, title } = existing.schedule;
@@ -115,26 +115,31 @@ export class SchedulesService {
   }
 
   /** 밴드 공간 기준 일정 목록을 cursor pagination으로 조회한다. */
-  async getSpaceSchedules(bandSpaceId: string, query: GetSchedulesQuery, tx?: Prisma.TransactionClient): Promise<GetSpaceSchedulesResult> {
+  async getSpaceSchedules(
+    bandSpaceId: string,
+    userId: string,
+    query: GetSchedulesQuery,
+    tx?: Prisma.TransactionClient,
+  ): Promise<GetSpaceSchedulesResult> {
     const space = await this.schedulesRepository.findBandSpaceById(bandSpaceId, tx);
     if (!space) throw new NotFoundException('요청한 합주 공간을 찾을 수 없습니다.');
 
-    return this.schedulesRepository.findSchedulesBySpaceId(bandSpaceId, query, tx);
+    return this.schedulesRepository.findSchedulesBySpaceId(bandSpaceId, query, userId, tx);
   }
 
   /** 일정 상세 정보를 조회한다. */
-  async getScheduleDetail(scheduleId: string, tx?: Prisma.TransactionClient): Promise<GetScheduleDetailResult> {
-    const result = await this.schedulesRepository.findScheduleById(scheduleId, tx);
+  async getScheduleDetail(scheduleId: string, userId: string, tx?: Prisma.TransactionClient): Promise<GetScheduleDetailResult> {
+    const result = await this.schedulesRepository.findScheduleById(scheduleId, userId, tx);
     if (!result) throw new NotFoundException('요청한 일정을 찾을 수 없습니다.');
 
     return result;
   }
 
   /** 밴드에 속한 전체 공간의 일정 목록을 조회한다. */
-  async getBandSchedules(bandId: string, query: GetSchedulesQuery, tx?: Prisma.TransactionClient): Promise<GetBandSchedulesResult> {
+  async getBandSchedules(bandId: string, userId: string, query: GetSchedulesQuery, tx?: Prisma.TransactionClient): Promise<GetBandSchedulesResult> {
     const band = await this.schedulesRepository.findBandById(bandId, tx);
     if (!band) throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
 
-    return this.schedulesRepository.findSchedulesByBandId(bandId, query, tx);
+    return this.schedulesRepository.findSchedulesByBandId(bandId, query, userId, tx);
   }
 }

--- a/backend/src/modules/schedules/schedules.service.ts
+++ b/backend/src/modules/schedules/schedules.service.ts
@@ -42,6 +42,11 @@ export class SchedulesService {
         throw new BadRequestException('종료 시간은 시작 시간보다 이후여야 합니다.');
       }
 
+      if (input.teamId) {
+        const team = await this.schedulesRepository.findTeamInSameBandAsSpace(input.teamId, bandSpaceId, client);
+        if (!team) throw new BadRequestException('해당 밴드에 속한 팀이 아닙니다.');
+      }
+
       return this.schedulesRepository.createSchedule(bandSpaceId, bandMember.id, input, client);
     };
 

--- a/backend/src/modules/schedules/types/band-schedule-list-item.type.ts
+++ b/backend/src/modules/schedules/types/band-schedule-list-item.type.ts
@@ -9,6 +9,7 @@ export interface BandScheduleListItem {
   startAt: string | null;
   endAt: string | null;
   status: string;
+  isMine: boolean;
 }
 
 export interface GetBandSchedulesResult {

--- a/backend/src/modules/schedules/types/create-schedule-result.type.ts
+++ b/backend/src/modules/schedules/types/create-schedule-result.type.ts
@@ -16,6 +16,7 @@ export interface CreateScheduleResult {
   status: string;
   songs: ScheduleSongItem[];
   participantCount: number;
+  teamId: string | null;
   memo: string | null;
   createdAt: string;
 }

--- a/backend/src/modules/schedules/types/schedule-detail.type.ts
+++ b/backend/src/modules/schedules/types/schedule-detail.type.ts
@@ -3,6 +3,9 @@ import type { ScheduleSongItem } from './create-schedule-result.type';
 export interface ScheduleParticipantDetail {
   participantId: string;
   bandMemberId: string;
+  userId: string;
+  nickname: string;
+  avatarUrl: string | null;
   attendanceStatus: string | null;
   note: string | null;
 }

--- a/backend/src/modules/schedules/types/schedule-detail.type.ts
+++ b/backend/src/modules/schedules/types/schedule-detail.type.ts
@@ -27,6 +27,7 @@ export interface GetScheduleDetailResult {
     participants: ScheduleParticipantDetail[];
     memo: string | null;
     createdByBandMemberId: string;
+    isMine: boolean;
     createdAt: string;
     updatedAt: string;
   };

--- a/backend/src/modules/schedules/types/schedule-list-item.type.ts
+++ b/backend/src/modules/schedules/types/schedule-list-item.type.ts
@@ -12,6 +12,7 @@ export interface SpaceScheduleListItem {
   participantCount: number;
   memo: string | null;
   status: string;
+  isMine: boolean;
 }
 
 export interface ScheduleListCursor {

--- a/backend/src/modules/schedules/types/schedule-list-item.type.ts
+++ b/backend/src/modules/schedules/types/schedule-list-item.type.ts
@@ -10,9 +10,15 @@ export interface SpaceScheduleListItem {
   place: { placeId: string; name: string } | null;
   songs: ScheduleSongItem[];
   participantCount: number;
+  participants: ScheduleParticipantAvatar[];
   memo: string | null;
   status: string;
   isMine: boolean;
+}
+
+export interface ScheduleParticipantAvatar {
+  userId: string;
+  avatarUrl: string | null;
 }
 
 export interface ScheduleListCursor {

--- a/backend/src/modules/schedules/types/schedule-list-item.type.ts
+++ b/backend/src/modules/schedules/types/schedule-list-item.type.ts
@@ -8,6 +8,7 @@ export interface SpaceScheduleListItem {
   startAt: string | null;
   endAt: string | null;
   place: { placeId: string; name: string } | null;
+  team: { teamId: string; name: string } | null;
   songs: ScheduleSongItem[];
   participantCount: number;
   participants: ScheduleParticipantAvatar[];

--- a/backend/src/modules/schedules/types/schedule-list-item.type.ts
+++ b/backend/src/modules/schedules/types/schedule-list-item.type.ts
@@ -11,15 +11,16 @@ export interface SpaceScheduleListItem {
   team: { teamId: string; name: string } | null;
   songs: ScheduleSongItem[];
   participantCount: number;
-  participants: ScheduleParticipantAvatar[];
+  participants: ScheduleParticipantPreview[];
   memo: string | null;
   status: string;
   isMine: boolean;
 }
 
-export interface ScheduleParticipantAvatar {
-  userId: string;
-  avatarUrl: string | null;
+export interface ScheduleParticipantPreview {
+  bandMemberId: string;
+  nickname: string;
+  profileImageUrl: string | null;
 }
 
 export interface ScheduleListCursor {

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
@@ -125,20 +125,14 @@ describe('SongsPrismaRepository', () => {
       expect(prisma.song.findMany).toHaveBeenCalledWith({
         where: {
           bandId: 'band-id',
-          AND: [
-            {
-              title: {
-                contains: 'Harder',
-                mode: 'insensitive',
-              },
-            },
-            {
-              artistName: {
-                contains: 'Daft',
-                mode: 'insensitive',
-              },
-            },
-          ],
+          title: {
+            contains: 'Harder',
+            mode: 'insensitive',
+          },
+          artistName: {
+            contains: 'Daft',
+            mode: 'insensitive',
+          },
         },
         include: {
           songSkills: {

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
+import { parseToPrismaQuery } from '../../../common/query';
 import { PrismaService } from '../../../database/prisma';
 import type { Prisma } from '../../../generated/prisma';
 import type { GetBandSongsQuery } from '../dto/get-band-songs-query.dto';
@@ -72,12 +73,11 @@ export class SongsPrismaRepository implements SongsRepository {
    */
   async findBandSongs(bandId: string, query: GetBandSongsQuery, tx?: Prisma.TransactionClient): Promise<GetBandSongsResult> {
     const client = tx ?? this.prisma;
+    const { where, orderBy } = parseToPrismaQuery<Prisma.SongWhereInput>(query);
+    where.bandId = bandId;
 
     const songs = await client.song.findMany({
-      where: {
-        bandId,
-        ...this.createSongListSearchWhere(query),
-      },
+      where,
       include: {
         songSkills: {
           include: {
@@ -92,7 +92,7 @@ export class SongsPrismaRepository implements SongsRepository {
           },
         },
       },
-      orderBy: [{ createdAt: query.order__created_at }, { id: query.order__id }],
+      orderBy,
       ...(query.cursor__id ? { cursor: { id: query.cursor__id }, skip: 1 } : {}),
       take: query.take,
     });
@@ -353,36 +353,6 @@ export class SongsPrismaRepository implements SongsRepository {
     return skillTypeIds
       .map(skillTypeId => skillTypes.find(skillType => skillType.id === skillTypeId))
       .filter((skillType): skillType is CreatedSongSkillType => skillType !== undefined);
-  }
-
-  private createSongListSearchWhere(query: GetBandSongsQuery): Prisma.SongWhereInput {
-    const searchWhere: Prisma.SongWhereInput[] = [];
-
-    if (query.where__title__contain !== undefined) {
-      searchWhere.push({
-        title: {
-          contains: query.where__title__contain,
-          mode: 'insensitive',
-        },
-      });
-    }
-
-    if (query.where__artist_name__contain !== undefined) {
-      searchWhere.push({
-        artistName: {
-          contains: query.where__artist_name__contain,
-          mode: 'insensitive',
-        },
-      });
-    }
-
-    if (searchWhere.length === 0) {
-      return {};
-    }
-
-    return {
-      AND: searchWhere,
-    };
   }
 
   private createUpdateSongData(input: UpdateSongInput): Prisma.SongUpdateInput {


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 20분

<br/>

## 📌 작업 요약

목록 조회 공통 유틸을 미적용 모듈에 맞춰 적용함. 합주 공간 일정 조회에 isMine·팀·참여자 프로필과 "내가 포함된 일정만" 필터를 추가함. 알림 목록에 초대 발신자와 수락 상태를 함께 내려줌. 초대 수락은 row 삭제에서 상태 변경으로 바꿈.

<br/>

## 🗄 스키마 변경

- `Notification`에 컬럼 2개 추가: `referenceType`(`NotificationReferenceType?`, `@map("reference_type")`), `referenceId`(`String? @db.Uuid`, `@map("reference_id")`).
- enum `NotificationReferenceType { BAND_INVITATION }` 추가.
- 마이그레이션 파일: `20260705120000_add_notification_reference` (enum 생성 + 컬럼 2개 추가). 원격 공유 DB라 미적용 상태.
- 초대 수락 정책 변경은 스키마 변경 없음. `BandInvitationStatus.ACCEPTED`와 `BandInvitation.respondedAt`은 기존에 존재했고, 로직만 수정함.

<br/>

## 📝 작업 내용

1. `parseToPrismaQuery` / `buildNextPath` 공통 유틸을 알림·곡·밴드 목록 조회에 적용함.
2. 일정 목록·상세 조회에 `isMine` 추가함(생성자이거나 참여자면 true). 일정 조회 3종에 인증 가드 적용함.
3. 일정 상세 참여자 응답에 `userId`, `nickname`, `avatarUrl` 추가함.
4. 합주 공간 일정 목록에 참여자 미리보기(`bandMemberId`, `nickname`, `profileImageUrl`) 추가함 — FE 응답 타입에 맞춤.
5. 일정 생성 시 `teamId`로 소속 팀 지정(ScheduleTeam), 목록 응답에 `team` 노출, `where__team_id` 필터 추가함. teamId는 공간과 같은 밴드의 팀인지 검증함.
6. "내가 포함된 일정만 보기" 서버 필터(`where__is_mine`) 추가함.
7. 알림에 `referenceType`·`referenceId` 추가함. 초대 알림 생성 시 초대를 참조로 저장하고, 조회 시 초대를 조인해 발신자·현재 상태를 내려줌.
8. 초대 수락을 row 삭제에서 상태 변경(`ACCEPTED`)으로 바꿈.

<br/>

## 🚨 주요 고민 및 해결 과정

### isMine / "내가 포함된 일정만" — 소유 기준이 두 가지임

일정 소유가 생성자와 참여자로 나뉨. 생성자는 `Schedule.createdByBandMember`(BandMember), 참여자는 `ScheduleParticipant`(scheduleId + bandMemberId)에 있고 둘 다 `BandMember.userId`로 User에 닿음. 그래서 `isMine`과 `where__is_mine`을 같은 기준으로 판정함 — 생성자 userId가 나이거나, 참여자 중 내 userId가 있으면 true.

목록 필터에서는 커서 페이지네이션이 이미 최상위 `OR`을 쓰고 있어 isMine을 `OR`로 또 넣으면 키가 겹침. 커서 조건과 isMine 조건을 각각 한 절로 만들어 `AND` 배열에 담아 합침.

### 참여자 프로필

프로필 사진은 `ScheduleParticipant → BandMember → User → UserProfile`을 따라가 nickname·avatarUrl을 가져옴. `UserProfile`이 없을 수 있어 `nickname ?? ''`, `avatarUrl ?? null`로 처리함. isMine 판정도 같은 include의 `bandMember.userId`를 재사용해서, 참여자를 한 번만 include해 카운트·isMine·미리보기를 전부 만듦.

### 일정과 팀 연결

`ScheduleTeam`(scheduleId + teamId)이 스키마에만 있고 값을 넣는 코드가 없어서, 어떤 일정이 어떤 팀 것인지 알 수 없었음. 일정 생성 DTO에서 `teamId`를 받아 `ScheduleTeam`을 만들도록 하고, 목록은 `scheduleTeams`를 조인해 내려줌(한 일정에 팀 하나 기준으로 `take: 1`).

teamId는 FK만으로는 검증이 부족함. 팀과 공간이 같은 밴드인지 확인해야 해서 `Team.band`와 `BandSpace.band`를 타고 `team.band.bandSpaces`에 해당 공간이 있는지 확인함.

### 알림과 초대 연결

`Notification`은 title·description·targetPath만 있고 초대와 이어진 곳이 없었음. 초대 외에 가입 요청 등 다른 소스도 알림을 만들어서, `BandInvitation`으로 바로 FK를 걸지 않고 `referenceType`(enum)·`referenceId`(uuid, DB 제약 없음)를 두는 방식으로 넣음. 초대 알림을 만들 때 `BAND_INVITATION`과 초대 id를 함께 저장함.

발신자·수락 상태는 저장 시점 값이 아니라 조회 시점의 최신값이어야 함. 그래서 저장값을 쓰지 않고 `BAND_INVITATION` 참조가 있는 알림들의 referenceId를 모아 `BandInvitation`을 한 번에 조회한 뒤, `inviterBandMember → User → UserProfile`로 발신자를, `BandInvitation.status`로 상태를 붙임.

### 초대 수락 방식 변경

기존에는 수락 시 `BandInvitation` row를 삭제해서, 알림에서 수락된 초대의 상태를 확인할 수 없었음. 삭제 대신 `status`를 `ACCEPTED`로 바꾸고 `respondedAt`을 기록하도록 수정함. 이제 알림 참조가 PENDING·ACCEPTED·DECLINED 모두 상태를 반환함.

