### PR TITLE
밴드 초대 단건 조회 API 추가

### DIFF
--- a/backend/docs/backend/api-docs/band-invitation.md
+++ b/backend/docs/backend/api-docs/band-invitation.md
@@ -305,3 +305,50 @@
 | 코드 | 조건 |
 |------|------|
 | 401 | 인증 실패 (JWT 없음 또는 만료) |
+
+---
+
+## #20 GET /invitations/{invitationId}
+
+**설명:** 초대받은 사용자가 자신의 밴드 초대를 단건으로 조회한다.
+**인증:** 필요 (JWT Bearer)
+**권한:** 초대받은 사용자 본인만 조회 가능
+
+### Request
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| invitationId | string (UUID) | ✅ | 초대 ID |
+
+### Response 200
+
+```json
+{
+  "data": {
+    "invitationId": "uuid",
+    "band": {
+      "bandId": "uuid",
+      "name": "Rocking Stars",
+      "description": "직장인 밴드"
+    },
+    "inviter": {
+      "userId": "uuid",
+      "nickname": "Jun"
+    },
+    "message": "같이 밴드 하실래요?",
+    "invitationStatus": "PENDING",
+    "createdAt": "2026-04-30T10:00:00.000Z"
+  },
+  "success": true
+}
+```
+
+### Error
+
+| 코드 | 조건 |
+|------|------|
+| 401 | 인증 실패 (JWT 없음 또는 만료) |
+| 403 | 권한 없음 (본인이 받은 초대가 아님) |
+| 404 | 초대 없음 |

--- a/backend/src/modules/bands/band-invitations.controller.ts
+++ b/backend/src/modules/bands/band-invitations.controller.ts
@@ -10,7 +10,7 @@ import { GetSentBandInvitationsQueryDto } from './dto/get-sent-band-invitations-
 import type { AcceptBandInvitationResult } from './types/accept-band-invitation-result.type';
 import type { DeclineBandInvitationResult } from './types/decline-band-invitation-result.type';
 import type { DeleteBandInvitationResult } from './types/delete-band-invitation-result.type';
-import type { GetReceivedBandInvitationsResult } from './types/received-band-invitation-list.type';
+import type { GetReceivedBandInvitationsResult, ReceivedBandInvitationListItem } from './types/received-band-invitation-list.type';
 import type { GetSentBandInvitationsResult } from './types/sent-band-invitation-list.type';
 import { BandsService } from './bands.service';
 
