### PR TITLE
밴드 초대 링크 발급 및 코드 가입 API 추가

### DIFF
--- a/backend/docs/backend/api-docs/README.md
+++ b/backend/docs/backend/api-docs/README.md
@@ -9,6 +9,7 @@ API 엔드포인트, 요청 DTO, 응답 DTO, 응답 예시를 작성하거나 �
 - [유저 API 명세](./users.md)
 - [밴드 API 명세](./band.md)
 - [밴드 초대 API 명세](./band-invitation.md)
+- [밴드 초대 링크 API 명세](./band-invite-link.md)
 - [밴드 가입 요청 API 명세](./band-join-request.md)
 - [곡 API 명세](./song.md)
 - [합주 공간 관리 API 명세](./bandspaces.md)

--- a/backend/docs/backend/api-docs/band-invite-link.md
+++ b/backend/docs/backend/api-docs/band-invite-link.md
@@ -1,0 +1,138 @@
+# 밴드 초대 링크 API
+
+밴드 운영자가 초대 코드를 발급·재발급·폐기하고, 인증 사용자가 유효한 코드로 밴드에 가입하는 API를 정리한다.
+
+> 최초 작성: 2026-07-28
+>
+> 기존 통합 명세의 `#51 밴드 초대 링크 생성`은 정책이 정해지지 않은 채 MVP 제외로 남아 있었다. 이번 구현에서 권한, 가입 방식, 만료, 재사용, 재발급, 폐기 정책을 확정했다.
+
+## 정책
+
+- `BM`과 `ADMIN`만 링크를 발급·재발급·폐기할 수 있다.
+- 링크 발급은 가입을 미리 승인한 것으로 보며, 유효한 코드를 사용한 인증 사용자는 즉시 `MEMBER`가 된다.
+- 공개·비공개 밴드 모두 링크 가입을 허용한다.
+- 밴드에서 차단된 사용자는 링크로 가입할 수 없다.
+- 링크는 발급 후 7일 동안 여러 사용자가 재사용할 수 있다.
+- 밴드마다 링크를 하나만 유지하며, 재발급하면 기존 코드는 즉시 무효화된다.
+- 원본 코드는 발급 응답에서 한 번만 반환하고 DB에는 SHA-256 해시를 저장한다.
+
+## API 목록
+
+| 메서드 | 경로 | 설명 |
+|--------|------|------|
+| POST | `/bands/:bandId/invite-link` | 초대 링크 발급·재발급 |
+| DELETE | `/bands/:bandId/invite-link` | 초대 링크 폐기 |
+| POST | `/invite-links/:code/join` | 초대 코드로 밴드 가입 |
+
+---
+
+## 초대 링크 발급·재발급
+
+- Method: `POST`
+- Path: `/bands/:bandId/invite-link`
+- 인증: AccessToken
+- 권한: `BM`, `ADMIN`
+- Request Body: 없음
+
+### Path Parameters
+
+| 이름 | 타입 | 설명 |
+|------|------|------|
+| `bandId` | UUID | 대상 밴드 ID |
+
+### Response 201
+
+```json
+{
+  "success": true,
+  "message": "밴드 초대 링크를 발급했습니다.",
+  "data": {
+    "bandId": "uuid",
+    "inviteCode": "7KQ2M9ABCD3FE8NP",
+    "expiredAt": "2026-08-04T00:00:00.000Z"
+  }
+}
+```
+
+`inviteCode`는 이 응답에서만 확인할 수 있다. 프론트엔드는 `${window.location.origin}/invite-links/${inviteCode}` 형태로 링크를 만든다.
+
+### Error
+
+| 코드 | 조건 |
+|------|------|
+| 401 | 인증 실패 |
+| 403 | 밴드 멤버가 아니거나 `MEMBER` 역할 |
+| 404 | 삭제되지 않은 밴드를 찾을 수 없음 |
+
+---
+
+## 초대 링크 폐기
+
+- Method: `DELETE`
+- Path: `/bands/:bandId/invite-link`
+- 인증: AccessToken
+- 권한: `BM`, `ADMIN`
+
+### Response 200
+
+```json
+{
+  "success": true,
+  "message": "밴드 초대 링크를 폐기했습니다.",
+  "data": {
+    "bandId": "uuid",
+    "revokedAt": "2026-07-28T00:00:00.000Z"
+  }
+}
+```
+
+### Error
+
+| 코드 | 조건 |
+|------|------|
+| 401 | 인증 실패 |
+| 403 | 밴드 멤버가 아니거나 `MEMBER` 역할 |
+| 404 | 밴드 또는 폐기할 링크를 찾을 수 없음 |
+
+---
+
+## 초대 코드로 밴드 가입
+
+- Method: `POST`
+- Path: `/invite-links/:code/join`
+- 인증: AccessToken
+- Request Body: 없음
+
+### Path Parameters
+
+| 이름 | 타입 | 설명 |
+|------|------|------|
+| `code` | string | 발급받은 16자리 초대 코드 |
+
+코드는 앞뒤 공백을 제거하고 대문자로 변환한 뒤 검증한다.
+
+### Response 201
+
+```json
+{
+  "success": true,
+  "message": "밴드에 가입했습니다.",
+  "data": {
+    "bandId": "uuid",
+    "userId": "uuid",
+    "memberId": "uuid",
+    "joinedAt": "2026-07-28T00:00:00.000Z"
+  }
+}
+```
+
+가입에 성공하면 같은 밴드·사용자의 대기 중 직접 초대와 가입 요청을 함께 삭제한다.
+
+### Error
+
+| 코드 | 조건 |
+|------|------|
+| 401 | 인증 실패 |
+| 403 | 밴드에서 차단된 사용자 |
+| 404 | 코드가 없거나 링크가 만료·폐기됐거나 밴드가 삭제됨 |
+| 409 | 이미 밴드 멤버 |

