### PR TITLE
[KAN-80]곡 생성/수정 API에 커버 이미지·참고자료 파일·외부링크·곡 길이 추가

### DIFF
--- a/backend/docs/IMPROVEMENTS.md
+++ b/backend/docs/IMPROVEMENTS.md
@@ -32,6 +32,7 @@
 | 중간 | `docs/backend/conventions.md` | ORDER_DIRECTIONS는 Prisma 호환을 위해 소문자(`'asc'`/`'desc'`)로 정의한다는 규칙 추가 필요. songs는 소문자, places는 대문자로 불일치 발생 — 대문자를 쓰면 repository에서 `.toLowerCase() as 'asc' \| 'desc'` 캐스트 우회가 필요해짐. | places 모듈 리뷰 중 |
 | 낮음 | `.claude/agents/be-designer.md` | cursor__created_at 날짜 유효성 검사(`Number.isNaN`) 패턴을 Service 비즈니스 규칙 체크리스트에 추가. bands는 `validateCursorPair`에서 날짜 파싱 후 NaN 체크를 하는데 places에는 누락되어 잘못된 날짜가 Prisma에 전달될 수 있음. | bands와 places 비교 중 발견 |
 | 높음 | `CLAUDE.md`, `.claude/agents/be-orchestrator.md` | 하네스 Phase 4(QA) 이후 PR 생성을 Phase 5로 추가해야 함. 현재는 QA 통과 후 설계 문서 보관으로 끝나는데, API 단위로 작업할 때 PR까지 생성하는 흐름이 표준화되어야 함. `/pr` 슬래시 커맨드 또는 `be-orchestrate` 스킬 마지막 단계에 PR 생성 안내를 포함하는 방식 검토. | places 모듈 전체 구현 완료 후 PR 생성이 흐름에서 빠져 있음을 발견 |
+| 중간 | `src/modules/songs/songs.service.spec.ts` | 파일 전체가 손으로 만든 Repository Stub이 아닌 `jest.Mocked<SongsRepository>` + `jest.fn()` 패턴으로 작성되어 있어 "Backend 필수 규칙"(auth 제외 TestingModule/jest.fn() 금지)과 충돌. 곡 미디어 필드(songCoverUrl 등) 추가 작업에서는 기존 패턴에 값만 추가했고, 파일 전체를 Stub 패턴으로 재작성하는 것은 해당 작업 범위를 벗어나 별도 리팩터링으로 분리 필요. | 곡 생성/수정 API에 songCoverUrl·referenceFiles·externalLinks·songLength 추가 후 be-qa 검증 중 발견 |
 
 **기록 방법** (한 줄씩 추가):
 