@@ -50,6 +50,23 @@ export class BandInvitationsController {
     const invitations = await this.bandsService.getSentBandInvitations(request.user.id, query);
 
     return createSuccessResponse('보낸 초대 목록 조회 성공', invitations);
+  }
+
+  @Get(':invitationId')
+  @UseGuards(AccessTokenGuard)
+  @ApiOperation({ summary: '밴드 초대 단건 조회' })
+  @ApiParam({ name: 'invitationId', description: '초대 ID (UUID)', type: String })
+  @ApiResponse({ status: 200, description: '초대 조회 성공' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  @ApiResponse({ status: 404, description: '초대를 찾을 수 없음' })
+  async getBandInvitation(
+    @Req() request: AuthenticatedRequest,
+    @Param('invitationId') invitationId: string,
+  ): Promise<ApiSuccessResponse<ReceivedBandInvitationListItem>> {
+    const invitation = await this.bandsService.getBandInvitationDetail(request.user.id, invitationId);
+
+    return createSuccessResponse('초대 조회 성공', invitation);
   }
 
   @Post(':invitationId/accept')

--- a/backend/src/modules/bands/bands.service.spec.ts
+++ b/backend/src/modules/bands/bands.service.spec.ts
@@ -73,6 +73,14 @@ function createBandsRepositoryStub(options?: {
     status: 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'EXPIRED';
     inviterUserId: string;
   } | null;
+  bandInvitationDetail?: {
+    invitationId: string;
+    band: { bandId: string; name: string; description: string | null };
+    inviter: { userId: string; nickname: string };
+    message: string | null;
+    invitationStatus: 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'EXPIRED';
+    createdAt: string;
+  } | null;
   bandBlacklist?: { id: string } | null;
   onAcceptBandInvitation?: (invitationId: string, bandId: string, userId: string, respondedAt: Date, tx: unknown) => void;
   onApproveBandJoinRequest?: (joinRequestId: string, bandId: string, userId: string, tx: unknown) => void;
@@ -89,6 +97,7 @@ function createBandsRepositoryStub(options?: {
   onFindBandForJoinRequest?: (tx: unknown) => void;
   onFindBandInvitationForDelete?: (tx: unknown) => void;
   onFindBandInvitationForResponse?: (tx: unknown) => void;
+  onFindBandInvitationDetail?: (tx: unknown) => void;
   onFindBandInvitationByBandIdAndInviteeUserId?: (tx: unknown) => void;
   onFindBandJoinRequestByBandIdAndUserId?: (tx: unknown) => void;
   onFindBandJoinRequestForResponse?: (tx: unknown) => void;
@@ -566,6 +575,29 @@ function createBandsRepositoryStub(options?: {
         inviterUserId: BAND_MASTER_USER_ID,
         inviteeUserId: INVITEE_USER_ID,
         status: 'PENDING',
+      };
+    },
+    async findBandInvitationDetail(_invitationId, tx) {
+      options?.onFindBandInvitationDetail?.(tx);
+
+      if (options?.bandInvitationDetail !== undefined) {
+        return options.bandInvitationDetail;
+      }
+
+      return {
+        invitationId: 'invitation-001',
+        band: {
+          bandId: 'band-001',
+          name: 'Rocking Stars',
+          description: '직장인 밴드',
+        },
+        inviter: {
+          userId: BAND_MASTER_USER_ID,
+          nickname: 'Jun',
+        },
+        message: '같이 밴드 하실래요?',
+        invitationStatus: 'PENDING',
+        createdAt: '2026-04-30T10:00:00.000Z',
       };
     },
     async findBandInvitationForDelete(_invitationId, tx) {
@@ -1905,6 +1937,67 @@ describe('BandsService', () => {
       );
 
       expect(capturedTransaction).toBe(externalTx);
+    });
+  });
+
+  describe('getBandInvitationDetail', () => {
+    it('초대받은 사용자가 자신의 초대를 단건 조회한다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      const result = await service.getBandInvitationDetail(INVITEE_USER_ID, 'invitation-001');
+
+      expect(result).toEqual({
+        invitationId: 'invitation-001',
+        band: {
+          bandId: 'band-001',
+          name: 'Rocking Stars',
+          description: '직장인 밴드',
+        },
+        inviter: {
+          userId: BAND_MASTER_USER_ID,
+          nickname: 'Jun',
+        },
+        message: '같이 밴드 하실래요?',
+        invitationStatus: 'PENDING',
+        createdAt: '2026-04-30T10:00:00.000Z',
+      });
+    });
+
+    it('초대가 없으면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub({
+        invitationForResponse: null,
+      });
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.getBandInvitationDetail(INVITEE_USER_ID, 'invitation-missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('초대받은 사용자가 아니면 예외를 던진다', async () => {
+      const repository = createBandsRepositoryStub();
+      const service = new BandsService(repository, createPrismaServiceStub());
+
+      await expect(service.getBandInvitationDetail(BAND_MASTER_USER_ID, 'invitation-001')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('외부 transaction client를 repository로 전달한다', async () => {
+      const externalTx = {
+        transactionClient: true,
+      };
+      const capturedTransactions: unknown[] = [];
+      const repository = createBandsRepositoryStub({
+        onFindBandInvitationForResponse(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBandInvitationDetail(tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandsService(repository, createPrismaServiceFailingTransactionStub());
+
+      await service.getBandInvitationDetail(INVITEE_USER_ID, 'invitation-001', externalTx as never);
+
+      expect(capturedTransactions).toEqual([externalTx, externalTx]);
     });
   });
 

--- a/backend/src/modules/bands/bands.service.ts
+++ b/backend/src/modules/bands/bands.service.ts
@@ -31,7 +31,7 @@ import type { DeleteBandResult } from './types/delete-band-result.type';
 import type { GetBandResult } from './types/get-band-result.type';
 import type { LeaveBandResult } from './types/leave-band-result.type';
 import type { GetMyBandsResult } from './types/my-band-list.type';
-import type { GetReceivedBandInvitationsResult } from './types/received-band-invitation-list.type';
+import type { GetReceivedBandInvitationsResult, ReceivedBandInvitationListItem } from './types/received-band-invitation-list.type';
 import type { RejectBandJoinRequestResult } from './types/reject-band-join-request-result.type';
 import type { GetSentBandInvitationsResult } from './types/sent-band-invitation-list.type';
 import type { GetSentBandJoinRequestsResult } from './types/sent-band-join-request-list.type';
@@ -287,6 +287,34 @@ export class BandsService {
     tx?: Prisma.TransactionClient,
   ): Promise<GetReceivedBandInvitationsResult> {
     return this.bandsRepository.findReceivedBandInvitations(userId, query, tx);
+  }
+
+  /**
+   * 초대받은 사용자만 자신의 밴드 초대를 단건으로 조회할 수 있다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} invitationId - 조회할 초대 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<ReceivedBandInvitationListItem>} 초대 상세 정보
+   */
+  async getBandInvitationDetail(userId: string, invitationId: string, tx?: Prisma.TransactionClient): Promise<ReceivedBandInvitationListItem> {
+    const invitation = await this.bandsRepository.findBandInvitationForResponse(invitationId, tx);
+
+    if (invitation === null) {
+      throw new NotFoundException('요청한 밴드 초대를 찾을 수 없습니다.');
+    }
+
+    if (invitation.inviteeUserId !== userId) {
+      throw new ForbiddenException('밴드 초대 조회 권한이 없습니다.');
+    }
+
+    const detail = await this.bandsRepository.findBandInvitationDetail(invitationId, tx);
+
+    if (detail === null) {
+      throw new NotFoundException('요청한 밴드 초대를 찾을 수 없습니다.');
+    }
+
+    return detail;
   }
 
   /**

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.spec.ts
@@ -646,6 +646,90 @@ describe('BandsPrismaRepository', () => {
     });
   });
 
+  describe('findBandInvitationDetail', () => {
+    it('초대 ID로 초대 상세 정보를 조회하고 매핑한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.findFirst.mockResolvedValue({
+        id: 'invitation-001',
+        message: '같이 밴드 하실래요?',
+        status: 'PENDING',
+        createdAt: mockCreatedAt,
+        band: {
+          id: 'band-001',
+          name: 'Rocking Stars',
+          description: '직장인 밴드',
+        },
+        inviterBandMember: {
+          userId: 'user-001',
+          user: {
+            profile: {
+              nickname: 'Jun',
+            },
+          },
+        },
+      });
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findBandInvitationDetail('invitation-001');
+
+      expect(prisma.bandInvitation.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 'invitation-001',
+          band: {
+            deletedAt: null,
+          },
+        },
+        include: {
+          band: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+            },
+          },
+          inviterBandMember: {
+            include: {
+              user: {
+                include: {
+                  profile: {
+                    select: {
+                      nickname: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(result).toEqual({
+        invitationId: 'invitation-001',
+        band: {
+          bandId: 'band-001',
+          name: 'Rocking Stars',
+          description: '직장인 밴드',
+        },
+        inviter: {
+          userId: 'user-001',
+          nickname: 'Jun',
+        },
+        message: '같이 밴드 하실래요?',
+        invitationStatus: 'PENDING',
+        createdAt: '2026-04-10T12:00:00.000Z',
+      });
+    });
+
+    it('초대가 없으면 null을 반환한다', async () => {
+      const prisma = createPrismaMock();
+      prisma.bandInvitation.findFirst.mockResolvedValue(null);
+      const repository = new BandsPrismaRepository(prisma as unknown as PrismaService);
+
+      const result = await repository.findBandInvitationDetail('invitation-missing');
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe('acceptBandInvitation', () => {
     it('밴드 멤버를 생성하고 초대 상태를 ACCEPTED로 변경한다', async () => {
       const prisma = createPrismaMock();

--- a/backend/src/modules/bands/repositories/bands.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/bands.prisma-repository.ts
@@ -893,6 +893,50 @@ export class BandsPrismaRepository implements BandsRepository {
   }
 
   /**
+   * 초대 ID로 밴드 초대 상세 정보를 단건 조회한다.
+   *
+   * @param {string} invitationId - 조회할 초대 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<ReceivedBandInvitationListItem | null>} 초대 상세 정보
+   */
+  async findBandInvitationDetail(invitationId: string, tx?: Prisma.TransactionClient): Promise<ReceivedBandInvitationListItem | null> {
+    const client = tx ?? this.prisma;
+
+    const invitation = await client.bandInvitation.findFirst({
+      where: {
+        id: invitationId,
+        band: {
+          deletedAt: null,
+        },
+      },
+      include: {
+        band: {
+          select: {
+            id: true,
+            name: true,
+            description: true,
+          },
+        },
+        inviterBandMember: {
+          include: {
+            user: {
+              include: {
+                profile: {
+                  select: {
+                    nickname: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return invitation === null ? null : this.mapReceivedBandInvitationListItem(invitation);
+  }
+
+  /**
    * 인증 사용자가 직접 보낸 초대를 상태와 커서 기준으로 조회한다.
    *
    * @param {string} userId - 인증된 사용자 ID

--- a/backend/src/modules/bands/repositories/bands.repository.ts
+++ b/backend/src/modules/bands/repositories/bands.repository.ts
@@ -25,7 +25,7 @@ import type { DeleteBandResult } from '../types/delete-band-result.type';
 import type { GetBandResult } from '../types/get-band-result.type';
 import type { LeaveBandResult } from '../types/leave-band-result.type';
 import type { GetMyBandsResult } from '../types/my-band-list.type';
-import type { GetReceivedBandInvitationsResult } from '../types/received-band-invitation-list.type';
+import type { GetReceivedBandInvitationsResult, ReceivedBandInvitationListItem } from '../types/received-band-invitation-list.type';
 import type { RejectBandJoinRequestResult } from '../types/reject-band-join-request-result.type';
 import type { GetSentBandInvitationsResult } from '../types/sent-band-invitation-list.type';
 import type { GetSentBandJoinRequestsResult } from '../types/sent-band-join-request-list.type';
@@ -93,6 +93,7 @@ export interface BandsRepository {
     query: GetReceivedBandInvitationsQuery,
     tx?: Prisma.TransactionClient,
   ): Promise<GetReceivedBandInvitationsResult>;
+  findBandInvitationDetail(invitationId: string, tx?: Prisma.TransactionClient): Promise<ReceivedBandInvitationListItem | null>;
   findSentBandInvitations(userId: string, query: GetSentBandInvitationsQuery, tx?: Prisma.TransactionClient): Promise<GetSentBandInvitationsResult>;
   findSentBandJoinRequests(
     userId: string,


### PR DESCRIPTION
## ⏱ 소요 시간
- 리뷰 예상 시간: 5분

## 📌 작업 요약
받은 밴드 초대를 초대 ID로 단건 조회하는 API를 추가했습니다.

## 📝 작업 내용
1. `GET /invitations/{invitationId}` 엔드포인트 추가 (`BandInvitationsController`)
2. `BandsService.getBandInvitationDetail` 추가 — 초대 존재 여부(404), 초대받은 사용자 본인 여부(403) 검증
3. `BandsRepository.findBandInvitationDetail` 추가 — 기존 "받은 초대 목록" 조회와 동일한 응답 형태로 상세 조회
4. Service/Repository 단위 테스트 추가



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 받은 밴드 초대를 초대 ID로 조회할 수 있는 기능을 추가했습니다.
  * 초대 상세 정보, 밴드 정보, 초대자, 메시지, 상태 및 생성일을 확인할 수 있습니다.
  * 본인이 받은 초대만 조회할 수 있으며, 인증·권한·존재 여부에 따른 오류 안내를 제공합니다.

* **문서**
  * 초대 상세 조회 API 사용법과 응답 및 오류 형식을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->