--- a/backend/docs/backend/designs/bands/band-invite-link.md
+++ b/backend/docs/backend/designs/bands/band-invite-link.md
@@ -1,0 +1,89 @@
+# 밴드 초대 링크·코드 설계
+
+> 대상 모듈: `src/modules/bands`
+>
+> 관련 API 명세: [밴드 초대 링크 API](../../api-docs/band-invite-link.md)
+>
+> 결정일: 2026-07-28
+
+## 결정 배경
+
+기존 통합 명세에는 밴드 초대 링크가 `MVP 제외`로만 표시되어 있었고, 가입 승인 방식·코드 만료·재사용·재발급 정책은 정해져 있지 않았다.
+
+현재 직접 초대는 운영자가 특정 사용자를 지정하는 흐름이고, 가입 요청은 사용자가 공개 밴드에 승인을 요청하는 흐름이다. 링크 초대는 운영자가 불특정 사용자에게 가입 권한을 미리 공유하는 방식으로 구분했다. 링크를 사용한 뒤 다시 가입 승인을 받게 하면 기존 가입 요청과 역할이 겹치므로, 유효한 링크 사용자는 즉시 일반 멤버로 가입시킨다.
+
+## 정책
+
+- `BM`과 `ADMIN`만 발급·재발급·폐기 가능
+- 공개·비공개 밴드 모두 링크 가입 가능
+- 링크 사용자는 별도 승인 없이 `MEMBER`로 즉시 가입
+- 차단 사용자는 가입 불가
+- 7일 동안 여러 사용자가 재사용 가능
+- 밴드당 링크 하나만 유지
+- 재발급 시 기존 코드 즉시 무효화
+- 폐기 시 링크 row hard delete
+- 이미 가입한 사용자는 409
+- 가입 성공 시 대기 중 직접 초대와 가입 요청 삭제
+
+## 코드 보안
+
+코드는 `node:crypto.randomInt`로 생성한다. `0`, `O`, `1`, `I`를 제외한 32개 문자에서 16자를 선택해 80비트 경우의 수를 확보한다.
+
+원본 코드는 발급 응답에서 한 번만 반환하고 DB에는 SHA-256 해시를 저장한다. 사용자가 코드를 잃어버린 경우 재발급하며, 재발급과 동시에 기존 코드가 무효화된다.
+
+## 모듈 구성
+
+- `band-invite-links.controller.ts`: 요청 전달과 성공 응답 래핑
+- `band-invite-links.service.ts`: 권한·코드·만료·가입 정책
+- `repositories/band-invite-links.repository.ts`: Repository 인터페이스
+- `repositories/band-invite-links.prisma-repository.ts`: Prisma DB 접근
+- `types/band-invite-link.type.ts`: Service와 응답 타입
+
+링크 정책은 기존 `BandsService`에 추가하지 않고 같은 bands 도메인의 별도 Service로 분리한다.
+
+## Repository 인터페이스
+
+```typescript
+interface BandInviteLinksRepository {
+  findActiveBandWithRequesterMember(bandId, userId, tx?);
+  upsertBandInviteLink(input, tx?);
+  deleteBandInviteLinkByBandId(bandId, tx?);
+  findBandInviteLinkByCodeHash(codeHash, tx?);
+  findBandMemberByBandIdAndUserId(bandId, userId, tx?);
+  findBandBlacklistByBandIdAndUserId(bandId, userId, tx?);
+  createBandMember(bandId, userId, tx?);
+  deletePendingBandEntryRequests(bandId, userId, tx?);
+}
+```
+
+## DB 모델
+
+기존 `band_invite_link.code` 컬럼에는 원본 대신 해시를 저장한다. Prisma 필드명을 `codeHash`로 바꾸고 실제 컬럼명은 유지한다.
+
+```prisma
+model BandInviteLink {
+  codeHash String? @map("code") @db.VarChar(255)
+
+  @@unique([bandId])
+  @@unique([codeHash])
+}
+```
+
+`bandId` unique는 한 밴드당 링크 하나를, `codeHash` unique는 코드 중복 방지를 보장한다. 기존 데이터 호환을 위해 `codeHash`와 `expiredAt`의 nullable 속성은 유지한다.
+
+## 트랜잭션
+
+- 발급: 권한 조회와 링크 upsert를 같은 transaction client로 실행
+- 폐기: 권한 조회와 링크 hard delete를 같은 transaction client로 실행
+- 가입: 링크·멤버·차단 조회, 멤버 생성, 대기 항목 삭제를 같은 transaction client로 실행
+
+## 테스트
+
+- BM/ADMIN 발급, 일반 멤버·비멤버 거부
+- 7일 만료와 코드 해시 저장
+- 링크 폐기 및 없는 링크 처리
+- 코드 정규화, 만료·없는 코드 처리
+- 중복 멤버와 차단 사용자 처리
+- 멤버 생성과 대기 초대·가입 요청 정리
+- 트랜잭션 일관성과 외부 tx 전달
+- Prisma 조회·upsert·delete·멤버 생성 쿼리

--- a/backend/prisma/migrations/20260728110000_add_band_invite_link_constraints/migration.sql
+++ b/backend/prisma/migrations/20260728110000_add_band_invite_link_constraints/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "band_invite_link_band_id_key" ON "band_invite_link"("band_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "band_invite_link_code_key" ON "band_invite_link"("code");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -186,13 +186,15 @@ model BandInviteLink {
   id                 String     @id @default(uuid()) @db.Uuid
   bandId             String     @map("band_id") @db.Uuid
   createBandMemberId String     @map("create_band_member_id") @db.Uuid
-  code               String?    @db.VarChar(255)
+  codeHash           String?    @map("code") @db.VarChar(255)
   expiredAt          DateTime?  @map("expired_at") @db.Timestamptz(6)
   createdAt          DateTime   @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt          DateTime   @updatedAt @map("updated_at") @db.Timestamptz(6)
   band               Band       @relation(fields: [bandId], references: [id], onDelete: Cascade)
   createBandMember   BandMember @relation("BandInviteLinkCreator", fields: [createBandMemberId], references: [id], onDelete: Cascade)
 
+  @@unique([bandId])
+  @@unique([codeHash])
   @@map("band_invite_link")
 }
 