--- a/backend/docs/backend/api-docs/song.md
+++ b/backend/docs/backend/api-docs/song.md
@@ -7,6 +7,7 @@
 > ⚠️ 변환 노트:
 > - Notion "곡 api" 데이터베이스에 대응하는 로컬 문서가 없어 `src/modules/songs/songs.controller.ts`, `songs.service.ts` 코드를 1차 소스로 신규 작성.
 > - Notion 번호(#24~27)는 곡 CRUD 4종에 대응한다. 외부 음원 검색/미리듣기 2종은 Notion에 번호 없는 별도 페이지로 존재.
+> - [설계자 보완 2026-07-09] 곡 커버 이미지(`songCoverUrl`), 참고자료 파일(`referenceFiles`), 외부 링크(`externalLinks`), 곡 길이(`songLength`) 필드를 #24/#25/#26에 추가 (신규 엔드포인트 없음, 기존 번호 유지). 설계 문서: [docs/backend/designs/songs/song-media-fields.md] (QA 통과 후 보관 예정)
 
 ## API 목록
 
@@ -42,7 +43,13 @@
   "sourceUrl": "https://open.spotify.com/track/...",
   "sourceType": "SPOTIFY",
   "memo": "인트로 부분 연습 필요",
-  "skillTypeIds": ["uuid"]
+  "skillTypeIds": ["uuid"],
+  "songCoverUrl": "https://.../song-covers/uuid.jpg",
+  "songLength": 355,
+  "externalLinks": ["https://youtube.com/watch?v=..."],
+  "referenceFiles": [
+    { "fileUrl": "https://.../song-references/uuid.pdf", "fileName": "악보_1절.pdf" }
+  ]
 }
 ```
 
@@ -54,6 +61,10 @@
 | `sourceType` | `"SPOTIFY" \| "DEEZER"` | Y | 음원 출처 |
 | `memo` | string | N | 곡 메모 |
 | `skillTypeIds` | string[] (UUID) | N | 관련 스킬 타입 ID 목록 |
+| `songCoverUrl` | string | N | 곡 커버 이미지 URL (`/storage/presigned-url`로 업로드 후 objectUrl 전달) |
+| `songLength` | number | N | 곡 길이 (초 단위) |
+| `externalLinks` | string[] | N | 외부 링크 URL 목록 |
+| `referenceFiles` | `{ fileUrl: string; fileName: string }[]` | N | 참고자료 파일 목록 (`fileUrl`은 storage 업로드 후 objectUrl) |
 
 ### Response 201
 
@@ -73,6 +84,12 @@
       "key": null,
       "bpm": null,
       "difficultyLevel": null,
+      "songCoverUrl": "https://.../song-covers/uuid.jpg",
+      "songLength": 355,
+      "externalLinks": ["https://youtube.com/watch?v=..."],
+      "referenceFiles": [
+        { "id": "uuid", "fileUrl": "https://.../song-references/uuid.pdf", "fileName": "악보_1절.pdf", "createdAt": "2026-07-05T00:00:00.000Z" }
+      ],
       "userId": "uuid",
       "createdAt": "2026-07-05T00:00:00.000Z"
     },
@@ -135,6 +152,12 @@
         "difficultyLevel": null,
         "sourceUrl": "https://open.spotify.com/track/...",
         "sourceType": "SPOTIFY",
+        "songCoverUrl": "https://.../song-covers/uuid.jpg",
+        "songLength": 355,
+        "externalLinks": ["https://youtube.com/watch?v=..."],
+        "referenceFiles": [
+          { "id": "uuid", "fileUrl": "https://.../song-references/uuid.pdf", "fileName": "악보_1절.pdf", "createdAt": "2026-07-05T00:00:00.000Z" }
+        ],
         "createdAt": "2026-07-05T00:00:00.000Z",
         "skills": [
           { "skillTypeId": "uuid", "skillName": "기타" }
@@ -175,7 +198,8 @@
 
 ### Request Body
 
-전달된 필드만 업데이트한다. `sourceUrl`/`sourceType`/`memo`는 `null` 전달 시 삭제된다.
+전달된 필드만 업데이트한다. `sourceUrl`/`sourceType`/`memo`/`songCoverUrl`/`songLength`는 `null` 전달 시 삭제된다.
+`externalLinks`/`referenceFiles`는 `skillTypeIds`와 동일하게 전달 시(빈 배열 포함) 기존 값을 전체 교체하며, 미전달 시 기존 값을 유지한다.
 
 ```json
 {
@@ -184,9 +208,22 @@
   "sourceUrl": null,
   "sourceType": null,
   "memo": null,
-  "skillTypeIds": ["uuid"]
+  "skillTypeIds": ["uuid"],
+  "songCoverUrl": null,
+  "songLength": 355,
+  "externalLinks": ["https://youtube.com/watch?v=..."],
+  "referenceFiles": [
+    { "fileUrl": "https://.../song-references/uuid.pdf", "fileName": "악보_1절.pdf" }
+  ]
 }
 ```
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `songCoverUrl` | string \| null | 곡 커버 이미지 URL (null 전달 시 삭제) |
+| `songLength` | number \| null | 곡 길이 초 단위 (null 전달 시 삭제) |
+| `externalLinks` | string[] | 전달 시 전체 교체 (빈 배열 전달 시 전체 삭제) |
+| `referenceFiles` | `{ fileUrl: string; fileName: string }[]` | 전달 시 전체 교체 (빈 배열 전달 시 전체 삭제) |
 
 ### Response 200
 
@@ -206,6 +243,12 @@
       "key": null,
       "bpm": null,
       "difficultyLevel": null,
+      "songCoverUrl": null,
+      "songLength": 355,
+      "externalLinks": ["https://youtube.com/watch?v=..."],
+      "referenceFiles": [
+        { "id": "uuid", "fileUrl": "https://.../song-references/uuid.pdf", "fileName": "악보_1절.pdf", "createdAt": "2026-07-05T00:00:00.000Z" }
+      ],
       "updatedAt": "2026-07-05T00:00:00.000Z",
       "skills": [
         { "skillTypeId": "uuid", "skillName": "기타" }

--- a/backend/docs/backend/designs/songs/song-media-fields.md
+++ b/backend/docs/backend/designs/songs/song-media-fields.md
@@ -1,0 +1,293 @@
+# 설계 문서: 곡(Song) 생성/수정 API 확장 — 커버 이미지 · 참고자료 파일 · 외부링크 · 곡 길이
+
+> 대상 모듈: `src/modules/songs`
+> 관련 API 명세: [docs/backend/api-docs/song.md](../docs/backend/api-docs/song.md) — `#24 곡 생성`, `#25 밴드 곡 목록 조회`, `#26 곡 수정`
+> 사용자 확정 사항:
+> - 외부 링크(다중): **배열 컬럼(`String[]`)**
+> - 곡 길이(songLength): **초 단위 정수(Int)**
+> - 참고자료 파일 / 외부링크의 PATCH 갱신 방식: **전체 교체 (`skillTypeIds`와 동일 패턴)**
+
+---
+
+## 1. 작업 범위
+
+```
+신규:
+- prisma/schema.prisma  (Song 모델 필드 추가 + SongReferenceFile 모델 신규)
+- src/modules/songs/dto/song-reference-file.dto.ts  (참고자료 파일 항목 DTO)
+- src/modules/songs/types/song-reference-file.type.ts  (참고자료 파일 응답 타입)
+
+수정:
+- prisma/schema.prisma  (Song: songCoverUrl, songLength, externalLinks 필드 + referenceFiles 관계 추가)
+- src/modules/songs/dto/create-song.dto.ts  (songCoverUrl, songLength, externalLinks, referenceFiles 추가)
+- src/modules/songs/dto/update-song.dto.ts  (동일 필드 optional/nullable 추가)
+- src/modules/songs/types/create-song-result.type.ts  (응답에 신규 필드 추가)
+- src/modules/songs/types/update-song-result.type.ts  (응답에 신규 필드 추가)
+- src/modules/songs/types/song-list.type.ts  (SongListItem에 신규 필드 추가)
+- src/modules/songs/repositories/songs.repository.ts  (CreateSongRepositoryInput 확장)
+- src/modules/songs/repositories/songs.prisma-repository.ts  (create/update/list 쿼리에 신규 필드 반영)
+- src/modules/songs/songs.service.ts  (validateUpdateSongInput에 신규 필드 조건 추가)
+- docs/backend/api-docs/song.md  (#24, #25, #26 명세에 신규 필드 반영)
+```
+
+파일 업로드(커버 이미지, 참고자료 파일)는 기존 `src/storage` 모듈의 `POST /storage/presigned-url` 흐름을 그대로 재사용한다. 프론트엔드가 먼저 presigned URL로 S3(NCP Object Storage)에 업로드한 뒤, 반환받은 `objectUrl`을 곡 생성/수정 요청 본문에 문자열로 전달하는 방식이다. **storage 모듈 자체는 수정하지 않는다.**
+
+---
+
+## 2. Prisma 스키마 변경
+
+### 2.1 `Song` 모델 필드 추가
+
+```prisma
+model Song {
+  id                    String              @id @default(uuid()) @db.Uuid
+  bandId                String              @map("band_id") @db.Uuid
+  title                 String              @db.VarChar(200)
+  artistName            String              @map("artist_name") @db.VarChar(200)
+  key                    SongKey?           @map("key")
+  bpm                   Int?                @db.SmallInt
+  sourceUrl             String?             @map("source_url")
+  sourceType            String?             @map("source_type") @db.VarChar(20)
+  memo                  String?
+  difficultyLevel       Int?                @map("difficulty_level") @db.SmallInt
+  songCoverUrl          String?             @map("song_cover_url") @db.VarChar(255)   // 신규
+  songLength            Int?                @map("song_length") @db.SmallInt          // 신규 (초 단위)
+  externalLinks         String[]            @map("external_links") @default([])       // 신규
+  createdByBandMemberId String?             @map("created_by_band_member_id") @db.Uuid
+  createdAt             DateTime            @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt             DateTime            @updatedAt @map("updated_at") @db.Timestamptz(6)
+  scheduleSongs         ScheduleSong[]
+  songSkills            SongSkill[]
+  referenceFiles        SongReferenceFile[]                                           // 신규
+  band                  Band                @relation(fields: [bandId], references: [id], onDelete: Cascade)
+  createdByBandMember   BandMember?         @relation("SongCreator", fields: [createdByBandMemberId], references: [id])
+  teamSongs             TeamSong[]
+
+  @@map("songs")
+}
+```
+
+- `songCoverUrl`: `Team.teamCoverUrl`와 동일한 패턴(`String? @db.VarChar(255)`, 오브젝트 URL 저장).
+- `songLength`: `bpm`/`difficultyLevel`과 동일하게 `SmallInt` 사용. 최대값 32767초(약 9.1시간)로 실사용 범위에 충분.
+- `externalLinks`: Postgres native array. 마이그레이션 시 기존 row는 `@default([])`로 빈 배열 채움.
+
+### 2.2 `SongReferenceFile` 모델 신규
+
+```prisma
+model SongReferenceFile {
+  id        String   @id @default(uuid()) @db.Uuid
+  songId    String   @map("song_id") @db.Uuid
+  fileUrl   String   @map("file_url")
+  fileName  String   @map("file_name") @db.VarChar(255)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  song      Song     @relation(fields: [songId], references: [id], onDelete: Cascade)
+
+  @@map("song_reference_files")
+}
+```
+
+- `fileUrl`: storage 모듈이 반환한 `objectUrl`.
+- `fileName`: 업로드 시점의 원본 파일명(다운로드/표시용). presigned URL 발급 응답에는 없으므로 클라이언트가 별도로 전달해야 한다.
+- `SongSkill`과 동일하게 `onDelete: Cascade` — 곡이 hard delete되면 참고자료 파일 row도 함께 삭제된다.
+- soft delete 없음 (컨벤션 8: 특별한 이유 없이 `deletedAt` 추가 금지, 이 테이블은 곡과 생명주기를 공유하므로 불필요).
+
+스키마 변경 후 `pnpm run prisma:generate` 및 `pnpm run prisma:migrate:dev` 필요.
+
+---
+
+## 3. Repository 인터페이스 변경
+
+`songs.repository.ts`의 `CreateSongRepositoryInput`은 `CreateSongInput`(DTO)을 확장하므로, DTO에 필드가 추가되면 자동으로 포함된다. 인터페이스 시그니처 자체는 변경 없음 — `createSong`/`updateSong`의 내부 구현(prisma-repository)만 수정한다.
+
+```typescript
+// songs.repository.ts — 변경 없음, 참고용으로 명시
+export interface CreateSongRepositoryInput extends CreateSongInput {
+  bandId: string;
+  userId: string;
+  createdByBandMemberId: string;
+  skillTypeIds: string[];
+}
+```
+
+---
+
+## 4. Service 비즈니스 규칙
+
+`createSong`, `updateSong`의 기존 흐름(밴드 멤버십 검증 → skillType 검증 → repository 위임)은 변경하지 않는다. 신규 필드는 별도의 비즈니스 규칙 검증이 필요 없는 단순 전달 값이므로 Service 레이어에 로직을 추가하지 않는다 (DTO 레벨 검증으로 충분).
+
+`validateUpdateSongInput`만 아래와 같이 조건을 확장한다:
+
+```
+validateUpdateSongInput(input):
+1. 기존 조건(title/artistName/sourceUrl/sourceType/memo/skillTypeIds) 중 하나라도 존재하면 통과
+2. songCoverUrl, songLength, externalLinks, referenceFiles 중 하나라도 존재하면 통과
+3. 모두 없으면 BadRequestException("수정할 곡 정보가 필요합니다.")
+```
+
+---
+
+## 5. API 번호 및 Swagger
+
+기존 엔드포인트(`#24 곡 생성`, `#25 밴드 곡 목록 조회`, `#26 곡 수정`)의 요청/응답 필드만 확장한다. **신규 엔드포인트 없음 → 새 `#N` 번호 불필요.**
+
+Swagger는 기존 `CreateSongBodyDto`/`UpdateSongBodyDto`의 `@ApiProperty`/`@ApiPropertyOptional`을 신규 필드에 추가하는 것으로 충분하며, Controller의 `@ApiOperation`/`@ApiResponse`는 변경하지 않는다.
+
+---
+
+## 6. DTO 및 타입 정의
+
+### 6.1 `SongReferenceFileDto` (신규 파일: `dto/song-reference-file.dto.ts`)
+
+`update-user-profile.dto.ts`의 `UpdateSkillDto` 중첩 배열 패턴을 따른다.
+
+```typescript
+export class SongReferenceFileDto {
+  @ApiProperty({ description: '파일 URL (storage 업로드 후 objectUrl)', example: 'https://.../songs/uuid/reference.pdf' })
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty({ message: notemptyValidationMessage })
+  fileUrl!: string;
+
+  @ApiProperty({ description: '원본 파일명 (최대 255자)', example: '악보_1절.pdf' })
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty({ message: notemptyValidationMessage })
+  @MaxLength(255, { message: lengthValidationMessage })
+  fileName!: string;
+}
+```
+
+### 6.2 `CreateSongBodyDto` 추가 필드
+
+```typescript
+@ApiPropertyOptional({ description: '곡 커버 이미지 URL', example: 'https://.../song-covers/uuid.jpg' })
+@Transform(normalizeOptionalStringValue)
+@IsOptional()
+@IsString({ message: stringValidationMessage })
+songCoverUrl?: string;
+
+@ApiPropertyOptional({ description: '곡 길이 (초 단위)', example: 355 })
+@IsOptional()
+@IsInt({ message: intValidationMessage })
+@Min(1, { message: minValidationMessage })
+songLength?: number;
+
+@ApiPropertyOptional({ description: '외부 링크 목록 (URL 배열)', type: [String] })
+@IsOptional()
+@IsArray()
+@IsString({ each: true, message: stringValidationMessage })
+externalLinks?: string[];
+
+@ApiPropertyOptional({ description: '참고자료 파일 목록', type: [SongReferenceFileDto] })
+@IsOptional()
+@IsArray()
+@ValidateNested({ each: true })
+@Type(() => SongReferenceFileDto)
+referenceFiles?: SongReferenceFileDto[];
+```
+
+### 6.3 `UpdateSongBodyDto` 추가 필드
+
+`sourceUrl`/`memo`와 동일하게 `null` 전달 시 값 삭제. `externalLinks`/`referenceFiles`는 `skillTypeIds`와 동일하게 **미전달 시 유지, 전달 시(빈 배열 포함) 전체 교체** — nullable 아님.
+
+```typescript
+@ApiPropertyOptional({ description: '곡 커버 이미지 URL (null로 설정 시 삭제)', nullable: true, example: 'https://.../song-covers/uuid.jpg' })
+@Transform(normalizeOptionalStringValue)
+@IsOptional()
+@IsString({ message: stringValidationMessage })
+songCoverUrl?: string | null;
+
+@ApiPropertyOptional({ description: '곡 길이 (초 단위, null로 설정 시 삭제)', nullable: true, example: 355 })
+@IsOptional()
+@IsInt({ message: intValidationMessage })
+@Min(1, { message: minValidationMessage })
+songLength?: number | null;
+
+@ApiPropertyOptional({ description: '외부 링크 목록 (전달 시 전체 교체, 빈 배열 전달 시 전체 삭제)', type: [String] })
+@IsOptional()
+@IsArray()
+@IsString({ each: true, message: stringValidationMessage })
+externalLinks?: string[];
+
+@ApiPropertyOptional({ description: '참고자료 파일 목록 (전달 시 전체 교체, 빈 배열 전달 시 전체 삭제)', type: [SongReferenceFileDto] })
+@IsOptional()
+@IsArray()
+@ValidateNested({ each: true })
+@Type(() => SongReferenceFileDto)
+referenceFiles?: SongReferenceFileDto[];
+```
+
+> `normalizeOptionalStringValue`는 `typeof value !== 'string'`이면 원본을 그대로 반환하므로 `null`이 그대로 통과하고, `@IsOptional()`이 `null`을 검증 생략 대상으로 처리한다 (기존 `sourceUrl` 패턴과 동일).
+
+### 6.4 응답 타입 (`types/`)
+
+`create-song-result.type.ts`, `update-song-result.type.ts`, `song-list.type.ts`의 `song` 객체에 아래 필드 추가:
+
+```typescript
+songCoverUrl: string | null;
+songLength: number | null;
+externalLinks: string[];
+referenceFiles: SongReferenceFileItem[];  // song-reference-file.type.ts (신규)
+```
+
+`song-reference-file.type.ts` (신규):
+
+```typescript
+export interface SongReferenceFileItem {
+  id: string;
+  fileUrl: string;
+  fileName: string;
+  createdAt: string;
+}
+```
+
+---
+
+## 7. Soft Delete 여부
+
+- `Song`: soft delete 없음 (기존과 동일, hard delete).
+- `SongReferenceFile`: soft delete 없음. `deletedAt` 미보유, 곡과 함께 cascade hard delete.
+
+---
+
+## 8. 트랜잭션 경계
+
+| 메서드                  | tx 필요 여부 | 이유                                                                 |
+| ----------------------- | :----------: | -------------------------------------------------------------------- |
+| createSong (repository) |     필요     | song insert + songSkill insert + songReferenceFile insert를 원자적으로 처리 (기존과 동일하게 Service의 `$transaction` 경계를 그대로 사용) |
+| updateSong (repository) |     필요     | songSkill 전체 교체 + songReferenceFile 전체 교체 + song update를 원자적으로 처리 |
+
+Service의 `createSong`/`updateSong`이 이미 `tx?` 인자를 받아 `$transaction`으로 감싸고 있으므로, 신규 로직은 그 안에서 실행되는 repository 메서드에 편입될 뿐 트랜잭션 경계 자체는 변경되지 않는다.
+
+---
+
+## 9. 테스트 계획
+
+`songs.service.spec.ts` (Repository Stub 기반):
+
+| 메서드         | 케이스                                                        | 검증 방법                                          |
+| -------------- | -------------------------------------------------------------- | --------------------------------------------------- |
+| createSong     | songCoverUrl/songLength/externalLinks/referenceFiles 포함 생성 | 반환된 song 객체에 필드가 그대로 반영되는지 확인    |
+| createSong     | 신규 필드 없이 생성 (기존 계약 유지)                            | 기존 happy path 그대로 통과 확인 (회귀 없음)         |
+| updateSong     | referenceFiles를 빈 배열로 전달 → 기존 파일 전체 삭제           | repository stub에 전달된 delete 호출 인자 검증       |
+| updateSong     | externalLinks만 전달 → 다른 필드는 유지                         | 업데이트 데이터에 externalLinks만 포함되는지 확인    |
+| updateSong     | 모든 신규 필드 미전달 + 기존 필드도 미전달                       | BadRequestException("수정할 곡 정보가 필요합니다.") |
+| updateSong     | songCoverUrl/songLength를 null로 전달 → 삭제                    | update data에 null이 전달되는지 확인                 |
+| updateSong     | tx 일관성                                                       | capturedTransactions 검증 (기존 패턴)                |
+| updateSong     | 외부 tx 전달                                                    | createPrismaServiceFailingTransactionStub 사용       |
+
+`songs.prisma-repository.spec.ts`:
+
+| 메서드     | 케이스                                             | 검증 방법                                                |
+| ---------- | --------------------------------------------------- | ----------------------------------------------------------- |
+| createSong | referenceFiles 포함 시 songReferenceFile.createMany 호출 확인 | prisma mock 호출 인자 검증                                  |
+| updateSong | referenceFiles 전달 시 deleteMany 후 createMany 호출 확인      | 호출 순서/인자 검증 (기존 skillTypeIds 테스트와 동일 구조) |
+| updateSong | externalLinks 전달 시 `{ set: [...] }`로 update 호출 확인       | prisma mock 호출 인자 검증                                  |
+
+---
+
+## 10. 미결 사항
+
+1. **목록 조회(#25) 응답에 `referenceFiles`/`externalLinks`를 전체 포함할지 여부.**
+   현재 단일 곡 상세 조회(GET) 엔드포인트가 없어, 생성/수정 응답 이외에 참고자료 파일에 접근할 방법이 목록 조회뿐이다. 기존 `skills`가 목록에 전체 임베딩되는 패턴을 따라 이번 설계도 `referenceFiles`/`externalLinks`를 목록 아이템에 전체 포함하는 것으로 가정했다. 곡당 참고자료 파일 수가 많아질 경우 목록 조회 payload가 커질 수 있으니, 필요하면 목록에는 개수(`referenceFileCount`)만 노출하고 상세는 별도 `GET /songs/:songId` 엔드포인트를 새로 설계하는 방안도 가능하다. **→ 확인 필요.**
+2. **참고자료 파일/외부링크 개수 제한.** 곡 하나당 업로드 가능한 파일 수, 링크 수에 상한이 필요한지 명시되지 않아 이번 설계에는 제한을 두지 않았다. 필요 시 Service 레벨에서 `BadRequestException`으로 제한 추가 가능.
+3. **참고자료 파일의 MIME 타입/용량 제한.** storage 모듈의 presigned URL 발급 단계에서 별도 제약이 없다면, 곡 참고자료 업로드에도 별도 제약을 걸지 않는 것으로 가정했다. 프론트엔드/스토리지 정책상 필요하면 별도 논의 필요.
+4. **`songCoverUrl` 업로드 폴더명.** `POST /storage/presigned-url`의 `folder` 파라미터에 어떤 값을 쓸지는 프론트엔드/클라이언트 재량으로 가정(예: `song-covers`, `song-references`). 백엔드 스키마/검증에는 영향 없음.

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -284,23 +284,27 @@ model SpaceMember {
 }
 
 model Song {
-  id                    String         @id @default(uuid()) @db.Uuid
-  bandId                String         @map("band_id") @db.Uuid
-  title                 String         @db.VarChar(200)
-  artistName            String         @map("artist_name") @db.VarChar(200)
-  key                   SongKey?       @map("key")
-  bpm                   Int?           @db.SmallInt
-  sourceUrl             String?        @map("source_url")
-  sourceType            String?        @map("source_type") @db.VarChar(20)
+  id                    String              @id @default(uuid()) @db.Uuid
+  bandId                String              @map("band_id") @db.Uuid
+  title                 String              @db.VarChar(200)
+  artistName            String              @map("artist_name") @db.VarChar(200)
+  key                   SongKey?            @map("key")
+  bpm                   Int?                @db.SmallInt
+  sourceUrl             String?             @map("source_url")
+  sourceType            String?             @map("source_type") @db.VarChar(20)
   memo                  String?
-  difficultyLevel       Int?           @map("difficulty_level") @db.SmallInt
-  createdByBandMemberId String?        @map("created_by_band_member_id") @db.Uuid
-  createdAt             DateTime       @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt             DateTime       @updatedAt @map("updated_at") @db.Timestamptz(6)
+  difficultyLevel       Int?                @map("difficulty_level") @db.SmallInt
+  songCoverUrl          String?             @map("song_cover_url") @db.VarChar(255)
+  songLength            Int?                @map("song_length") @db.SmallInt
+  externalLinks         String[]            @default([]) @map("external_links")
+  createdByBandMemberId String?             @map("created_by_band_member_id") @db.Uuid
+  createdAt             DateTime            @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt             DateTime            @updatedAt @map("updated_at") @db.Timestamptz(6)
   scheduleSongs         ScheduleSong[]
   songSkills            SongSkill[]
-  band                  Band           @relation(fields: [bandId], references: [id], onDelete: Cascade)
-  createdByBandMember   BandMember?    @relation("SongCreator", fields: [createdByBandMemberId], references: [id])
+  referenceFiles        SongReferenceFile[]
+  band                  Band                @relation(fields: [bandId], references: [id], onDelete: Cascade)
+  createdByBandMember   BandMember?         @relation("SongCreator", fields: [createdByBandMemberId], references: [id])
   teamSongs             TeamSong[]
 
   @@map("songs")
@@ -315,6 +319,17 @@ model SongSkill {
 
   @@unique([songId, skillTypeId])
   @@map("song_skills")
+}
+
+model SongReferenceFile {
+  id        String   @id @default(uuid()) @db.Uuid
+  songId    String   @map("song_id") @db.Uuid
+  fileUrl   String   @map("file_url")
+  fileName  String   @map("file_name") @db.VarChar(255)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  song      Song     @relation(fields: [songId], references: [id], onDelete: Cascade)
+
+  @@map("song_reference_files")
 }
 
 model Schedule {

--- a/backend/src/modules/songs/dto/create-song.dto.ts
+++ b/backend/src/modules/songs/dto/create-song.dto.ts
@@ -104,6 +104,10 @@ export class CreateSongBodyDto {
     each: true,
     message: stringValidationMessage,
   })
+  @IsNotEmpty({
+    each: true,
+    message: notemptyValidationMessage,
+  })
   externalLinks?: string[];
 
   @ApiPropertyOptional({ description: '참고자료 파일 목록', type: [SongReferenceFileDto] })

--- a/backend/src/modules/songs/dto/create-song.dto.ts
+++ b/backend/src/modules/songs/dto/create-song.dto.ts
@@ -1,14 +1,18 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Transform } from 'class-transformer';
-import { IsArray, IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { IsArray, IsEnum, IsInt, IsNotEmpty, IsOptional, IsString, IsUUID, MaxLength, Min, ValidateNested } from 'class-validator';
 
 import { normalizeOptionalStringValue, trimStringValue } from '../../../common/validation/transform.util';
 import { enumValidationMessage } from '../../../common/validation-message/enum-validation.message';
+import { intValidationMessage } from '../../../common/validation-message/int-validation.message';
 import { lengthValidationMessage } from '../../../common/validation-message/length-validation.message';
+import { minValidationMessage } from '../../../common/validation-message/min-validation.message';
 import { notemptyValidationMessage } from '../../../common/validation-message/notempty-validation.message';
 import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
 import { uuidValidationMessage } from '../../../common/validation-message/uuid-validation.message';
 import type { SongSourceType } from '../types/song-preview.type';
+
+import { SongReferenceFileDto } from './song-reference-file.dto';
 
 export const SONG_SOURCE_TYPES = ['SPOTIFY', 'DEEZER'] as const satisfies readonly SongSourceType[];
 
@@ -74,6 +78,40 @@ export class CreateSongBodyDto {
     message: uuidValidationMessage,
   })
   skillTypeIds?: string[];
+
+  @ApiPropertyOptional({ description: '곡 커버 이미지 URL', example: 'https://.../song-covers/uuid.jpg' })
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({
+    message: stringValidationMessage,
+  })
+  songCoverUrl?: string;
+
+  @ApiPropertyOptional({ description: '곡 길이 (초 단위)', example: 355 })
+  @IsOptional()
+  @IsInt({
+    message: intValidationMessage,
+  })
+  @Min(1, {
+    message: minValidationMessage,
+  })
+  songLength?: number;
+
+  @ApiPropertyOptional({ description: '외부 링크 URL 목록', type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({
+    each: true,
+    message: stringValidationMessage,
+  })
+  externalLinks?: string[];
+
+  @ApiPropertyOptional({ description: '참고자료 파일 목록', type: [SongReferenceFileDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SongReferenceFileDto)
+  referenceFiles?: SongReferenceFileDto[];
 }
 
 export type CreateSongInput = CreateSongBodyDto;

--- a/backend/src/modules/songs/dto/song-reference-file.dto.ts
+++ b/backend/src/modules/songs/dto/song-reference-file.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+import { lengthValidationMessage } from '../../../common/validation-message/length-validation.message';
+import { notemptyValidationMessage } from '../../../common/validation-message/notempty-validation.message';
+import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
+
+/**
+ * 참고자료 파일 항목. fileUrl은 storage 모듈 presigned URL 업로드 후 반환된 objectUrl이다.
+ */
+export class SongReferenceFileDto {
+  @ApiProperty({ description: '파일 URL (storage 업로드 후 objectUrl)', example: 'https://.../song-references/uuid.pdf' })
+  @IsString({
+    message: stringValidationMessage,
+  })
+  @IsNotEmpty({
+    message: notemptyValidationMessage,
+  })
+  fileUrl!: string;
+
+  @ApiProperty({ description: '원본 파일명 (최대 255자)', example: '악보_1절.pdf' })
+  @IsString({
+    message: stringValidationMessage,
+  })
+  @IsNotEmpty({
+    message: notemptyValidationMessage,
+  })
+  @MaxLength(255, {
+    message: lengthValidationMessage,
+  })
+  fileName!: string;
+}

--- a/backend/src/modules/songs/dto/update-song.dto.ts
+++ b/backend/src/modules/songs/dto/update-song.dto.ts
@@ -1,16 +1,19 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Transform } from 'class-transformer';
-import { IsArray, IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { IsArray, IsEnum, IsInt, IsNotEmpty, IsOptional, IsString, IsUUID, MaxLength, Min, ValidateNested } from 'class-validator';
 
 import { normalizeOptionalStringValue, trimStringValue } from '../../../common/validation/transform.util';
 import { enumValidationMessage } from '../../../common/validation-message/enum-validation.message';
+import { intValidationMessage } from '../../../common/validation-message/int-validation.message';
 import { lengthValidationMessage } from '../../../common/validation-message/length-validation.message';
+import { minValidationMessage } from '../../../common/validation-message/min-validation.message';
 import { notemptyValidationMessage } from '../../../common/validation-message/notempty-validation.message';
 import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
 import { uuidValidationMessage } from '../../../common/validation-message/uuid-validation.message';
 import type { SongSourceType } from '../types/song-preview.type';
 
 import { SONG_SOURCE_TYPES } from './create-song.dto';
+import { SongReferenceFileDto } from './song-reference-file.dto';
 
 /**
  * 곡 수정 요청 본문은 PATCH 의미에 맞춰 전달된 필드만 검증한다.
@@ -75,6 +78,40 @@ export class UpdateSongBodyDto {
     message: uuidValidationMessage,
   })
   skillTypeIds?: string[];
+
+  @ApiPropertyOptional({ description: '곡 커버 이미지 URL (null로 설정 시 삭제)', nullable: true, example: 'https://.../song-covers/uuid.jpg' })
+  @Transform(normalizeOptionalStringValue)
+  @IsOptional()
+  @IsString({
+    message: stringValidationMessage,
+  })
+  songCoverUrl?: string | null;
+
+  @ApiPropertyOptional({ description: '곡 길이 (초 단위, null로 설정 시 삭제)', nullable: true, example: 355 })
+  @IsOptional()
+  @IsInt({
+    message: intValidationMessage,
+  })
+  @Min(1, {
+    message: minValidationMessage,
+  })
+  songLength?: number | null;
+
+  @ApiPropertyOptional({ description: '외부 링크 목록 (전달 시 전체 교체, 빈 배열 전달 시 전체 삭제)', type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({
+    each: true,
+    message: stringValidationMessage,
+  })
+  externalLinks?: string[];
+
+  @ApiPropertyOptional({ description: '참고자료 파일 목록 (전달 시 전체 교체, 빈 배열 전달 시 전체 삭제)', type: [SongReferenceFileDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SongReferenceFileDto)
+  referenceFiles?: SongReferenceFileDto[];
 }
 
 export type UpdateSongInput = UpdateSongBodyDto;

--- a/backend/src/modules/songs/dto/update-song.dto.ts
+++ b/backend/src/modules/songs/dto/update-song.dto.ts
@@ -104,6 +104,10 @@ export class UpdateSongBodyDto {
     each: true,
     message: stringValidationMessage,
   })
+  @IsNotEmpty({
+    each: true,
+    message: notemptyValidationMessage,
+  })
   externalLinks?: string[];
 
   @ApiPropertyOptional({ description: '참고자료 파일 목록 (전달 시 전체 교체, 빈 배열 전달 시 전체 삭제)', type: [SongReferenceFileDto] })

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.spec.ts
@@ -20,6 +20,11 @@ const createPrismaMock = () => ({
     createMany: jest.fn(),
     deleteMany: jest.fn(),
   },
+  songReferenceFile: {
+    createMany: jest.fn(),
+    deleteMany: jest.fn(),
+    findMany: jest.fn(),
+  },
 });
 
 describe('SongsPrismaRepository', () => {
@@ -147,6 +152,11 @@ describe('SongsPrismaRepository', () => {
               skillTypeId: 'asc',
             },
           },
+          referenceFiles: {
+            orderBy: {
+              createdAt: 'asc',
+            },
+          },
         },
         orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
         cursor: { id: 'cursor-song-id' },
@@ -167,6 +177,9 @@ describe('SongsPrismaRepository', () => {
           difficultyLevel: null,
           sourceUrl: 'https://www.deezer.com/track/3135556',
           sourceType: 'DEEZER',
+          songCoverUrl: 'https://storage.example.com/song-covers/uuid.jpg',
+          songLength: 355,
+          externalLinks: ['https://youtube.com/watch?v=uuid'],
           createdAt: new Date('2026-05-20T00:00:00.000Z'),
           songSkills: [
             {
@@ -174,6 +187,14 @@ describe('SongsPrismaRepository', () => {
               skillType: {
                 name: '기타',
               },
+            },
+          ],
+          referenceFiles: [
+            {
+              id: 'reference-file-id',
+              fileUrl: 'https://storage.example.com/song-references/uuid.pdf',
+              fileName: '악보_1절.pdf',
+              createdAt: new Date('2026-05-20T00:00:00.000Z'),
             },
           ],
         },
@@ -187,8 +208,12 @@ describe('SongsPrismaRepository', () => {
           difficultyLevel: null,
           sourceUrl: 'https://www.deezer.com/track/3135557',
           sourceType: 'DEEZER',
+          songCoverUrl: null,
+          songLength: null,
+          externalLinks: [],
           createdAt: new Date('2026-05-19T00:00:00.000Z'),
           songSkills: [],
+          referenceFiles: [],
         },
       ]);
 
@@ -210,11 +235,22 @@ describe('SongsPrismaRepository', () => {
             difficultyLevel: null,
             sourceUrl: 'https://www.deezer.com/track/3135556',
             sourceType: 'DEEZER',
+            songCoverUrl: 'https://storage.example.com/song-covers/uuid.jpg',
+            songLength: 355,
+            externalLinks: ['https://youtube.com/watch?v=uuid'],
             createdAt: '2026-05-20T00:00:00.000Z',
             skills: [
               {
                 skillTypeId: 'skill-type-1',
                 skillName: '기타',
+              },
+            ],
+            referenceFiles: [
+              {
+                id: 'reference-file-id',
+                fileUrl: 'https://storage.example.com/song-references/uuid.pdf',
+                fileName: '악보_1절.pdf',
+                createdAt: '2026-05-20T00:00:00.000Z',
               },
             ],
           },
@@ -228,8 +264,12 @@ describe('SongsPrismaRepository', () => {
             difficultyLevel: null,
             sourceUrl: 'https://www.deezer.com/track/3135557',
             sourceType: 'DEEZER',
+            songCoverUrl: null,
+            songLength: null,
+            externalLinks: [],
             createdAt: '2026-05-19T00:00:00.000Z',
             skills: [],
+            referenceFiles: [],
           },
         ],
         meta: {
@@ -350,6 +390,10 @@ describe('SongsPrismaRepository', () => {
       memo: '후렴 진입 전 드럼 큐 확인',
       createdByBandMemberId: 'band-member-id',
       skillTypeIds: ['skill-type-2', 'skill-type-1'],
+      songCoverUrl: 'https://storage.example.com/song-covers/uuid.jpg',
+      songLength: 355,
+      externalLinks: ['https://youtube.com/watch?v=uuid'],
+      referenceFiles: [{ fileUrl: 'https://storage.example.com/song-references/uuid.pdf', fileName: '악보_1절.pdf' }],
     };
 
     beforeEach(() => {
@@ -364,9 +408,21 @@ describe('SongsPrismaRepository', () => {
         key: null,
         bpm: null,
         difficultyLevel: null,
+        songCoverUrl: 'https://storage.example.com/song-covers/uuid.jpg',
+        songLength: 355,
+        externalLinks: ['https://youtube.com/watch?v=uuid'],
         createdAt: new Date('2026-05-20T00:00:00.000Z'),
       });
       prisma.songSkill.createMany.mockResolvedValue({ count: 2 });
+      prisma.songReferenceFile.createMany.mockResolvedValue({ count: 1 });
+      prisma.songReferenceFile.findMany.mockResolvedValue([
+        {
+          id: 'reference-file-id',
+          fileUrl: 'https://storage.example.com/song-references/uuid.pdf',
+          fileName: '악보_1절.pdf',
+          createdAt: new Date('2026-05-20T00:00:00.000Z'),
+        },
+      ]);
       prisma.skillType.findMany.mockResolvedValue([
         {
           id: 'skill-type-1',
@@ -390,6 +446,9 @@ describe('SongsPrismaRepository', () => {
           sourceUrl: 'https://www.deezer.com/track/3135556',
           sourceType: 'DEEZER',
           memo: '후렴 진입 전 드럼 큐 확인',
+          songCoverUrl: 'https://storage.example.com/song-covers/uuid.jpg',
+          songLength: 355,
+          externalLinks: ['https://youtube.com/watch?v=uuid'],
           createdByBandMemberId: 'band-member-id',
         },
         select: {
@@ -403,6 +462,9 @@ describe('SongsPrismaRepository', () => {
           key: true,
           bpm: true,
           difficultyLevel: true,
+          songCoverUrl: true,
+          songLength: true,
+          externalLinks: true,
           createdAt: true,
         },
       });
@@ -415,6 +477,15 @@ describe('SongsPrismaRepository', () => {
           {
             songId: 'song-id',
             skillTypeId: 'skill-type-1',
+          },
+        ],
+      });
+      expect(prisma.songReferenceFile.createMany).toHaveBeenCalledWith({
+        data: [
+          {
+            songId: 'song-id',
+            fileUrl: 'https://storage.example.com/song-references/uuid.pdf',
+            fileName: '악보_1절.pdf',
           },
         ],
       });
@@ -435,6 +506,17 @@ describe('SongsPrismaRepository', () => {
           key: null,
           bpm: null,
           difficultyLevel: null,
+          songCoverUrl: 'https://storage.example.com/song-covers/uuid.jpg',
+          songLength: 355,
+          externalLinks: ['https://youtube.com/watch?v=uuid'],
+          referenceFiles: [
+            {
+              id: 'reference-file-id',
+              fileUrl: 'https://storage.example.com/song-references/uuid.pdf',
+              fileName: '악보_1절.pdf',
+              createdAt: '2026-05-20T00:00:00.000Z',
+            },
+          ],
           userId: 'user-id',
           createdAt: '2026-05-20T00:00:00.000Z',
         },
@@ -459,12 +541,23 @@ describe('SongsPrismaRepository', () => {
 
       expect(prisma.songSkill.createMany).not.toHaveBeenCalled();
     });
+
+    it('참고자료 파일이 없으면 참고자료 파일 연결을 생성하지 않는다', async () => {
+      await repository.createSong({
+        ...input,
+        referenceFiles: [],
+      });
+
+      expect(prisma.songReferenceFile.createMany).not.toHaveBeenCalled();
+    });
   });
 
   describe('updateSong', () => {
     beforeEach(() => {
       prisma.songSkill.deleteMany.mockResolvedValue({ count: 2 });
       prisma.songSkill.createMany.mockResolvedValue({ count: 1 });
+      prisma.songReferenceFile.deleteMany.mockResolvedValue({ count: 1 });
+      prisma.songReferenceFile.createMany.mockResolvedValue({ count: 1 });
       prisma.song.update.mockResolvedValue({
         id: 'song-id',
         bandId: 'band-id',
@@ -476,6 +569,9 @@ describe('SongsPrismaRepository', () => {
         key: null,
         bpm: null,
         difficultyLevel: null,
+        songCoverUrl: 'https://storage.example.com/song-covers/uuid.jpg',
+        songLength: 355,
+        externalLinks: ['https://youtube.com/watch?v=uuid'],
         updatedAt: new Date('2026-05-20T00:00:00.000Z'),
         songSkills: [
           {
@@ -483,6 +579,14 @@ describe('SongsPrismaRepository', () => {
             skillType: {
               name: '기타',
             },
+          },
+        ],
+        referenceFiles: [
+          {
+            id: 'reference-file-id',
+            fileUrl: 'https://storage.example.com/song-references/uuid.pdf',
+            fileName: '악보_1절.pdf',
+            createdAt: new Date('2026-05-20T00:00:00.000Z'),
           },
         ],
       });
@@ -529,6 +633,11 @@ describe('SongsPrismaRepository', () => {
               skillTypeId: 'asc',
             },
           },
+          referenceFiles: {
+            orderBy: {
+              createdAt: 'asc',
+            },
+          },
         },
       });
     });
@@ -556,6 +665,68 @@ describe('SongsPrismaRepository', () => {
       expect(prisma.songSkill.createMany).not.toHaveBeenCalled();
     });
 
+    it('referenceFiles가 전달되면 기존 참고자료 파일을 교체한다', async () => {
+      await repository.updateSong('song-id', {
+        referenceFiles: [{ fileUrl: 'https://storage.example.com/song-references/new.pdf', fileName: '새_악보.pdf' }],
+      });
+
+      expect(prisma.songReferenceFile.deleteMany).toHaveBeenCalledWith({
+        where: {
+          songId: 'song-id',
+        },
+      });
+      expect(prisma.songReferenceFile.createMany).toHaveBeenCalledWith({
+        data: [
+          {
+            songId: 'song-id',
+            fileUrl: 'https://storage.example.com/song-references/new.pdf',
+            fileName: '새_악보.pdf',
+          },
+        ],
+      });
+    });
+
+    it('referenceFiles가 없으면 참고자료 파일을 수정하지 않는다', async () => {
+      await repository.updateSong('song-id', {
+        memo: null,
+      });
+
+      expect(prisma.songReferenceFile.deleteMany).not.toHaveBeenCalled();
+      expect(prisma.songReferenceFile.createMany).not.toHaveBeenCalled();
+    });
+
+    it('referenceFiles가 빈 배열이면 기존 참고자료 파일만 삭제한다', async () => {
+      await repository.updateSong('song-id', {
+        referenceFiles: [],
+      });
+
+      expect(prisma.songReferenceFile.deleteMany).toHaveBeenCalledWith({
+        where: {
+          songId: 'song-id',
+        },
+      });
+      expect(prisma.songReferenceFile.createMany).not.toHaveBeenCalled();
+    });
+
+    it('externalLinks가 전달되면 set으로 전체 교체한다', async () => {
+      await repository.updateSong('song-id', {
+        externalLinks: ['https://youtube.com/watch?v=new'],
+      });
+
+      expect(prisma.song.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { externalLinks: { set: ['https://youtube.com/watch?v=new'] } } }),
+      );
+    });
+
+    it('songCoverUrl과 songLength를 null로 전달하면 삭제한다', async () => {
+      await repository.updateSong('song-id', {
+        songCoverUrl: null,
+        songLength: null,
+      });
+
+      expect(prisma.song.update).toHaveBeenCalledWith(expect.objectContaining({ data: { songCoverUrl: null, songLength: null } }));
+    });
+
     it('수정된 곡 정보를 응답 형태로 매핑한다', async () => {
       const result = await repository.updateSong('song-id', {
         memo: '템포 124 기준으로 연습',
@@ -573,6 +744,17 @@ describe('SongsPrismaRepository', () => {
           key: null,
           bpm: null,
           difficultyLevel: null,
+          songCoverUrl: 'https://storage.example.com/song-covers/uuid.jpg',
+          songLength: 355,
+          externalLinks: ['https://youtube.com/watch?v=uuid'],
+          referenceFiles: [
+            {
+              id: 'reference-file-id',
+              fileUrl: 'https://storage.example.com/song-references/uuid.pdf',
+              fileName: '악보_1절.pdf',
+              createdAt: '2026-05-20T00:00:00.000Z',
+            },
+          ],
           updatedAt: '2026-05-20T00:00:00.000Z',
           skills: [
             {

--- a/backend/src/modules/songs/repositories/songs.prisma-repository.ts
+++ b/backend/src/modules/songs/repositories/songs.prisma-repository.ts
@@ -10,6 +10,7 @@ import type { DeleteSongResult } from '../types/delete-song-result.type';
 import type { ActiveBandWithMember, SongWithBandMember } from '../types/song-access-context.type';
 import type { GetBandSongsResult, SongListItem } from '../types/song-list.type';
 import type { SongSourceType } from '../types/song-preview.type';
+import type { SongReferenceFileItem } from '../types/song-reference-file.type';
 import type { UpdateSongResult } from '../types/update-song-result.type';
 
 import type { CreateSongRepositoryInput, SongsRepository } from './songs.repository';
@@ -89,6 +90,11 @@ export class SongsPrismaRepository implements SongsRepository {
           },
           orderBy: {
             skillTypeId: 'asc',
+          },
+        },
+        referenceFiles: {
+          orderBy: {
+            createdAt: 'asc',
           },
         },
       },
@@ -180,6 +186,9 @@ export class SongsPrismaRepository implements SongsRepository {
         sourceUrl: input.sourceUrl,
         sourceType: input.sourceType,
         memo: input.memo,
+        songCoverUrl: input.songCoverUrl,
+        songLength: input.songLength,
+        externalLinks: input.externalLinks,
         createdByBandMemberId: input.createdByBandMemberId,
       },
       select: {
@@ -193,6 +202,9 @@ export class SongsPrismaRepository implements SongsRepository {
         key: true,
         bpm: true,
         difficultyLevel: true,
+        songCoverUrl: true,
+        songLength: true,
+        externalLinks: true,
         createdAt: true,
       },
     });
@@ -202,6 +214,16 @@ export class SongsPrismaRepository implements SongsRepository {
         data: input.skillTypeIds.map(skillTypeId => ({
           songId: song.id,
           skillTypeId,
+        })),
+      });
+    }
+
+    if (input.referenceFiles !== undefined && input.referenceFiles.length > 0) {
+      await client.songReferenceFile.createMany({
+        data: input.referenceFiles.map(referenceFile => ({
+          songId: song.id,
+          fileUrl: referenceFile.fileUrl,
+          fileName: referenceFile.fileName,
         })),
       });
     }
@@ -218,6 +240,21 @@ export class SongsPrismaRepository implements SongsRepository {
       },
     });
 
+    const referenceFiles = await client.songReferenceFile.findMany({
+      where: {
+        songId: song.id,
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
+      select: {
+        id: true,
+        fileUrl: true,
+        fileName: true,
+        createdAt: true,
+      },
+    });
+
     return {
       song: {
         id: song.id,
@@ -230,6 +267,10 @@ export class SongsPrismaRepository implements SongsRepository {
         key: song.key,
         bpm: song.bpm,
         difficultyLevel: song.difficultyLevel,
+        songCoverUrl: song.songCoverUrl,
+        songLength: song.songLength,
+        externalLinks: song.externalLinks,
+        referenceFiles: this.mapReferenceFiles(referenceFiles),
         userId: input.userId,
         createdAt: song.createdAt.toISOString(),
       },
@@ -265,6 +306,24 @@ export class SongsPrismaRepository implements SongsRepository {
       }
     }
 
+    if (input.referenceFiles !== undefined) {
+      await client.songReferenceFile.deleteMany({
+        where: {
+          songId,
+        },
+      });
+
+      if (input.referenceFiles.length > 0) {
+        await client.songReferenceFile.createMany({
+          data: input.referenceFiles.map(referenceFile => ({
+            songId,
+            fileUrl: referenceFile.fileUrl,
+            fileName: referenceFile.fileName,
+          })),
+        });
+      }
+    }
+
     const updatedSong = await client.song.update({
       where: {
         id: songId,
@@ -283,6 +342,11 @@ export class SongsPrismaRepository implements SongsRepository {
             skillTypeId: 'asc',
           },
         },
+        referenceFiles: {
+          orderBy: {
+            createdAt: 'asc',
+          },
+        },
       },
     });
 
@@ -298,6 +362,10 @@ export class SongsPrismaRepository implements SongsRepository {
         key: updatedSong.key,
         bpm: updatedSong.bpm,
         difficultyLevel: updatedSong.difficultyLevel,
+        songCoverUrl: updatedSong.songCoverUrl,
+        songLength: updatedSong.songLength,
+        externalLinks: updatedSong.externalLinks,
+        referenceFiles: this.mapReferenceFiles(updatedSong.referenceFiles),
         updatedAt: updatedSong.updatedAt.toISOString(),
         skills: updatedSong.songSkills.map(songSkill => ({
           skillTypeId: songSkill.skillTypeId,
@@ -378,7 +446,28 @@ export class SongsPrismaRepository implements SongsRepository {
       data.memo = input.memo;
     }
 
+    if (input.songCoverUrl !== undefined) {
+      data.songCoverUrl = input.songCoverUrl;
+    }
+
+    if (input.songLength !== undefined) {
+      data.songLength = input.songLength;
+    }
+
+    if (input.externalLinks !== undefined) {
+      data.externalLinks = { set: input.externalLinks };
+    }
+
     return data;
+  }
+
+  private mapReferenceFiles(referenceFiles: { id: string; fileUrl: string; fileName: string; createdAt: Date }[]): SongReferenceFileItem[] {
+    return referenceFiles.map(referenceFile => ({
+      id: referenceFile.id,
+      fileUrl: referenceFile.fileUrl,
+      fileName: referenceFile.fileName,
+      createdAt: referenceFile.createdAt.toISOString(),
+    }));
   }
 
   private mapSongListItem(
@@ -393,6 +482,7 @@ export class SongsPrismaRepository implements SongsRepository {
             };
           };
         };
+        referenceFiles: true;
       };
     }>,
   ): SongListItem {
@@ -406,6 +496,10 @@ export class SongsPrismaRepository implements SongsRepository {
       difficultyLevel: song.difficultyLevel,
       sourceUrl: song.sourceUrl,
       sourceType: song.sourceType as SongSourceType | null,
+      songCoverUrl: song.songCoverUrl,
+      songLength: song.songLength,
+      externalLinks: song.externalLinks,
+      referenceFiles: this.mapReferenceFiles(song.referenceFiles),
       createdAt: song.createdAt.toISOString(),
       skills: song.songSkills.map(songSkill => ({
         skillTypeId: songSkill.skillTypeId,

--- a/backend/src/modules/songs/songs.service.spec.ts
+++ b/backend/src/modules/songs/songs.service.spec.ts
@@ -140,6 +140,17 @@ describe('SongsService', () => {
         key: null,
         bpm: null,
         difficultyLevel: null,
+        songCoverUrl: 'https://storage.example.com/song-covers/uuid.jpg',
+        songLength: 355,
+        externalLinks: ['https://youtube.com/watch?v=uuid'],
+        referenceFiles: [
+          {
+            id: 'reference-file-id',
+            fileUrl: 'https://storage.example.com/song-references/uuid.pdf',
+            fileName: '악보_1절.pdf',
+            createdAt: '2026-05-20T00:00:00.000Z',
+          },
+        ],
         userId: 'user-id',
         createdAt: '2026-05-20T00:00:00.000Z',
       },
@@ -162,6 +173,10 @@ describe('SongsService', () => {
       sourceType: 'DEEZER',
       memo: '후렴 진입 전 드럼 큐 확인',
       skillTypeIds: ['skill-type-1', 'skill-type-2'],
+      songCoverUrl: 'https://storage.example.com/song-covers/uuid.jpg',
+      songLength: 355,
+      externalLinks: ['https://youtube.com/watch?v=uuid'],
+      referenceFiles: [{ fileUrl: 'https://storage.example.com/song-references/uuid.pdf', fileName: '악보_1절.pdf' }],
     });
 
     expect(repository.findActiveBandWithMemberByBandIdAndUserId).toHaveBeenCalledWith('band-id', 'user-id', transactionClient);
@@ -174,6 +189,10 @@ describe('SongsService', () => {
         sourceType: 'DEEZER',
         memo: '후렴 진입 전 드럼 큐 확인',
         skillTypeIds: ['skill-type-1', 'skill-type-2'],
+        songCoverUrl: 'https://storage.example.com/song-covers/uuid.jpg',
+        songLength: 355,
+        externalLinks: ['https://youtube.com/watch?v=uuid'],
+        referenceFiles: [{ fileUrl: 'https://storage.example.com/song-references/uuid.pdf', fileName: '악보_1절.pdf' }],
         bandId: 'band-id',
         userId: 'user-id',
         createdByBandMemberId: 'band-member-id',
@@ -181,6 +200,7 @@ describe('SongsService', () => {
       transactionClient,
     );
     expect(result.song.userId).toBe('user-id');
+    expect(result.song.referenceFiles).toHaveLength(1);
   });
 
   it('상위 트랜잭션이 있으면 새 트랜잭션을 열지 않는다', async () => {
@@ -206,6 +226,10 @@ describe('SongsService', () => {
         key: null,
         bpm: null,
         difficultyLevel: null,
+        songCoverUrl: null,
+        songLength: null,
+        externalLinks: [],
+        referenceFiles: [],
         userId: 'user-id',
         createdAt: '2026-05-20T00:00:00.000Z',
       },
@@ -323,6 +347,10 @@ describe('SongsService', () => {
           difficultyLevel: null,
           sourceUrl: 'https://www.deezer.com/track/3135556',
           sourceType: 'DEEZER',
+          songCoverUrl: null,
+          songLength: null,
+          externalLinks: [],
+          referenceFiles: [],
           createdAt: '2026-05-20T00:00:00.000Z',
           skills: [
             {
@@ -424,6 +452,10 @@ describe('SongsService', () => {
         key: null,
         bpm: null,
         difficultyLevel: null,
+        songCoverUrl: null,
+        songLength: null,
+        externalLinks: [],
+        referenceFiles: [],
         updatedAt: '2026-05-20T00:00:00.000Z',
         skills: [
           {
@@ -471,6 +503,10 @@ describe('SongsService', () => {
         key: null,
         bpm: null,
         difficultyLevel: null,
+        songCoverUrl: null,
+        songLength: null,
+        externalLinks: [],
+        referenceFiles: [],
         updatedAt: '2026-05-20T00:00:00.000Z',
         skills: [],
       },
@@ -481,6 +517,46 @@ describe('SongsService', () => {
     expect(prisma.$transaction).not.toHaveBeenCalled();
     expect(repository.findSongWithBandMemberBySongIdAndUserId).toHaveBeenCalledWith('song-id', 'user-id', tx);
     expect(repository.updateSong).toHaveBeenCalledWith('song-id', { memo: null }, tx);
+  });
+
+  it('곡 수정 시 신규 미디어 필드만 전달해도 수정할 수 있다', async () => {
+    const { service, repository, transactionClient } = createService();
+
+    repository.findSongWithBandMemberBySongIdAndUserId.mockResolvedValue({
+      id: 'song-id',
+      bandId: 'band-id',
+      member: {
+        id: 'band-member-id',
+        userId: 'user-id',
+      },
+    });
+    repository.updateSong.mockResolvedValue({
+      song: {
+        id: 'song-id',
+        bandId: 'band-id',
+        title: 'Song',
+        artistName: 'Artist',
+        sourceUrl: null,
+        sourceType: null,
+        memo: null,
+        key: null,
+        bpm: null,
+        difficultyLevel: null,
+        songCoverUrl: null,
+        songLength: 355,
+        externalLinks: [],
+        referenceFiles: [],
+        updatedAt: '2026-05-20T00:00:00.000Z',
+        skills: [],
+      },
+    });
+
+    const input = { songCoverUrl: null, songLength: 355, externalLinks: [], referenceFiles: [] };
+
+    const result = await service.updateSong('user-id', 'song-id', input);
+
+    expect(repository.updateSong).toHaveBeenCalledWith('song-id', input, transactionClient);
+    expect(result.song.songLength).toBe(355);
   });
 
   it('곡 수정 본문이 비어 있으면 BadRequestException을 던진다', async () => {

--- a/backend/src/modules/songs/songs.service.ts
+++ b/backend/src/modules/songs/songs.service.ts
@@ -229,8 +229,23 @@ export class SongsService {
     const hasSourceType = input.sourceType !== undefined;
     const hasMemo = input.memo !== undefined;
     const hasSkillTypeIds = input.skillTypeIds !== undefined;
+    const hasSongCoverUrl = input.songCoverUrl !== undefined;
+    const hasSongLength = input.songLength !== undefined;
+    const hasExternalLinks = input.externalLinks !== undefined;
+    const hasReferenceFiles = input.referenceFiles !== undefined;
 
-    if (!hasTitle && !hasArtistName && !hasSourceUrl && !hasSourceType && !hasMemo && !hasSkillTypeIds) {
+    if (
+      !hasTitle &&
+      !hasArtistName &&
+      !hasSourceUrl &&
+      !hasSourceType &&
+      !hasMemo &&
+      !hasSkillTypeIds &&
+      !hasSongCoverUrl &&
+      !hasSongLength &&
+      !hasExternalLinks &&
+      !hasReferenceFiles
+    ) {
       throw new BadRequestException('수정할 곡 정보가 필요합니다.');
     }
   }

--- a/backend/src/modules/songs/types/create-song-result.type.ts
+++ b/backend/src/modules/songs/types/create-song-result.type.ts
@@ -1,6 +1,7 @@
 import type { SongKey } from '../../../generated/prisma';
 
 import type { SongSourceType } from './song-preview.type';
+import type { SongReferenceFileItem } from './song-reference-file.type';
 
 export interface CreatedSongSkillType {
   id: string;
@@ -19,6 +20,10 @@ export interface CreateSongResult {
     key: SongKey | null;
     bpm: number | null;
     difficultyLevel: number | null;
+    songCoverUrl: string | null;
+    songLength: number | null;
+    externalLinks: string[];
+    referenceFiles: SongReferenceFileItem[];
     userId: string;
     createdAt: string;
   };

--- a/backend/src/modules/songs/types/song-list.type.ts
+++ b/backend/src/modules/songs/types/song-list.type.ts
@@ -1,6 +1,7 @@
 import type { SongKey } from '../../../generated/prisma';
 
 import type { SongSourceType } from './song-preview.type';
+import type { SongReferenceFileItem } from './song-reference-file.type';
 
 export interface SongListSkillItem {
   skillTypeId: string;
@@ -17,6 +18,10 @@ export interface SongListItem {
   difficultyLevel: number | null;
   sourceUrl: string | null;
   sourceType: SongSourceType | null;
+  songCoverUrl: string | null;
+  songLength: number | null;
+  externalLinks: string[];
+  referenceFiles: SongReferenceFileItem[];
   createdAt: string;
   skills: SongListSkillItem[];
 }

--- a/backend/src/modules/songs/types/song-reference-file.type.ts
+++ b/backend/src/modules/songs/types/song-reference-file.type.ts
@@ -1,0 +1,6 @@
+export interface SongReferenceFileItem {
+  id: string;
+  fileUrl: string;
+  fileName: string;
+  createdAt: string;
+}

--- a/backend/src/modules/songs/types/update-song-result.type.ts
+++ b/backend/src/modules/songs/types/update-song-result.type.ts
@@ -2,6 +2,7 @@ import type { SongKey } from '../../../generated/prisma';
 
 import type { SongListSkillItem } from './song-list.type';
 import type { SongSourceType } from './song-preview.type';
+import type { SongReferenceFileItem } from './song-reference-file.type';
 
 export interface UpdateSongResult {
   song: {
@@ -15,6 +16,10 @@ export interface UpdateSongResult {
     key: SongKey | null;
     bpm: number | null;
     difficultyLevel: number | null;
+    songCoverUrl: string | null;
+    songLength: number | null;
+    externalLinks: string[];
+    referenceFiles: SongReferenceFileItem[];
     updatedAt: string;
     skills: SongListSkillItem[];
   };


### PR DESCRIPTION
## ⏱ 소요 시간
- 리뷰 예상 시간: 20분

## 📌 작업 요약
곡 생성/수정 API에 커버 이미지(songCoverUrl), 참고자료 파일(다중), 외부 링크(다중), 곡 길이(songLength) 필드를 추가했다.

## 📝 작업 내용
1. `Song` 모델에 `songCoverUrl`·`songLength`·`externalLinks` 필드 추가, 참고자료 파일 다중 업로드를 위한 `SongReferenceFile` 테이블 신규 추가
2. 곡 생성(#24)/수정(#26) DTO에 신규 필드 반영, 목록 조회(#25) 응답에도 노출
3. Repository/Service에 신규 필드 CRUD 로직 반영 및 단위 테스트 추가 (happy path, PATCH 전체 교체, null 삭제 등)
4. API 명세(`docs/backend/api-docs/song.md`), 설계 문서(`docs/backend/designs/songs/song-media-fields.md`) 갱신

## 🚨 주요 고민 및 해결 과정
### 문제
외부 링크(다중)를 배열 컬럼으로 둘지 별도 테이블로 분리할지, 그리고 참고자료 파일/외부링크를 PATCH에서 부분 갱신할지 전체 교체할지 결정이 필요했다.

### 해결 과정
외부 링크는 라벨 없이 URL만 필요해 `externalLinks String[]` 배열 컬럼으로, 참고자료 파일은 다중 업로드 + 파일명 메타데이터가 필요해 별도 테이블(`SongReferenceFile`)로 분리했다. PATCH 갱신은 기존 `skillTypeIds` 패턴과 동일하게 "전달 시 전체 교체(빈 배열 시 전체 삭제), 미전달 시 유지"로 통일해 기존 API와 일관성을 유지했다.

## 📑 참고 문서/ ADR
- docs/backend/designs/songs/song-media-fields.md
- docs/backend/api-docs/song.md (#24 곡 생성, #25 밴드 곡 목록 조회, #26 곡 수정)

## 💬 리뷰 요구사항
- 목록 조회(#25) 응답에 `referenceFiles`를 전체 포함하도록 했습니다 (기존 `skills` 임베딩 패턴과 동일). 현재 단일 곡 상세 조회 API가 없어 목록이 유일한 조회 경로라 이렇게 결정했는데, 파일 수가 많아질 경우 payload 크기가 우려되면 알려주세요.
- 스키마 반영은 기존 마이그레이션 히스토리 drift(마이그레이션 재생 시 `band_genres` 제약조건 불일치)로 `prisma migrate dev`가 막혀 있어, `prisma db push`로 개발 DB에 직접 반영했습니다. 마이그레이션 히스토리 정리는 별도 이슈로 남겨두었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 곡 생성/수정/목록 조회에 커버 이미지, 곡 길이, 외부 링크, 참고자료 파일 정보가 추가되었습니다.
  * 참고자료 파일과 외부 링크는 여러 항목을 등록할 수 있으며, 응답에 함께 제공됩니다.
* **Bug Fixes**
  * 곡 수정 시 미디어 정보만 전달해도 정상 저장되도록 개선했습니다.
  * `null` 전달 시 해당 값은 삭제되고, 외부 링크/참고자료는 전달된 방식에 따라 전체 교체 또는 빈 배열 시 삭제됩니다.
* **Documentation**
  * 곡 API 문서의 요청/응답 형식 및 삭제 규칙이 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->