--- a/backend/src/modules/bands/band-invite-links.controller.ts
+++ b/backend/src/modules/bands/band-invite-links.controller.ts
@@ -1,0 +1,70 @@
+import { Controller, Delete, Param, Post, Req, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
+import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
+import type { AuthUser } from '../users/repositoreis/user.repository';
+
+import type { CreateBandInviteLinkResult, JoinBandByInviteLinkResult, RevokeBandInviteLinkResult } from './types/band-invite-link.type';
+import { BandInviteLinksService } from './band-invite-links.service';
+
+interface AuthenticatedRequest {
+  user: AuthUser;
+}
+
+@ApiTags('밴드 초대 링크')
+@ApiBearerAuth('access-token')
+@UseGuards(AccessTokenGuard)
+@Controller()
+export class BandInviteLinksController {
+  constructor(private readonly bandInviteLinksService: BandInviteLinksService) {}
+
+  @Post('bands/:bandId/invite-link')
+  @ApiOperation({ summary: '밴드 초대 링크 발급·재발급' })
+  @ApiParam({ name: 'bandId', description: '밴드 ID (UUID)', type: String })
+  @ApiResponse({ status: 201, description: '밴드 초대 링크 발급 성공' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  @ApiResponse({ status: 404, description: '밴드를 찾을 수 없음' })
+  async createBandInviteLink(
+    @Req() request: AuthenticatedRequest,
+    @Param('bandId') bandId: string,
+  ): Promise<ApiSuccessResponse<CreateBandInviteLinkResult>> {
+    const inviteLink = await this.bandInviteLinksService.createBandInviteLink(request.user.id, bandId);
+
+    return createSuccessResponse('밴드 초대 링크를 발급했습니다.', inviteLink);
+  }
+
+  @Delete('bands/:bandId/invite-link')
+  @ApiOperation({ summary: '밴드 초대 링크 폐기' })
+  @ApiParam({ name: 'bandId', description: '밴드 ID (UUID)', type: String })
+  @ApiResponse({ status: 200, description: '밴드 초대 링크 폐기 성공' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  @ApiResponse({ status: 404, description: '밴드 또는 초대 링크를 찾을 수 없음' })
+  async revokeBandInviteLink(
+    @Req() request: AuthenticatedRequest,
+    @Param('bandId') bandId: string,
+  ): Promise<ApiSuccessResponse<RevokeBandInviteLinkResult>> {
+    const revokedLink = await this.bandInviteLinksService.revokeBandInviteLink(request.user.id, bandId);
+
+    return createSuccessResponse('밴드 초대 링크를 폐기했습니다.', revokedLink);
+  }
+
+  @Post('invite-links/:code/join')
+  @ApiOperation({ summary: '밴드 초대 링크 가입' })
+  @ApiParam({ name: 'code', description: '밴드 초대 코드', type: String })
+  @ApiResponse({ status: 201, description: '밴드 초대 링크 가입 성공' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  @ApiResponse({ status: 403, description: '차단된 사용자' })
+  @ApiResponse({ status: 404, description: '유효한 초대 링크를 찾을 수 없음' })
+  @ApiResponse({ status: 409, description: '이미 밴드 멤버' })
+  async joinBandByInviteLink(
+    @Req() request: AuthenticatedRequest,
+    @Param('code') code: string,
+  ): Promise<ApiSuccessResponse<JoinBandByInviteLinkResult>> {
+    const joinedBand = await this.bandInviteLinksService.joinBandByInviteLink(request.user.id, code);
+
+    return createSuccessResponse('밴드에 가입했습니다.', joinedBand);
+  }
+}

--- a/backend/src/modules/bands/band-invite-links.service.spec.ts
+++ b/backend/src/modules/bands/band-invite-links.service.spec.ts
@@ -1,0 +1,356 @@
+import { createHash } from 'node:crypto';
+
+import { ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
+
+import type { PrismaService } from '../../database/prisma';
+import { BandMemberRole } from '../../generated/prisma';
+
+import type { BandInviteLinksRepository } from './repositories/band-invite-links.repository';
+import type { BandInviteLinkAccessContext, BandInviteLinkJoinContext, UpsertBandInviteLinkInput } from './types/band-invite-link.type';
+import { BandInviteLinksService } from './band-invite-links.service';
+
+const BAND_ID = '11111111-1111-4111-8111-111111111111';
+const BAND_MEMBER_ID = '22222222-2222-4222-8222-222222222222';
+const USER_ID = '33333333-3333-4333-8333-333333333333';
+const NOW = new Date('2026-07-28T00:00:00.000Z');
+const EXPIRED_AT = new Date('2099-07-28T00:00:00.000Z');
+
+interface RepositoryStubOptions {
+  accessContext?: BandInviteLinkAccessContext | null;
+  inviteLink?: BandInviteLinkJoinContext | null;
+  existingMember?: { id: string } | null;
+  blacklist?: { id: string } | null;
+  revoked?: boolean;
+  onFindAccessContext?: (tx: unknown) => void;
+  onUpsertInviteLink?: (input: UpsertBandInviteLinkInput, tx: unknown) => void;
+  onDeleteInviteLink?: (tx: unknown) => void;
+  onFindInviteLink?: (codeHash: string, tx: unknown) => void;
+  onFindMember?: (tx: unknown) => void;
+  onFindBlacklist?: (tx: unknown) => void;
+  onCreateMember?: (tx: unknown) => void;
+  onDeletePendingRequests?: (tx: unknown) => void;
+}
+
+function createRepositoryStub(options: RepositoryStubOptions = {}): BandInviteLinksRepository {
+  return {
+    async findActiveBandWithRequesterMember(_bandId, _userId, tx) {
+      options.onFindAccessContext?.(tx);
+
+      if (options.accessContext !== undefined) {
+        return options.accessContext;
+      }
+
+      return {
+        id: BAND_ID,
+        member: {
+          id: BAND_MEMBER_ID,
+          role: BandMemberRole.BM,
+        },
+      };
+    },
+    async upsertBandInviteLink(input, tx) {
+      options.onUpsertInviteLink?.(input, tx);
+
+      return {
+        bandId: input.bandId,
+        expiredAt: input.expiredAt,
+      };
+    },
+    async deleteBandInviteLinkByBandId(_bandId, tx) {
+      options.onDeleteInviteLink?.(tx);
+      return options.revoked ?? true;
+    },
+    async findBandInviteLinkByCodeHash(codeHash, tx) {
+      options.onFindInviteLink?.(codeHash, tx);
+
+      if (options.inviteLink !== undefined) {
+        return options.inviteLink;
+      }
+
+      return {
+        bandId: BAND_ID,
+        expiredAt: EXPIRED_AT,
+      };
+    },
+    async findBandMemberByBandIdAndUserId(_bandId, _userId, tx) {
+      options.onFindMember?.(tx);
+      return options.existingMember ?? null;
+    },
+    async findBandBlacklistByBandIdAndUserId(_bandId, _userId, tx) {
+      options.onFindBlacklist?.(tx);
+      return options.blacklist ?? null;
+    },
+    async createBandMember(_bandId, _userId, tx) {
+      options.onCreateMember?.(tx);
+
+      return {
+        id: BAND_MEMBER_ID,
+        joinedAt: NOW,
+      };
+    },
+    async deletePendingBandEntryRequests(_bandId, _userId, tx) {
+      options.onDeletePendingRequests?.(tx);
+    },
+  };
+}
+
+function createPrismaServiceStub(): PrismaService {
+  const transactionClient = { transactionClient: true };
+
+  return {
+    async $transaction(callback: (tx: unknown) => Promise<unknown>) {
+      return callback(transactionClient);
+    },
+  } as PrismaService;
+}
+
+function createFailingPrismaServiceStub(): PrismaService {
+  return {
+    async $transaction() {
+      throw new Error('외부 tx가 있으면 새 transaction을 열지 않아야 합니다.');
+    },
+  } as unknown as PrismaService;
+}
+
+describe('BandInviteLinksService', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('createBandInviteLink', () => {
+    it('BM이 7일 동안 유효한 초대 코드를 발급한다', async () => {
+      jest.useFakeTimers().setSystemTime(NOW);
+      let capturedInput: UpsertBandInviteLinkInput | undefined;
+      const capturedTransactions: unknown[] = [];
+      const repository = createRepositoryStub({
+        onFindAccessContext(tx) {
+          capturedTransactions.push(tx);
+        },
+        onUpsertInviteLink(input, tx) {
+          capturedInput = input;
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandInviteLinksService(repository, createPrismaServiceStub());
+
+      const result = await service.createBandInviteLink(USER_ID, BAND_ID);
+
+      expect(result.bandId).toBe(BAND_ID);
+      expect(result.inviteCode).toMatch(/^[A-HJ-NP-Z2-9]{16}$/);
+      expect(result.expiredAt).toBe('2026-08-04T00:00:00.000Z');
+      expect(capturedInput).toEqual({
+        bandId: BAND_ID,
+        createBandMemberId: BAND_MEMBER_ID,
+        codeHash: createHash('sha256').update(result.inviteCode).digest('hex'),
+        expiredAt: new Date('2026-08-04T00:00:00.000Z'),
+      });
+      expect(capturedTransactions).toHaveLength(2);
+      expect(capturedTransactions[0]).toBe(capturedTransactions[1]);
+    });
+
+    it('ADMIN도 초대 코드를 발급한다', async () => {
+      const repository = createRepositoryStub({
+        accessContext: {
+          id: BAND_ID,
+          member: {
+            id: BAND_MEMBER_ID,
+            role: BandMemberRole.ADMIN,
+          },
+        },
+      });
+      const service = new BandInviteLinksService(repository, createPrismaServiceStub());
+
+      const result = await service.createBandInviteLink(USER_ID, BAND_ID);
+
+      expect(result.bandId).toBe(BAND_ID);
+    });
+
+    it('밴드가 없으면 NotFoundException을 던진다', async () => {
+      const repository = createRepositoryStub({ accessContext: null });
+      const service = new BandInviteLinksService(repository, createPrismaServiceStub());
+
+      await expect(service.createBandInviteLink(USER_ID, BAND_ID)).rejects.toThrow(NotFoundException);
+    });
+
+    it('일반 멤버면 ForbiddenException을 던진다', async () => {
+      const repository = createRepositoryStub({
+        accessContext: {
+          id: BAND_ID,
+          member: {
+            id: BAND_MEMBER_ID,
+            role: BandMemberRole.MEMBER,
+          },
+        },
+      });
+      const service = new BandInviteLinksService(repository, createPrismaServiceStub());
+
+      await expect(service.createBandInviteLink(USER_ID, BAND_ID)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('외부 transaction client를 그대로 전달한다', async () => {
+      const externalTx = { transactionClient: true };
+      const capturedTransactions: unknown[] = [];
+      const repository = createRepositoryStub({
+        onFindAccessContext(tx) {
+          capturedTransactions.push(tx);
+        },
+        onUpsertInviteLink(_input, tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandInviteLinksService(repository, createFailingPrismaServiceStub());
+
+      await service.createBandInviteLink(USER_ID, BAND_ID, externalTx as never);
+
+      expect(capturedTransactions).toEqual([externalTx, externalTx]);
+    });
+  });
+
+  describe('revokeBandInviteLink', () => {
+    it('BM이 현재 초대 링크를 폐기한다', async () => {
+      jest.useFakeTimers().setSystemTime(NOW);
+      const capturedTransactions: unknown[] = [];
+      const repository = createRepositoryStub({
+        onFindAccessContext(tx) {
+          capturedTransactions.push(tx);
+        },
+        onDeleteInviteLink(tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandInviteLinksService(repository, createPrismaServiceStub());
+
+      const result = await service.revokeBandInviteLink(USER_ID, BAND_ID);
+
+      expect(result).toEqual({
+        bandId: BAND_ID,
+        revokedAt: NOW.toISOString(),
+      });
+      expect(capturedTransactions).toHaveLength(2);
+      expect(capturedTransactions[0]).toBe(capturedTransactions[1]);
+    });
+
+    it('폐기할 링크가 없으면 NotFoundException을 던진다', async () => {
+      const repository = createRepositoryStub({ revoked: false });
+      const service = new BandInviteLinksService(repository, createPrismaServiceStub());
+
+      await expect(service.revokeBandInviteLink(USER_ID, BAND_ID)).rejects.toThrow(NotFoundException);
+    });
+
+    it('외부 transaction client를 그대로 전달한다', async () => {
+      const externalTx = { transactionClient: true };
+      const capturedTransactions: unknown[] = [];
+      const repository = createRepositoryStub({
+        onFindAccessContext(tx) {
+          capturedTransactions.push(tx);
+        },
+        onDeleteInviteLink(tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandInviteLinksService(repository, createFailingPrismaServiceStub());
+
+      await service.revokeBandInviteLink(USER_ID, BAND_ID, externalTx as never);
+
+      expect(capturedTransactions).toEqual([externalTx, externalTx]);
+    });
+  });
+
+  describe('joinBandByInviteLink', () => {
+    it('유효한 코드를 정규화해 일반 멤버로 가입하고 대기 요청을 정리한다', async () => {
+      const capturedTransactions: unknown[] = [];
+      let capturedCodeHash: string | undefined;
+      const repository = createRepositoryStub({
+        onFindInviteLink(codeHash, tx) {
+          capturedCodeHash = codeHash;
+          capturedTransactions.push(tx);
+        },
+        onFindMember(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBlacklist(tx) {
+          capturedTransactions.push(tx);
+        },
+        onCreateMember(tx) {
+          capturedTransactions.push(tx);
+        },
+        onDeletePendingRequests(tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandInviteLinksService(repository, createPrismaServiceStub());
+
+      const result = await service.joinBandByInviteLink(USER_ID, '  abcdef23456789gh  ');
+
+      expect(capturedCodeHash).toBe(createHash('sha256').update('ABCDEF23456789GH').digest('hex'));
+      expect(result).toEqual({
+        bandId: BAND_ID,
+        userId: USER_ID,
+        memberId: BAND_MEMBER_ID,
+        joinedAt: NOW.toISOString(),
+      });
+      expect(capturedTransactions).toHaveLength(5);
+      expect(capturedTransactions.every(tx => tx === capturedTransactions[0])).toBe(true);
+    });
+
+    it('링크가 없으면 NotFoundException을 던진다', async () => {
+      const repository = createRepositoryStub({ inviteLink: null });
+      const service = new BandInviteLinksService(repository, createPrismaServiceStub());
+
+      await expect(service.joinBandByInviteLink(USER_ID, 'ABCDEF23456789GH')).rejects.toThrow(NotFoundException);
+    });
+
+    it('링크가 만료됐으면 NotFoundException을 던진다', async () => {
+      const repository = createRepositoryStub({
+        inviteLink: {
+          bandId: BAND_ID,
+          expiredAt: new Date('2020-01-01T00:00:00.000Z'),
+        },
+      });
+      const service = new BandInviteLinksService(repository, createPrismaServiceStub());
+
+      await expect(service.joinBandByInviteLink(USER_ID, 'ABCDEF23456789GH')).rejects.toThrow(NotFoundException);
+    });
+
+    it('이미 밴드 멤버면 ConflictException을 던진다', async () => {
+      const repository = createRepositoryStub({ existingMember: { id: BAND_MEMBER_ID } });
+      const service = new BandInviteLinksService(repository, createPrismaServiceStub());
+
+      await expect(service.joinBandByInviteLink(USER_ID, 'ABCDEF23456789GH')).rejects.toThrow(ConflictException);
+    });
+
+    it('차단된 사용자면 ForbiddenException을 던진다', async () => {
+      const repository = createRepositoryStub({ blacklist: { id: 'blacklist-id' } });
+      const service = new BandInviteLinksService(repository, createPrismaServiceStub());
+
+      await expect(service.joinBandByInviteLink(USER_ID, 'ABCDEF23456789GH')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('외부 transaction client를 그대로 전달한다', async () => {
+      const externalTx = { transactionClient: true };
+      const capturedTransactions: unknown[] = [];
+      const repository = createRepositoryStub({
+        onFindInviteLink(_codeHash, tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindMember(tx) {
+          capturedTransactions.push(tx);
+        },
+        onFindBlacklist(tx) {
+          capturedTransactions.push(tx);
+        },
+        onCreateMember(tx) {
+          capturedTransactions.push(tx);
+        },
+        onDeletePendingRequests(tx) {
+          capturedTransactions.push(tx);
+        },
+      });
+      const service = new BandInviteLinksService(repository, createFailingPrismaServiceStub());
+
+      await service.joinBandByInviteLink(USER_ID, 'ABCDEF23456789GH', externalTx as never);
+
+      expect(capturedTransactions).toEqual([externalTx, externalTx, externalTx, externalTx, externalTx]);
+    });
+  });
+});

--- a/backend/src/modules/bands/band-invite-links.service.ts
+++ b/backend/src/modules/bands/band-invite-links.service.ts
@@ -1,0 +1,182 @@
+import { createHash, randomInt } from 'node:crypto';
+
+import { ConflictException, ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+
+import { PrismaService } from '../../database/prisma';
+import { BandMemberRole, type Prisma } from '../../generated/prisma';
+
+import { BAND_INVITE_LINKS_REPOSITORY, type BandInviteLinksRepository } from './repositories/band-invite-links.repository';
+import type { CreateBandInviteLinkResult, JoinBandByInviteLinkResult, RevokeBandInviteLinkResult } from './types/band-invite-link.type';
+
+const INVITE_CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+const INVITE_CODE_LENGTH = 16;
+const INVITE_LINK_EXPIRATION_DAYS = 7;
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+@Injectable()
+export class BandInviteLinksService {
+  constructor(
+    @Inject(BAND_INVITE_LINKS_REPOSITORY)
+    private readonly bandInviteLinksRepository: BandInviteLinksRepository,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  /**
+   * 밴드 운영자만 기존 코드를 무효화하며 7일짜리 초대 코드를 발급할 수 있다.
+   *
+   * @param {string} requesterUserId - 인증된 사용자 ID
+   * @param {string} bandId - 링크를 발급할 밴드 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<CreateBandInviteLinkResult>} 새 원본 코드와 만료 시각
+   */
+  async createBandInviteLink(requesterUserId: string, bandId: string, tx?: Prisma.TransactionClient): Promise<CreateBandInviteLinkResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<CreateBandInviteLinkResult> => {
+      const manager = await this.findBandInviteLinkManager(bandId, requesterUserId, client);
+      const inviteCode = this.createInviteCode();
+      const codeHash = this.createCodeHash(inviteCode);
+      const expiredAt = new Date(Date.now() + INVITE_LINK_EXPIRATION_DAYS * MILLISECONDS_PER_DAY);
+
+      const inviteLink = await this.bandInviteLinksRepository.upsertBandInviteLink(
+        {
+          bandId,
+          createBandMemberId: manager.id,
+          codeHash,
+          expiredAt,
+        },
+        client,
+      );
+
+      return {
+        bandId: inviteLink.bandId,
+        inviteCode,
+        expiredAt: inviteLink.expiredAt.toISOString(),
+      };
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
+  /**
+   * 밴드 운영자만 현재 초대 링크를 즉시 폐기할 수 있다.
+   *
+   * @param {string} requesterUserId - 인증된 사용자 ID
+   * @param {string} bandId - 링크를 폐기할 밴드 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<RevokeBandInviteLinkResult>} 폐기한 밴드와 처리 시각
+   */
+  async revokeBandInviteLink(requesterUserId: string, bandId: string, tx?: Prisma.TransactionClient): Promise<RevokeBandInviteLinkResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<RevokeBandInviteLinkResult> => {
+      await this.findBandInviteLinkManager(bandId, requesterUserId, client);
+
+      const revoked = await this.bandInviteLinksRepository.deleteBandInviteLinkByBandId(bandId, client);
+
+      if (!revoked) {
+        throw new NotFoundException('폐기할 밴드 초대 링크를 찾을 수 없습니다.');
+      }
+
+      return {
+        bandId,
+        revokedAt: new Date().toISOString(),
+      };
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
+  /**
+   * 인증 사용자가 유효한 코드로 차단 여부를 검증받고 일반 멤버로 즉시 가입한다.
+   *
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {string} code - 사용자가 입력하거나 링크에서 전달한 원본 코드
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<JoinBandByInviteLinkResult>} 링크 가입 결과
+   */
+  async joinBandByInviteLink(userId: string, code: string, tx?: Prisma.TransactionClient): Promise<JoinBandByInviteLinkResult> {
+    const run = async (client: Prisma.TransactionClient): Promise<JoinBandByInviteLinkResult> => {
+      const normalizedCode = code.trim().toUpperCase();
+      const codeHash = this.createCodeHash(normalizedCode);
+      const inviteLink = await this.bandInviteLinksRepository.findBandInviteLinkByCodeHash(codeHash, client);
+
+      if (inviteLink === null || inviteLink.expiredAt === null || inviteLink.expiredAt.getTime() <= Date.now()) {
+        throw new NotFoundException('유효한 밴드 초대 링크를 찾을 수 없습니다.');
+      }
+
+      const existingMember = await this.bandInviteLinksRepository.findBandMemberByBandIdAndUserId(inviteLink.bandId, userId, client);
+
+      if (existingMember !== null) {
+        throw new ConflictException('이미 밴드 멤버인 사용자입니다.');
+      }
+
+      const blacklist = await this.bandInviteLinksRepository.findBandBlacklistByBandIdAndUserId(inviteLink.bandId, userId, client);
+
+      if (blacklist !== null) {
+        throw new ForbiddenException('밴드에서 차단된 사용자는 초대 링크로 가입할 수 없습니다.');
+      }
+
+      const member = await this.bandInviteLinksRepository.createBandMember(inviteLink.bandId, userId, client);
+      await this.bandInviteLinksRepository.deletePendingBandEntryRequests(inviteLink.bandId, userId, client);
+
+      return {
+        bandId: inviteLink.bandId,
+        userId,
+        memberId: member.id,
+        joinedAt: member.joinedAt.toISOString(),
+      };
+    };
+
+    if (tx !== undefined) {
+      return run(tx);
+    }
+
+    return this.prisma.$transaction(run);
+  }
+
+  private async findBandInviteLinkManager(
+    bandId: string,
+    userId: string,
+    tx: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+  }> {
+    const band = await this.bandInviteLinksRepository.findActiveBandWithRequesterMember(bandId, userId, tx);
+
+    if (band === null) {
+      throw new NotFoundException('요청한 밴드를 찾을 수 없습니다.');
+    }
+
+    if (band.member === null) {
+      throw new ForbiddenException('밴드 초대 링크 관리 권한이 없습니다.');
+    }
+
+    const canManageInviteLink = band.member.role === BandMemberRole.BM || band.member.role === BandMemberRole.ADMIN;
+
+    if (!canManageInviteLink) {
+      throw new ForbiddenException('밴드 초대 링크 관리 권한이 없습니다.');
+    }
+
+    return band.member;
+  }
+
+  private createInviteCode(): string {
+    let inviteCode = '';
+
+    for (let index = 0; index < INVITE_CODE_LENGTH; index += 1) {
+      const alphabetIndex = randomInt(INVITE_CODE_ALPHABET.length);
+      inviteCode += INVITE_CODE_ALPHABET[alphabetIndex];
+    }
+
+    return inviteCode;
+  }
+
+  private createCodeHash(code: string): string {
+    return createHash('sha256').update(code).digest('hex');
+  }
+}

--- a/backend/src/modules/bands/bands.module.ts
+++ b/backend/src/modules/bands/bands.module.ts
@@ -5,23 +5,33 @@ import { AccessTokenGuard } from '../../auth/guard/bearer-token.guard';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { UsersModule } from '../users/users.module';
 
+import { BandInviteLinksPrismaRepository } from './repositories/band-invite-links.prisma-repository';
+import { BAND_INVITE_LINKS_REPOSITORY } from './repositories/band-invite-links.repository';
 import { BandsPrismaRepository } from './repositories/bands.prisma-repository';
 import { BANDS_REPOSITORY } from './repositories/bands.repository';
 import { BandInvitationsController } from './band-invitations.controller';
+import { BandInviteLinksController } from './band-invite-links.controller';
+import { BandInviteLinksService } from './band-invite-links.service';
 import { BandJoinRequestsController } from './band-join-requests.controller';
 import { BandsController } from './bands.controller';
 import { BandsService } from './bands.service';
 
 @Module({
   imports: [AuthModule, UsersModule, NotificationsModule],
-  controllers: [BandsController, BandInvitationsController, BandJoinRequestsController],
+  controllers: [BandsController, BandInvitationsController, BandJoinRequestsController, BandInviteLinksController],
   providers: [
     AccessTokenGuard,
     BandsService,
     BandsPrismaRepository,
+    BandInviteLinksService,
+    BandInviteLinksPrismaRepository,
     {
       provide: BANDS_REPOSITORY,
       useExisting: BandsPrismaRepository,
+    },
+    {
+      provide: BAND_INVITE_LINKS_REPOSITORY,
+      useExisting: BandInviteLinksPrismaRepository,
     },
   ],
 })

--- a/backend/src/modules/bands/repositories/band-invite-links.prisma-repository.spec.ts
+++ b/backend/src/modules/bands/repositories/band-invite-links.prisma-repository.spec.ts
@@ -1,0 +1,239 @@
+import type { PrismaService } from '../../../database/prisma';
+
+import { BandInviteLinksPrismaRepository } from './band-invite-links.prisma-repository';
+
+const createPrismaMock = () => ({
+  band: {
+    findFirst: jest.fn(),
+  },
+  bandInviteLink: {
+    upsert: jest.fn(),
+    deleteMany: jest.fn(),
+    findFirst: jest.fn(),
+  },
+  bandMember: {
+    findFirst: jest.fn(),
+    create: jest.fn(),
+  },
+  bandBlacklist: {
+    findFirst: jest.fn(),
+  },
+  bandInvitation: {
+    deleteMany: jest.fn(),
+  },
+  bandJoinRequest: {
+    deleteMany: jest.fn(),
+  },
+});
+
+describe('BandInviteLinksPrismaRepository', () => {
+  let prisma: ReturnType<typeof createPrismaMock>;
+  let repository: BandInviteLinksPrismaRepository;
+
+  beforeEach(() => {
+    prisma = createPrismaMock();
+    repository = new BandInviteLinksPrismaRepository(prisma as unknown as PrismaService);
+  });
+
+  it('삭제되지 않은 밴드와 요청자 멤버를 조회한다', async () => {
+    prisma.band.findFirst.mockResolvedValue({
+      id: 'band-id',
+      members: [
+        {
+          id: 'band-member-id',
+          role: 'BM',
+        },
+      ],
+    });
+
+    const result = await repository.findActiveBandWithRequesterMember('band-id', 'user-id');
+
+    expect(prisma.band.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'band-id',
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        members: {
+          where: {
+            userId: 'user-id',
+          },
+          select: {
+            id: true,
+            role: true,
+          },
+          take: 1,
+        },
+      },
+    });
+    expect(result).toEqual({
+      id: 'band-id',
+      member: {
+        id: 'band-member-id',
+        role: 'BM',
+      },
+    });
+  });
+
+  it('밴드가 없으면 null을 반환한다', async () => {
+    prisma.band.findFirst.mockResolvedValue(null);
+
+    const result = await repository.findActiveBandWithRequesterMember('band-id', 'user-id');
+
+    expect(result).toBeNull();
+  });
+
+  it('밴드 ID를 기준으로 초대 링크를 생성하거나 교체한다', async () => {
+    const expiredAt = new Date('2026-08-04T00:00:00.000Z');
+    prisma.bandInviteLink.upsert.mockResolvedValue({
+      bandId: 'band-id',
+      expiredAt,
+    });
+
+    const result = await repository.upsertBandInviteLink({
+      bandId: 'band-id',
+      createBandMemberId: 'band-member-id',
+      codeHash: 'code-hash',
+      expiredAt,
+    });
+
+    expect(prisma.bandInviteLink.upsert).toHaveBeenCalledWith({
+      where: {
+        bandId: 'band-id',
+      },
+      update: {
+        createBandMemberId: 'band-member-id',
+        codeHash: 'code-hash',
+        expiredAt,
+      },
+      create: {
+        bandId: 'band-id',
+        createBandMemberId: 'band-member-id',
+        codeHash: 'code-hash',
+        expiredAt,
+      },
+      select: {
+        bandId: true,
+        expiredAt: true,
+      },
+    });
+    expect(result).toEqual({
+      bandId: 'band-id',
+      expiredAt,
+    });
+  });
+
+  it('tx가 전달되면 tx 클라이언트로 초대 링크를 저장한다', async () => {
+    const expiredAt = new Date('2026-08-04T00:00:00.000Z');
+    const tx = {
+      bandInviteLink: {
+        upsert: jest.fn().mockResolvedValue({
+          bandId: 'band-id',
+          expiredAt,
+        }),
+      },
+    };
+
+    await repository.upsertBandInviteLink(
+      {
+        bandId: 'band-id',
+        createBandMemberId: 'band-member-id',
+        codeHash: 'code-hash',
+        expiredAt,
+      },
+      tx as never,
+    );
+
+    expect(tx.bandInviteLink.upsert).toHaveBeenCalled();
+    expect(prisma.bandInviteLink.upsert).not.toHaveBeenCalled();
+  });
+
+  it('삭제된 초대 링크가 있으면 true를 반환한다', async () => {
+    prisma.bandInviteLink.deleteMany.mockResolvedValue({ count: 1 });
+
+    const result = await repository.deleteBandInviteLinkByBandId('band-id');
+
+    expect(prisma.bandInviteLink.deleteMany).toHaveBeenCalledWith({
+      where: {
+        bandId: 'band-id',
+      },
+    });
+    expect(result).toBe(true);
+  });
+
+  it('코드 해시와 활성 밴드 조건으로 초대 링크를 조회한다', async () => {
+    const expiredAt = new Date('2026-08-04T00:00:00.000Z');
+    prisma.bandInviteLink.findFirst.mockResolvedValue({
+      bandId: 'band-id',
+      expiredAt,
+    });
+
+    const result = await repository.findBandInviteLinkByCodeHash('code-hash');
+
+    expect(prisma.bandInviteLink.findFirst).toHaveBeenCalledWith({
+      where: {
+        codeHash: 'code-hash',
+        band: {
+          deletedAt: null,
+        },
+      },
+      select: {
+        bandId: true,
+        expiredAt: true,
+      },
+    });
+    expect(result).toEqual({
+      bandId: 'band-id',
+      expiredAt,
+    });
+  });
+
+  it('링크 가입 사용자를 일반 멤버로 생성한다', async () => {
+    const joinedAt = new Date('2026-07-28T00:00:00.000Z');
+    prisma.bandMember.create.mockResolvedValue({
+      id: 'band-member-id',
+      joinedAt,
+    });
+
+    const result = await repository.createBandMember('band-id', 'user-id');
+
+    expect(prisma.bandMember.create).toHaveBeenCalledWith({
+      data: {
+        bandId: 'band-id',
+        userId: 'user-id',
+        role: 'MEMBER',
+      },
+      select: {
+        id: true,
+        joinedAt: true,
+      },
+    });
+    expect(result).toEqual({
+      id: 'band-member-id',
+      joinedAt,
+    });
+  });
+
+  it('링크 가입 후 대기 중인 직접 초대와 가입 요청을 삭제한다', async () => {
+    prisma.bandInvitation.deleteMany.mockResolvedValue({ count: 1 });
+    prisma.bandJoinRequest.deleteMany.mockResolvedValue({ count: 1 });
+
+    await repository.deletePendingBandEntryRequests('band-id', 'user-id');
+
+    expect(prisma.bandInvitation.deleteMany).toHaveBeenCalledWith({
+      where: {
+        bandId: 'band-id',
+        inviteeUserId: 'user-id',
+        status: 'PENDING',
+      },
+    });
+    expect(prisma.bandJoinRequest.deleteMany).toHaveBeenCalledWith({
+      where: {
+        bandId: 'band-id',
+        userId: 'user-id',
+        status: 'PENDING',
+      },
+    });
+  });
+});

--- a/backend/src/modules/bands/repositories/band-invite-links.prisma-repository.ts
+++ b/backend/src/modules/bands/repositories/band-invite-links.prisma-repository.ts
@@ -1,0 +1,251 @@
+import { Injectable } from '@nestjs/common';
+
+import { PrismaService } from '../../../database/prisma';
+import type { Prisma } from '../../../generated/prisma';
+import type {
+  BandInviteLinkAccessContext,
+  BandInviteLinkItem,
+  BandInviteLinkJoinContext,
+  JoinedBandMember,
+  UpsertBandInviteLinkInput,
+} from '../types/band-invite-link.type';
+
+import type { BandInviteLinksRepository } from './band-invite-links.repository';
+
+@Injectable()
+export class BandInviteLinksPrismaRepository implements BandInviteLinksRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 링크 관리 권한 판단에 필요한 활성 밴드와 요청자 멤버 정보를 조회한다.
+   *
+   * @param {string} bandId - 대상 밴드 ID
+   * @param {string} userId - 인증된 사용자 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<BandInviteLinkAccessContext | null>} 활성 밴드와 요청자 멤버 정보
+   */
+  async findActiveBandWithRequesterMember(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<BandInviteLinkAccessContext | null> {
+    const client = tx ?? this.prisma;
+
+    const band = await client.band.findFirst({
+      where: {
+        id: bandId,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        members: {
+          where: {
+            userId,
+          },
+          select: {
+            id: true,
+            role: true,
+          },
+          take: 1,
+        },
+      },
+    });
+
+    if (band === null) {
+      return null;
+    }
+
+    return {
+      id: band.id,
+      member: band.members[0] ?? null,
+    };
+  }
+
+  /**
+   * 밴드별 단일 링크 정책을 DB unique key 기반 upsert로 반영한다.
+   *
+   * @param {UpsertBandInviteLinkInput} input - 발급할 코드 해시와 만료 정보
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<BandInviteLinkItem>} 저장된 링크 정보
+   */
+  async upsertBandInviteLink(input: UpsertBandInviteLinkInput, tx?: Prisma.TransactionClient): Promise<BandInviteLinkItem> {
+    const client = tx ?? this.prisma;
+
+    const inviteLink = await client.bandInviteLink.upsert({
+      where: {
+        bandId: input.bandId,
+      },
+      update: {
+        createBandMemberId: input.createBandMemberId,
+        codeHash: input.codeHash,
+        expiredAt: input.expiredAt,
+      },
+      create: {
+        bandId: input.bandId,
+        createBandMemberId: input.createBandMemberId,
+        codeHash: input.codeHash,
+        expiredAt: input.expiredAt,
+      },
+      select: {
+        bandId: true,
+        expiredAt: true,
+      },
+    });
+
+    return {
+      bandId: inviteLink.bandId,
+      expiredAt: inviteLink.expiredAt ?? input.expiredAt,
+    };
+  }
+
+  /**
+   * 밴드의 초대 링크를 hard delete해 즉시 폐기한다.
+   *
+   * @param {string} bandId - 대상 밴드 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<boolean>} 삭제된 링크가 있으면 true
+   */
+  async deleteBandInviteLinkByBandId(bandId: string, tx?: Prisma.TransactionClient): Promise<boolean> {
+    const client = tx ?? this.prisma;
+
+    const result = await client.bandInviteLink.deleteMany({
+      where: {
+        bandId,
+      },
+    });
+
+    return result.count > 0;
+  }
+
+  /**
+   * 코드 해시로 유효성 판단에 필요한 링크와 활성 밴드를 조회한다.
+   *
+   * @param {string} codeHash - 정규화한 코드의 SHA-256 해시
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<BandInviteLinkJoinContext | null>} 링크 가입 판단 정보
+   */
+  async findBandInviteLinkByCodeHash(codeHash: string, tx?: Prisma.TransactionClient): Promise<BandInviteLinkJoinContext | null> {
+    const client = tx ?? this.prisma;
+
+    return client.bandInviteLink.findFirst({
+      where: {
+        codeHash,
+        band: {
+          deletedAt: null,
+        },
+      },
+      select: {
+        bandId: true,
+        expiredAt: true,
+      },
+    });
+  }
+
+  /**
+   * 링크 가입 전 중복 멤버 여부를 조회한다.
+   *
+   * @param {string} bandId - 대상 밴드 ID
+   * @param {string} userId - 가입할 사용자 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string } | null>} 기존 멤버 정보
+   */
+  async findBandMemberByBandIdAndUserId(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    return client.bandMember.findFirst({
+      where: {
+        bandId,
+        userId,
+      },
+      select: {
+        id: true,
+      },
+    });
+  }
+
+  /**
+   * 링크 가입 전 밴드 차단 여부를 조회한다.
+   *
+   * @param {string} bandId - 대상 밴드 ID
+   * @param {string} userId - 가입할 사용자 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<{ id: string } | null>} 차단 정보
+   */
+  async findBandBlacklistByBandIdAndUserId(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+  } | null> {
+    const client = tx ?? this.prisma;
+
+    return client.bandBlacklist.findFirst({
+      where: {
+        bandId,
+        userId,
+      },
+      select: {
+        id: true,
+      },
+    });
+  }
+
+  /**
+   * 링크로 가입한 사용자를 일반 밴드 멤버로 생성한다.
+   *
+   * @param {string} bandId - 가입할 밴드 ID
+   * @param {string} userId - 가입할 사용자 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<JoinedBandMember>} 생성된 멤버 정보
+   */
+  async createBandMember(bandId: string, userId: string, tx?: Prisma.TransactionClient): Promise<JoinedBandMember> {
+    const client = tx ?? this.prisma;
+
+    return client.bandMember.create({
+      data: {
+        bandId,
+        userId,
+        role: 'MEMBER',
+      },
+      select: {
+        id: true,
+        joinedAt: true,
+      },
+    });
+  }
+
+  /**
+   * 링크 가입 후 더 이상 처리할 수 없는 대기 초대와 가입 요청을 제거한다.
+   *
+   * @param {string} bandId - 가입한 밴드 ID
+   * @param {string} userId - 가입한 사용자 ID
+   * @param {Prisma.TransactionClient | undefined} tx - 상위 트랜잭션 client
+   * @returns {Promise<void>} 정리 완료
+   */
+  async deletePendingBandEntryRequests(bandId: string, userId: string, tx?: Prisma.TransactionClient): Promise<void> {
+    const client = tx ?? this.prisma;
+
+    await client.bandInvitation.deleteMany({
+      where: {
+        bandId,
+        inviteeUserId: userId,
+        status: 'PENDING',
+      },
+    });
+
+    await client.bandJoinRequest.deleteMany({
+      where: {
+        bandId,
+        userId,
+        status: 'PENDING',
+      },
+    });
+  }
+}

--- a/backend/src/modules/bands/repositories/band-invite-links.repository.ts
+++ b/backend/src/modules/bands/repositories/band-invite-links.repository.ts
@@ -1,0 +1,33 @@
+import type { Prisma } from '../../../generated/prisma';
+import type {
+  BandInviteLinkAccessContext,
+  BandInviteLinkItem,
+  BandInviteLinkJoinContext,
+  JoinedBandMember,
+  UpsertBandInviteLinkInput,
+} from '../types/band-invite-link.type';
+
+export const BAND_INVITE_LINKS_REPOSITORY = Symbol('BAND_INVITE_LINKS_REPOSITORY');
+
+export interface BandInviteLinksRepository {
+  findActiveBandWithRequesterMember(bandId: string, userId: string, tx?: Prisma.TransactionClient): Promise<BandInviteLinkAccessContext | null>;
+  upsertBandInviteLink(input: UpsertBandInviteLinkInput, tx?: Prisma.TransactionClient): Promise<BandInviteLinkItem>;
+  deleteBandInviteLinkByBandId(bandId: string, tx?: Prisma.TransactionClient): Promise<boolean>;
+  findBandInviteLinkByCodeHash(codeHash: string, tx?: Prisma.TransactionClient): Promise<BandInviteLinkJoinContext | null>;
+  findBandMemberByBandIdAndUserId(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+  } | null>;
+  findBandBlacklistByBandIdAndUserId(
+    bandId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{
+    id: string;
+  } | null>;
+  createBandMember(bandId: string, userId: string, tx?: Prisma.TransactionClient): Promise<JoinedBandMember>;
+  deletePendingBandEntryRequests(bandId: string, userId: string, tx?: Prisma.TransactionClient): Promise<void>;
+}

--- a/backend/src/modules/bands/types/band-invite-link.type.ts
+++ b/backend/src/modules/bands/types/band-invite-link.type.ts
@@ -1,0 +1,49 @@
+import type { BandMemberRole } from '../../../generated/prisma';
+
+export interface BandInviteLinkAccessContext {
+  id: string;
+  member: {
+    id: string;
+    role: BandMemberRole;
+  } | null;
+}
+
+export interface BandInviteLinkJoinContext {
+  bandId: string;
+  expiredAt: Date | null;
+}
+
+export interface UpsertBandInviteLinkInput {
+  bandId: string;
+  createBandMemberId: string;
+  codeHash: string;
+  expiredAt: Date;
+}
+
+export interface BandInviteLinkItem {
+  bandId: string;
+  expiredAt: Date;
+}
+
+export interface JoinedBandMember {
+  id: string;
+  joinedAt: Date;
+}
+
+export interface CreateBandInviteLinkResult {
+  bandId: string;
+  inviteCode: string;
+  expiredAt: string;
+}
+
+export interface RevokeBandInviteLinkResult {
+  bandId: string;
+  revokedAt: string;
+}
+
+export interface JoinBandByInviteLinkResult {
+  bandId: string;
+  userId: string;
+  memberId: string;
+  joinedAt: string;
+}


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 15분

<br/>

## 📌 작업 요약

밴드 운영자가 7일 동안 사용할 수 있는 초대 코드를 발급·재발급·폐기하고, 인증된 사용자가 유효한 코드로 밴드에 바로 가입할 수 있도록 API를 추가했습니다.

<br/>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요 (이미지 첨부 가능)

1. `BM`과 `ADMIN`이 밴드별 초대 코드를 하나만 발급할 수 있도록 했습니다. 재발급하면 기존 코드는 바로 무효화되고, 폐기하면 링크 레코드를 삭제합니다.
2. 유효한 코드를 사용한 인증 사용자는 공개 여부와 관계없이 `MEMBER`로 바로 가입합니다. 이미 가입한 사용자와 밴드 차단 사용자는 거부하며, 가입 성공 시 남아 있던 직접 초대와 가입 요청을 함께 정리합니다.
3. 사람이 혼동하기 쉬운 문자를 뺀 16자리 코드를 안전한 난수로 만들고, 원본 코드는 발급 응답에서 한 번만 반환합니다. DB에는 SHA-256 해시만 저장합니다.
4. Service와 Repository 테스트 22개를 추가하고 API 명세와 설계 문서를 작성했습니다.
5. `prisma:format`, `prisma:validate`, `prisma:generate`, lint, format check, build, 전체 테스트 493개를 통과했습니다.

<br/>

## 🚨 주요 고민 및 해결 과정

> 주요 고민이나 문제 해결 과정 공유

### 문제

기존 문서에는 초대 링크가 `MVP 제외`로만 남아 있었고, 즉시 가입인지 승인 요청인지, 코드 만료와 재사용 범위, 재발급·폐기 방식이 정해져 있지 않았습니다.

원본 초대 코드를 그대로 저장하면 DB가 노출됐을 때 아직 유효한 링크를 바로 사용할 수 있고, 링크 가입 뒤 기존 직접 초대나 가입 요청이 남으면 같은 사용자의 가입 상태가 여러 흐름에 걸쳐 충돌할 수 있습니다.

### 해결 과정

초대 링크 공유 자체를 운영자의 사전 승인으로 보고, 별도 가입 승인 없이 바로 `MEMBER`로 가입하도록 정했습니다. 직접 초대와 가입 요청은 기존처럼 특정 사용자 초대와 승인형 가입에 사용하고, 링크는 불특정 사용자에게 미리 가입 권한을 주는 흐름으로 역할을 나눴습니다.

현재 서비스 규모에서는 복잡한 사용 횟수 관리보다 `7일 동안 여러 사용자가 재사용`, `밴드당 활성 코드 1개`가 운영하기 단순합니다. 유출 시에는 폐기하거나 재발급해 즉시 기존 코드를 무효화할 수 있습니다.

코드는 80비트 경우의 수를 갖는 16자리 난수로 만들고 DB에는 해시만 저장합니다. 링크 조회, 중복 멤버·차단 확인, 멤버 생성, 대기 초대·가입 요청 정리는 하나의 트랜잭션에서 처리했습니다.

프론트엔드 권장 흐름:

1. 운영 화면에서 `POST /bands/:bandId/invite-link`를 호출합니다.
2. 응답의 `inviteCode`로 `${window.location.origin}/invite-links/${inviteCode}`를 만들어 복사·공유합니다.
3. 초대 링크 진입 시 로그인을 거친 뒤 `POST /invite-links/:code/join`을 호출합니다.
4. 가입 성공 응답의 `bandId`로 밴드 상세 화면에 이동하고 밴드 목록·멤버 캐시를 갱신합니다.
5. 원본 코드는 발급 응답에서만 보여주고 별도로 영구 저장하지 않습니다. 코드를 잃어버리면 재발급합니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 밴드 초대 링크를 발급·재발급·폐기하고, 초대 코드로 밴드에 가입할 수 있습니다.
  * 초대 링크는 7일간 유효하며, 운영 권한이 있는 사용자만 관리할 수 있습니다.
  * 가입 시 차단 사용자와 기존 멤버를 검증하고, 관련 대기 요청을 자동으로 정리합니다.

* **문서**
  * 밴드 초대 링크 API 및 설계 문서를 추가했습니다.

* **테스트**
  * 권한, 만료, 중복 가입, 차단 사용자 및 코드 검증 시나리오를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->