### PR TITLE
링크 미리보기 및 일정 첨부·알림 요약 API 추가

### DIFF
--- a/backend/docs/backend/api-docs/link-preview.md
+++ b/backend/docs/backend/api-docs/link-preview.md
@@ -1,0 +1,35 @@
+# 링크 미리보기 API
+
+외부 페이지의 제목과 파비콘을 서버에서 읽어 반환한다. 브라우저 CORS 제약을 피하기 위한 공개 엔드포인트다.
+
+## GET `/link-previews`
+
+### Query Parameters
+
+| 이름 | 필수 | 설명 |
+|------|:----:|------|
+| `url` | Y | `http` 또는 `https` 절대 URL |
+
+### Response 200
+
+```json
+{
+  "status": "success",
+  "error": null,
+  "message": "링크 미리보기 조회 성공",
+  "data": {
+    "url": "https://bandco.atlassian.net/jira/project",
+    "title": "BandCo JIRA",
+    "siteName": "Jira",
+    "faviconUrl": "https://bandco.atlassian.net/favicon.ico"
+  }
+}
+```
+
+외부 페이지 조회 또는 파싱에 실패하면 HTTP 200을 유지하고 `title`, `siteName`, `faviconUrl`을 `null`로 반환한다. 사설 IP, localhost, 예약 IP 및 해당 주소로 이어지는 리다이렉트는 조회하지 않는다.
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 400 | `url`이 `http` 또는 `https` 절대 URL이 아님 |

--- a/backend/docs/backend/api-docs/notification.md
+++ b/backend/docs/backend/api-docs/notification.md
@@ -14,11 +14,46 @@
 | 번호 | 메서드 | 경로 | 설명 |
 |------|--------|------|------|
 | #44 | GET | `/notifications/me` | 알림 목록 조회 |
+| - | GET | `/notifications/unread-summary` | 타입별 미읽음 개수 조회 |
 | #45 | PATCH | `/notifications/:notificationId/read` | 단건 알림 읽음 처리 |
 | #46 | PATCH | `/notifications/read-all` | 전체 알림 읽음 처리 |
 | #47 | PATCH | `/notifications/read` | 다건 알림 읽음 처리 |
 | #49 | DELETE | `/notifications/:notificationId` | 단건 알림 삭제 |
 | #50 | DELETE | `/notifications` | 다건 알림 삭제 |
+
+---
+
+## 타입별 미읽음 개수 조회
+
+- Method: `GET`
+- Path: `/notifications/unread-summary`
+- 인증: AccessToken
+
+### Response 200
+
+```json
+{
+  "status": "success",
+  "error": null,
+  "message": "읽지 않은 알림 개수 조회 성공",
+  "data": {
+    "unreadCount": 4,
+    "unreadByType": {
+      "NOTICE": 1,
+      "INVITE": 2,
+      "REMINDER": 1
+    }
+  }
+}
+```
+
+읽지 않은 알림이 없는 타입도 값 `0`으로 포함한다.
+
+### Error
+
+| 코드 | 사유 |
+|------|------|
+| 401 | 인증 실패 |
 
 ---
 

--- a/backend/docs/backend/api-docs/schedules.md
+++ b/backend/docs/backend/api-docs/schedules.md
@@ -7,7 +7,7 @@
 > - #48 일정 목록 조회(밴드 기준) 응답 JSON 원본이 여는 중괄호(`{`) 없이 시작하는 오기가 있어 수정하여 기록함.
 > - teams 도메인 MVP 제외로 teamIds/teams 필드를 Request/Response에서 제거함.
 > - scheduleType enum: PRACTICE | MEETING / status enum: PLANNED | DONE | CANCELED (Prisma schema 기준)
-> - PATCH body 전체 필드 선택 (partial update 패턴). POST에서 memo, placeId, songIds, participantBandMemberIds는 선택.
+> - PATCH body 전체 필드 선택 (partial update 패턴). POST에서 memo, placeId, songIds, participantBandMemberIds, externalLinks, referenceFiles는 선택.
 
 ---
 
@@ -39,11 +39,18 @@
     "band-member-uuid-1",
     "band-member-uuid-2"
   ],
-  "memo": "후반부 템포 점검"
+  "memo": "후반부 템포 점검",
+  "externalLinks": ["https://example.com/notice"],
+  "referenceFiles": [
+    {
+      "fileUrl": "https://storage.example.com/schedule-references/uuid.pdf",
+      "fileName": "합주 공지.pdf"
+    }
+  ]
 }
 ```
 
-> 선택 필드: placeId, songIds, participantBandMemberIds, memo
+> 선택 필드: placeId, songIds, participantBandMemberIds, memo, externalLinks, referenceFiles
 
 ### Response 200
 ```json
@@ -70,6 +77,15 @@
     ],
     "participantCount": 2,
     "memo": "후반부 템포 점검",
+    "externalLinks": ["https://example.com/notice"],
+    "referenceFiles": [
+      {
+        "id": "reference-file-uuid",
+        "fileUrl": "https://storage.example.com/schedule-references/uuid.pdf",
+        "fileName": "합주 공지.pdf",
+        "createdAt": "2026-04-30T14:16:00.000+09:00"
+      }
+    ],
     "createdAt": "2026-04-30T14:16:00.000+09:00"
   }
 }
@@ -114,11 +130,13 @@
     "band-member-uuid-2",
     "band-member-uuid-3"
   ],
-  "memo": "후반부 템포 + 엔딩 합 맞추기"
+  "memo": "후반부 템포 + 엔딩 합 맞추기",
+  "externalLinks": [],
+  "referenceFiles": []
 }
 ```
 
-> 모든 필드 선택 (partial update — 전달된 필드만 업데이트)
+> 모든 필드 선택 (partial update — 전달된 필드만 업데이트). `externalLinks`, `referenceFiles`는 전달 시 전체 교체하며 빈 배열은 전체 삭제를 뜻한다.
 
 ### Response 200
 ```json
@@ -140,6 +158,8 @@
     ],
     "participantCount": 3,
     "memo": "후반부 템포 + 엔딩 합 맞추기",
+    "externalLinks": [],
+    "referenceFiles": [],
     "updatedAt": "2026-04-30T14:20:00.000+09:00"
   }
 }
@@ -378,6 +398,15 @@
         }
       ],
       "memo": "후렴 파트 합 맞추기",
+      "externalLinks": ["https://example.com/notice"],
+      "referenceFiles": [
+        {
+          "id": "reference-file-uuid",
+          "fileUrl": "https://storage.example.com/schedule-references/uuid.pdf",
+          "fileName": "합주 공지.pdf",
+          "createdAt": "2026-04-30T14:16:00.000+09:00"
+        }
+      ],
       "createdByBandMemberId": "band-member-uuid",
       "createdAt": "2026-04-30T14:16:00.000+09:00",
       "updatedAt": "2026-04-30T14:16:00.000+09:00"

--- a/backend/prisma/migrations/20260811090000_add_schedule_attachments/migration.sql
+++ b/backend/prisma/migrations/20260811090000_add_schedule_attachments/migration.sql
@@ -1,0 +1,19 @@
+-- AlterTable
+ALTER TABLE "schedules"
+ADD COLUMN "external_links" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+
+-- CreateTable
+CREATE TABLE "schedule_reference_files" (
+    "id" UUID NOT NULL,
+    "schedule_id" UUID NOT NULL,
+    "file_url" TEXT NOT NULL,
+    "file_name" VARCHAR(255) NOT NULL,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "schedule_reference_files_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "schedule_reference_files"
+ADD CONSTRAINT "schedule_reference_files_schedule_id_fkey"
+FOREIGN KEY ("schedule_id") REFERENCES "schedules"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -336,26 +336,39 @@ model SongReferenceFile {
 }
 
 model Schedule {
-  id                    String                @id @default(uuid()) @db.Uuid
-  bandSpaceId           String                @map("band_space_id") @db.Uuid
-  placeId               String?               @map("place_id") @db.Uuid
-  title                 String                @db.VarChar(150)
-  scheduleType          ScheduleType          @map("schedule_type")
-  startAt               DateTime?             @map("start_at") @db.Timestamptz(6)
-  endAt                 DateTime?             @map("end_at") @db.Timestamptz(6)
+  id                    String                  @id @default(uuid()) @db.Uuid
+  bandSpaceId           String                  @map("band_space_id") @db.Uuid
+  placeId               String?                 @map("place_id") @db.Uuid
+  title                 String                  @db.VarChar(150)
+  scheduleType          ScheduleType            @map("schedule_type")
+  startAt               DateTime?               @map("start_at") @db.Timestamptz(6)
+  endAt                 DateTime?               @map("end_at") @db.Timestamptz(6)
   memo                  String?
-  status                ScheduleStatus        @default(PLANNED)
-  createdByBandMemberId String                @map("created_by_band_member_id") @db.Uuid
-  createdAt             DateTime              @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt             DateTime              @updatedAt @map("updated_at") @db.Timestamptz(6)
+  externalLinks         String[]                @default([]) @map("external_links")
+  status                ScheduleStatus          @default(PLANNED)
+  createdByBandMemberId String                  @map("created_by_band_member_id") @db.Uuid
+  createdAt             DateTime                @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt             DateTime                @updatedAt @map("updated_at") @db.Timestamptz(6)
   participants          ScheduleParticipant[]
   scheduleSongs         ScheduleSong[]
   scheduleTeams         ScheduleTeam[]
-  bandSpace             BandSpace             @relation(fields: [bandSpaceId], references: [id])
-  createdByBandMember   BandMember            @relation("ScheduleCreator", fields: [createdByBandMemberId], references: [id])
-  place                 Place?                @relation(fields: [placeId], references: [id])
+  referenceFiles        ScheduleReferenceFile[]
+  bandSpace             BandSpace               @relation(fields: [bandSpaceId], references: [id])
+  createdByBandMember   BandMember              @relation("ScheduleCreator", fields: [createdByBandMemberId], references: [id])
+  place                 Place?                  @relation(fields: [placeId], references: [id])
 
   @@map("schedules")
+}
+
+model ScheduleReferenceFile {
+  id         String   @id @default(uuid()) @db.Uuid
+  scheduleId String   @map("schedule_id") @db.Uuid
+  fileUrl    String   @map("file_url")
+  fileName   String   @map("file_name") @db.VarChar(255)
+  createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  schedule   Schedule @relation(fields: [scheduleId], references: [id], onDelete: Cascade)
+
+  @@map("schedule_reference_files")
 }
 
 model ScheduleParticipant {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { PrismaModule } from './database/prisma';
 import { BandsModule } from './modules/bands/bands.module';
 import { BandSpacesModule } from './modules/bandspaces/bandspaces.module';
 import { CommonModule } from './modules/common/common.module';
+import { LinkPreviewsModule } from './modules/link-previews/link-previews.module';
 import { NotificationsModule } from './modules/notifications/notifications.module';
 import { PlacesModule } from './modules/places/places.module';
 import { SchedulesModule } from './modules/schedules/schedules.module';
@@ -27,6 +28,7 @@ import { StorageModule } from './storage/storage.module';
     BandsModule,
     SchedulesModule,
     CommonModule,
+    LinkPreviewsModule,
     PlacesModule,
     TeamsModule,
   ],

--- a/backend/src/common/validation-message/url-validation.message.ts
+++ b/backend/src/common/validation-message/url-validation.message.ts
@@ -1,0 +1,3 @@
+import type { ValidationArguments } from 'class-validator';
+
+export const urlValidationMessage = (args: ValidationArguments) => `${args.property}은(는) 올바른 URL 형식이어야 합니다.`;

--- a/backend/src/modules/link-previews/dto/get-link-preview-query.dto.ts
+++ b/backend/src/modules/link-previews/dto/get-link-preview-query.dto.ts
@@ -1,0 +1,21 @@
+import { Transform } from 'class-transformer';
+import { IsUrl } from 'class-validator';
+
+import { trimStringValue } from '../../../common/validation/transform.util';
+import { urlValidationMessage } from '../../../common/validation-message/url-validation.message';
+
+/**
+ * 링크 미리보기 요청 URL을 검증한다.
+ */
+export class GetLinkPreviewQueryDto {
+  @Transform(trimStringValue)
+  @IsUrl(
+    {
+      protocols: ['http', 'https'],
+      require_protocol: true,
+      require_valid_protocol: true,
+    },
+    { message: urlValidationMessage },
+  )
+  url!: string;
+}

--- a/backend/src/modules/link-previews/link-preview-http.client.spec.ts
+++ b/backend/src/modules/link-previews/link-preview-http.client.spec.ts
@@ -1,0 +1,14 @@
+import { isBlockedLinkPreviewAddress } from './link-preview-http.client';
+
+describe('isBlockedLinkPreviewAddress', () => {
+  it.each(['127.0.0.1', '10.0.0.1', '169.254.169.254', '192.168.0.1', '::1', 'fc00::1', 'fe80::1', '::ffff:127.0.0.1'])(
+    '사설·로컬·예약 주소 %s를 차단한다',
+    address => {
+      expect(isBlockedLinkPreviewAddress(address)).toBe(true);
+    },
+  );
+
+  it.each(['8.8.8.8', '1.1.1.1', '2606:4700:4700::1111'])('공인 주소 %s를 허용한다', address => {
+    expect(isBlockedLinkPreviewAddress(address)).toBe(false);
+  });
+});

--- a/backend/src/modules/link-previews/link-preview-http.client.ts
+++ b/backend/src/modules/link-previews/link-preview-http.client.ts
@@ -1,0 +1,242 @@
+import { lookup } from 'node:dns/promises';
+import { type IncomingMessage, request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { BlockList, isIP } from 'node:net';
+
+import { Injectable } from '@nestjs/common';
+
+import type { LinkPreviewMetadata } from './types/link-preview.type';
+import { parseLinkPreviewHtml } from './link-preview.parser';
+
+export interface LinkPreviewReader {
+  readLinkPreview(url: string): Promise<LinkPreviewMetadata>;
+}
+
+export const LINK_PREVIEW_READER = Symbol('LINK_PREVIEW_READER');
+
+const REQUEST_TIMEOUT_MS = 5_000;
+const MAX_REDIRECT_COUNT = 5;
+const MAX_HTML_BYTES = 512 * 1024;
+
+const blockedIpv4Addresses = new BlockList();
+blockedIpv4Addresses.addSubnet('0.0.0.0', 8, 'ipv4');
+blockedIpv4Addresses.addSubnet('10.0.0.0', 8, 'ipv4');
+blockedIpv4Addresses.addSubnet('100.64.0.0', 10, 'ipv4');
+blockedIpv4Addresses.addSubnet('127.0.0.0', 8, 'ipv4');
+blockedIpv4Addresses.addSubnet('169.254.0.0', 16, 'ipv4');
+blockedIpv4Addresses.addSubnet('172.16.0.0', 12, 'ipv4');
+blockedIpv4Addresses.addSubnet('192.0.0.0', 24, 'ipv4');
+blockedIpv4Addresses.addSubnet('192.0.2.0', 24, 'ipv4');
+blockedIpv4Addresses.addSubnet('192.168.0.0', 16, 'ipv4');
+blockedIpv4Addresses.addSubnet('198.18.0.0', 15, 'ipv4');
+blockedIpv4Addresses.addSubnet('198.51.100.0', 24, 'ipv4');
+blockedIpv4Addresses.addSubnet('203.0.113.0', 24, 'ipv4');
+blockedIpv4Addresses.addSubnet('224.0.0.0', 4, 'ipv4');
+blockedIpv4Addresses.addSubnet('240.0.0.0', 4, 'ipv4');
+
+const blockedIpv6Addresses = new BlockList();
+blockedIpv6Addresses.addAddress('::', 'ipv6');
+blockedIpv6Addresses.addAddress('::1', 'ipv6');
+blockedIpv6Addresses.addSubnet('::ffff:0:0', 96, 'ipv6');
+blockedIpv6Addresses.addSubnet('64:ff9b::', 96, 'ipv6');
+blockedIpv6Addresses.addSubnet('100::', 64, 'ipv6');
+blockedIpv6Addresses.addSubnet('2001:db8::', 32, 'ipv6');
+blockedIpv6Addresses.addSubnet('fc00::', 7, 'ipv6');
+blockedIpv6Addresses.addSubnet('fe80::', 10, 'ipv6');
+blockedIpv6Addresses.addSubnet('ff00::', 8, 'ipv6');
+
+interface ResolvedAddress {
+  address: string;
+  family: 4 | 6;
+}
+
+interface LinkPreviewHttpResponse {
+  html: string;
+  finalUrl: URL;
+}
+
+/**
+ * 외부 요청에 사용할 수 없는 사설·로컬·예약 IP인지 확인한다.
+ *
+ * @param {string} address - DNS 조회로 얻은 IP 주소
+ * @returns {boolean} 외부 요청이 차단되어야 하면 true
+ */
+export function isBlockedLinkPreviewAddress(address: string): boolean {
+  const family = isIP(address);
+
+  if (family === 4) {
+    return blockedIpv4Addresses.check(address, 'ipv4');
+  }
+
+  if (family === 6) {
+    return blockedIpv6Addresses.check(address, 'ipv6');
+  }
+
+  return true;
+}
+
+function validateProtocol(url: URL): void {
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('HTTP 또는 HTTPS URL만 조회할 수 있습니다.');
+  }
+
+  if (url.username.length > 0 || url.password.length > 0) {
+    throw new Error('인증 정보가 포함된 URL은 조회할 수 없습니다.');
+  }
+}
+
+async function resolvePublicAddress(url: URL): Promise<ResolvedAddress> {
+  validateProtocol(url);
+
+  const hostname = url.hostname.replace(/\.$/, '').toLowerCase();
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
+    throw new Error('로컬 주소는 조회할 수 없습니다.');
+  }
+
+  const addresses = await lookup(hostname, { all: true, verbatim: true });
+  if (addresses.length === 0 || addresses.some(item => isBlockedLinkPreviewAddress(item.address))) {
+    throw new Error('외부 공개 주소만 조회할 수 있습니다.');
+  }
+
+  const [selectedAddress] = addresses;
+  if (selectedAddress === undefined || (selectedAddress.family !== 4 && selectedAddress.family !== 6)) {
+    throw new Error('URL 주소를 확인할 수 없습니다.');
+  }
+
+  return {
+    address: selectedAddress.address,
+    family: selectedAddress.family,
+  };
+}
+
+function readResponseBody(response: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let html = '';
+    let receivedBytes = 0;
+    let completed = false;
+
+    const finish = (): void => {
+      if (completed) {
+        return;
+      }
+
+      completed = true;
+      resolve(html);
+    };
+
+    response.setEncoding('utf8');
+    response.on('data', (chunk: string) => {
+      if (completed) {
+        return;
+      }
+
+      receivedBytes += Buffer.byteLength(chunk);
+      if (receivedBytes > MAX_HTML_BYTES) {
+        finish();
+        response.destroy();
+        return;
+      }
+
+      html += chunk;
+      if (/<\/head>/i.test(html)) {
+        finish();
+        response.destroy();
+      }
+    });
+    response.on('end', finish);
+    response.on('error', error => {
+      if (!completed) {
+        reject(error);
+      }
+    });
+  });
+}
+
+async function requestHtml(url: URL, address: ResolvedAddress): Promise<{ html?: string; redirectUrl?: URL }> {
+  return new Promise((resolve, reject) => {
+    const requestOptions = {
+      protocol: url.protocol,
+      hostname: address.address,
+      family: address.family,
+      port: url.port || undefined,
+      path: `${url.pathname}${url.search}`,
+      method: 'GET',
+      headers: {
+        Accept: 'text/html,application/xhtml+xml',
+        'Accept-Encoding': 'identity',
+        Host: url.host,
+        'User-Agent': 'JamPlay-LinkPreview/1.0',
+      },
+    };
+
+    const onResponse = (response: IncomingMessage): void => {
+      const statusCode = response.statusCode ?? 0;
+      const location = response.headers.location;
+
+      if (statusCode >= 300 && statusCode < 400 && location !== undefined) {
+        response.resume();
+        resolve({ redirectUrl: new URL(location, url) });
+        return;
+      }
+
+      if (statusCode < 200 || statusCode >= 300) {
+        response.resume();
+        reject(new Error(`외부 페이지가 ${statusCode} 상태를 반환했습니다.`));
+        return;
+      }
+
+      const contentType = response.headers['content-type']?.toLowerCase() ?? '';
+      if (!contentType.includes('text/html') && !contentType.includes('application/xhtml+xml')) {
+        response.resume();
+        reject(new Error('HTML 페이지가 아닙니다.'));
+        return;
+      }
+
+      void readResponseBody(response).then(html => resolve({ html }), reject);
+    };
+
+    const request =
+      url.protocol === 'https:' ? httpsRequest({ ...requestOptions, servername: url.hostname }, onResponse) : httpRequest(requestOptions, onResponse);
+
+    request.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      request.destroy(new Error('외부 페이지 조회 시간이 초과되었습니다.'));
+    });
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+async function fetchHtml(url: URL): Promise<LinkPreviewHttpResponse> {
+  let currentUrl = url;
+
+  for (let redirectCount = 0; redirectCount <= MAX_REDIRECT_COUNT; redirectCount += 1) {
+    const address = await resolvePublicAddress(currentUrl);
+    const response = await requestHtml(currentUrl, address);
+
+    if (response.html !== undefined) {
+      return { html: response.html, finalUrl: currentUrl };
+    }
+
+    if (response.redirectUrl === undefined || redirectCount === MAX_REDIRECT_COUNT) {
+      throw new Error('외부 페이지의 리다이렉트 횟수를 초과했습니다.');
+    }
+
+    currentUrl = response.redirectUrl;
+  }
+
+  throw new Error('외부 페이지를 조회하지 못했습니다.');
+}
+
+@Injectable()
+export class LinkPreviewHttpClient implements LinkPreviewReader {
+  /**
+   * SSRF 방어가 적용된 HTTP 요청으로 링크 미리보기 메타데이터를 읽는다.
+   *
+   * @param {string} url - 조회할 외부 절대 URL
+   * @returns {Promise<LinkPreviewMetadata>} 파싱된 링크 메타데이터
+   */
+  async readLinkPreview(url: string): Promise<LinkPreviewMetadata> {
+    const response = await fetchHtml(new URL(url));
+    return parseLinkPreviewHtml(response.html, response.finalUrl);
+  }
+}

--- a/backend/src/modules/link-previews/link-preview.parser.spec.ts
+++ b/backend/src/modules/link-previews/link-preview.parser.spec.ts
@@ -1,0 +1,32 @@
+import { parseLinkPreviewHtml } from './link-preview.parser';
+
+describe('parseLinkPreviewHtml', () => {
+  it('og:title을 title보다 우선하고 상대 favicon을 절대 URL로 변환한다', () => {
+    const html = `
+      <html>
+        <head>
+          <title>HTML Title</title>
+          <meta content="BandCo &amp; JIRA" property="og:title" />
+          <meta property="og:site_name" content="Jira" />
+          <link href="/assets/favicon.ico" rel="shortcut icon" />
+        </head>
+      </html>
+    `;
+
+    expect(parseLinkPreviewHtml(html, new URL('https://bandco.atlassian.net/jira/project'))).toEqual({
+      title: 'BandCo & JIRA',
+      siteName: 'Jira',
+      faviconUrl: 'https://bandco.atlassian.net/assets/favicon.ico',
+    });
+  });
+
+  it('og:title이 없으면 title을 사용하고 없는 필드는 null로 반환한다', () => {
+    const html = '<html><head><title>  BandCo   Docs  </title></head></html>';
+
+    expect(parseLinkPreviewHtml(html, new URL('https://docs.example.com'))).toEqual({
+      title: 'BandCo Docs',
+      siteName: null,
+      faviconUrl: null,
+    });
+  });
+});

--- a/backend/src/modules/link-previews/link-preview.parser.ts
+++ b/backend/src/modules/link-previews/link-preview.parser.ts
@@ -1,0 +1,113 @@
+import type { LinkPreviewMetadata } from './types/link-preview.type';
+
+const ATTRIBUTE_PATTERN = /([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+
+function decodeHtmlEntities(value: string): string {
+  const namedEntities: Record<string, string> = {
+    amp: '&',
+    apos: "'",
+    gt: '>',
+    lt: '<',
+    nbsp: ' ',
+    quot: '"',
+  };
+
+  return value.replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (entity, code: string) => {
+    if (code.startsWith('#x') || code.startsWith('#X')) {
+      return String.fromCodePoint(Number.parseInt(code.slice(2), 16));
+    }
+
+    if (code.startsWith('#')) {
+      return String.fromCodePoint(Number.parseInt(code.slice(1), 10));
+    }
+
+    return namedEntities[code.toLowerCase()] ?? entity;
+  });
+}
+
+function normalizeText(value: string | undefined): string | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  const normalized = decodeHtmlEntities(value).replace(/\s+/g, ' ').trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function parseAttributes(tag: string): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  const content = tag.replace(/^<\/?[a-z0-9:-]+/i, '').replace(/\/?\s*>$/, '');
+
+  for (const match of content.matchAll(ATTRIBUTE_PATTERN)) {
+    const [, rawName, doubleQuoted, singleQuoted, unquoted] = match;
+    if (rawName === undefined) {
+      continue;
+    }
+
+    attributes[rawName.toLowerCase()] = doubleQuoted ?? singleQuoted ?? unquoted ?? '';
+  }
+
+  return attributes;
+}
+
+function findOpenGraphContent(head: string, property: string): string | null {
+  const metaTags = head.match(/<meta\b[^>]*>/gi) ?? [];
+
+  for (const tag of metaTags) {
+    const attributes = parseAttributes(tag);
+    const propertyName = attributes.property ?? attributes.name;
+
+    if (propertyName?.toLowerCase() === property) {
+      return normalizeText(attributes.content);
+    }
+  }
+
+  return null;
+}
+
+function findTitle(head: string): string | null {
+  const match = /<title\b[^>]*>([\s\S]*?)<\/title>/i.exec(head);
+  return normalizeText(match?.[1]);
+}
+
+function findFaviconUrl(head: string, baseUrl: URL): string | null {
+  const linkTags = head.match(/<link\b[^>]*>/gi) ?? [];
+
+  for (const tag of linkTags) {
+    const attributes = parseAttributes(tag);
+    const relTokens = attributes.rel?.toLowerCase().split(/\s+/) ?? [];
+
+    if (!relTokens.includes('icon') || attributes.href === undefined) {
+      continue;
+    }
+
+    try {
+      const faviconUrl = new URL(attributes.href, baseUrl);
+      if (faviconUrl.protocol === 'http:' || faviconUrl.protocol === 'https:') {
+        return faviconUrl.toString();
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * HTML head에서 화면에 필요한 최소 링크 메타데이터만 추출한다.
+ *
+ * @param {string} html - 외부 페이지 HTML
+ * @param {URL} baseUrl - 상대 favicon URL을 해석할 최종 응답 URL
+ * @returns {LinkPreviewMetadata} 링크 미리보기 메타데이터
+ */
+export function parseLinkPreviewHtml(html: string, baseUrl: URL): LinkPreviewMetadata {
+  const headMatch = /<head\b[^>]*>([\s\S]*?)(?:<\/head>|$)/i.exec(html);
+  const head = headMatch?.[1] ?? html;
+
+  return {
+    title: findOpenGraphContent(head, 'og:title') ?? findTitle(head),
+    siteName: findOpenGraphContent(head, 'og:site_name'),
+    faviconUrl: findFaviconUrl(head, baseUrl),
+  };
+}

--- a/backend/src/modules/link-previews/link-previews.controller.ts
+++ b/backend/src/modules/link-previews/link-previews.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { type ApiSuccessResponse, createSuccessResponse } from '../../common/api-response';
+
+import { GetLinkPreviewQueryDto } from './dto/get-link-preview-query.dto';
+import type { LinkPreview } from './types/link-preview.type';
+import { LinkPreviewsService } from './link-previews.service';
+
+@ApiTags('링크 미리보기')
+@Controller('link-previews')
+export class LinkPreviewsController {
+  constructor(private readonly linkPreviewsService: LinkPreviewsService) {}
+
+  @Get()
+  @ApiOperation({ summary: '외부 링크 미리보기 조회' })
+  @ApiResponse({ status: 200, description: '링크 미리보기 조회 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 URL 형식' })
+  async getLinkPreview(@Query() query: GetLinkPreviewQueryDto): Promise<ApiSuccessResponse<LinkPreview>> {
+    const result = await this.linkPreviewsService.getLinkPreview(query.url);
+    return createSuccessResponse('링크 미리보기 조회 성공', result);
+  }
+}

--- a/backend/src/modules/link-previews/link-previews.module.ts
+++ b/backend/src/modules/link-previews/link-previews.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+
+import { LINK_PREVIEW_READER, LinkPreviewHttpClient } from './link-preview-http.client';
+import { LinkPreviewsController } from './link-previews.controller';
+import { LinkPreviewsService } from './link-previews.service';
+
+@Module({
+  controllers: [LinkPreviewsController],
+  providers: [
+    LinkPreviewsService,
+    LinkPreviewHttpClient,
+    {
+      provide: LINK_PREVIEW_READER,
+      useExisting: LinkPreviewHttpClient,
+    },
+  ],
+})
+export class LinkPreviewsModule {}

--- a/backend/src/modules/link-previews/link-previews.service.spec.ts
+++ b/backend/src/modules/link-previews/link-previews.service.spec.ts
@@ -1,0 +1,42 @@
+import type { LinkPreviewReader } from './link-preview-http.client';
+import { LinkPreviewsService } from './link-previews.service';
+
+const LINK_URL = 'https://bandco.atlassian.net/jira/project';
+
+describe('LinkPreviewsService', () => {
+  it('외부 페이지의 링크 미리보기 정보를 반환한다', async () => {
+    const reader: LinkPreviewReader = {
+      async readLinkPreview() {
+        return {
+          title: 'BandCo JIRA',
+          siteName: 'Jira',
+          faviconUrl: 'https://bandco.atlassian.net/favicon.ico',
+        };
+      },
+    };
+    const service = new LinkPreviewsService(reader);
+
+    await expect(service.getLinkPreview(LINK_URL)).resolves.toEqual({
+      url: LINK_URL,
+      title: 'BandCo JIRA',
+      siteName: 'Jira',
+      faviconUrl: 'https://bandco.atlassian.net/favicon.ico',
+    });
+  });
+
+  it('외부 페이지를 읽지 못하면 원본 URL과 null 메타데이터를 반환한다', async () => {
+    const reader: LinkPreviewReader = {
+      async readLinkPreview() {
+        throw new Error('조회 실패');
+      },
+    };
+    const service = new LinkPreviewsService(reader);
+
+    await expect(service.getLinkPreview(LINK_URL)).resolves.toEqual({
+      url: LINK_URL,
+      title: null,
+      siteName: null,
+      faviconUrl: null,
+    });
+  });
+});

--- a/backend/src/modules/link-previews/link-previews.service.ts
+++ b/backend/src/modules/link-previews/link-previews.service.ts
@@ -1,0 +1,32 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import type { LinkPreview } from './types/link-preview.type';
+import { LINK_PREVIEW_READER, type LinkPreviewReader } from './link-preview-http.client';
+
+@Injectable()
+export class LinkPreviewsService {
+  constructor(
+    @Inject(LINK_PREVIEW_READER)
+    private readonly linkPreviewReader: LinkPreviewReader,
+  ) {}
+
+  /**
+   * 외부 페이지를 읽지 못해도 원본 URL과 비어 있는 메타데이터를 반환한다.
+   *
+   * @param {string} url - 미리보기를 조회할 절대 URL
+   * @returns {Promise<LinkPreview>} 프론트 폴백이 가능한 링크 미리보기
+   */
+  async getLinkPreview(url: string): Promise<LinkPreview> {
+    try {
+      const metadata = await this.linkPreviewReader.readLinkPreview(url);
+      return { url, ...metadata };
+    } catch {
+      return {
+        url,
+        title: null,
+        siteName: null,
+        faviconUrl: null,
+      };
+    }
+  }
+}

--- a/backend/src/modules/link-previews/types/link-preview.type.ts
+++ b/backend/src/modules/link-previews/types/link-preview.type.ts
@@ -1,0 +1,9 @@
+export interface LinkPreviewMetadata {
+  title: string | null;
+  siteName: string | null;
+  faviconUrl: string | null;
+}
+
+export interface LinkPreview extends LinkPreviewMetadata {
+  url: string;
+}

--- a/backend/src/modules/notifications/notifications.controller.ts
+++ b/backend/src/modules/notifications/notifications.controller.ts
@@ -14,6 +14,7 @@ import type { MarkAllReadResult } from './types/mark-all-read-result.type';
 import type { MarkManyReadResult } from './types/mark-many-read-result.type';
 import type { MarkNotificationReadResult } from './types/mark-notification-read-result.type';
 import type { GetNotificationsResult } from './types/notification-list-item.type';
+import type { NotificationUnreadSummary } from './types/notification-unread-summary.type';
 import { NotificationsService } from './notifications.service';
 
 @ApiTags('알림')
@@ -22,6 +23,15 @@ import { NotificationsService } from './notifications.service';
 @UseGuards(AccessTokenGuard)
 export class NotificationsController {
   constructor(private readonly notificationsService: NotificationsService) {}
+
+  @Get('unread-summary')
+  @ApiOperation({ summary: '읽지 않은 알림 개수 조회' })
+  @ApiResponse({ status: 200, description: '읽지 않은 알림 개수 조회 성공' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  async getUnreadSummary(@Req() req: { user: AuthUser }): Promise<ApiSuccessResponse<NotificationUnreadSummary>> {
+    const result = await this.notificationsService.getUnreadSummary(req.user.id);
+    return createSuccessResponse('읽지 않은 알림 개수 조회 성공', result);
+  }
 
   @Get('me')
   @ApiOperation({ summary: '알림 목록 조회' })

--- a/backend/src/modules/notifications/notifications.service.spec.ts
+++ b/backend/src/modules/notifications/notifications.service.spec.ts
@@ -10,6 +10,7 @@ import type { MarkAllReadResult } from './types/mark-all-read-result.type';
 import type { MarkManyReadResult } from './types/mark-many-read-result.type';
 import type { MarkNotificationReadResult } from './types/mark-notification-read-result.type';
 import type { GetNotificationsResult } from './types/notification-list-item.type';
+import type { NotificationUnreadSummary } from './types/notification-unread-summary.type';
 import { NotificationsService } from './notifications.service';
 
 const mockListResult: GetNotificationsResult = {
@@ -42,6 +43,10 @@ const mockAllReadResult: MarkAllReadResult = { updatedCount: 3 };
 const mockManyReadResult: MarkManyReadResult = { updatedCount: 2, notificationIds: ['noti-001', 'noti-002'] };
 const mockDeleteResult: DeleteNotificationResult = { notificationId: 'noti-001' };
 const mockDeleteManyResult: DeleteManyNotificationsResult = { deletedCount: 2, notificationIds: ['noti-001', 'noti-002'] };
+const mockUnreadSummary: NotificationUnreadSummary = {
+  unreadCount: 3,
+  unreadByType: { INVITE: 2, NOTICE: 1, REMINDER: 0 },
+};
 
 const repositoryStub: NotificationsRepository = {
   async createNotification() {
@@ -52,6 +57,9 @@ const repositoryStub: NotificationsRepository = {
   },
   async findNotifications() {
     return mockListResult;
+  },
+  async findUnreadSummary() {
+    return mockUnreadSummary;
   },
   async markAllNotificationsAsRead() {
     return mockAllReadResult;
@@ -87,6 +95,12 @@ describe('NotificationsService', () => {
       const result = await service.getNotifications('user-001', query);
       expect(result.items).toHaveLength(1);
       expect(result.meta.next).toBeNull();
+    });
+  });
+
+  describe('getUnreadSummary', () => {
+    it('repository의 타입별 미읽음 개수를 반환한다', async () => {
+      await expect(service.getUnreadSummary('user-001')).resolves.toEqual(mockUnreadSummary);
     });
   });
 

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -8,6 +8,7 @@ import {
   NOTIFICATIONS_REPOSITORY,
   type NotificationsRepository,
 } from './repositories/notifications.repository';
+import type { NotificationUnreadSummary } from './types/notification-unread-summary.type';
 
 @Injectable()
 export class NotificationsService {
@@ -26,6 +27,10 @@ export class NotificationsService {
 
   async getNotifications(userId: string, query: GetNotificationsQuery, tx?: Prisma.TransactionClient) {
     return this.notificationsRepository.findNotifications(userId, query, tx);
+  }
+
+  async getUnreadSummary(userId: string, tx?: Prisma.TransactionClient): Promise<NotificationUnreadSummary> {
+    return this.notificationsRepository.findUnreadSummary(userId, tx);
   }
 
   async markManyNotificationsAsRead(userId: string, notificationIds: string[], tx?: Prisma.TransactionClient) {

--- a/backend/src/modules/notifications/repositories/notifications.prisma-repository.spec.ts
+++ b/backend/src/modules/notifications/repositories/notifications.prisma-repository.spec.ts
@@ -20,6 +20,7 @@ const mockPrisma = {
     create: jest.fn(),
     createMany: jest.fn(),
     findMany: jest.fn(),
+    groupBy: jest.fn(),
     findFirst: jest.fn(),
     update: jest.fn(),
     updateMany: jest.fn(),
@@ -43,6 +44,36 @@ describe('NotificationsPrismaRepository', () => {
     repository = module.get(NotificationsPrismaRepository);
     jest.clearAllMocks();
     mockPrisma.$transaction.mockImplementation((fn: (tx: typeof mockPrisma) => unknown) => fn(mockPrisma));
+  });
+
+  describe('findUnreadSummary', () => {
+    it('타입별 미읽음 개수와 전체 개수를 반환한다', async () => {
+      mockPrisma.notification.groupBy.mockResolvedValue([
+        { type: 'INVITE', _count: { _all: 2 } },
+        { type: 'NOTICE', _count: { _all: 3 } },
+      ]);
+
+      const result = await repository.findUnreadSummary('user-001');
+
+      expect(mockPrisma.notification.groupBy).toHaveBeenCalledWith({
+        by: ['type'],
+        where: { userId: 'user-001', isRead: false },
+        _count: { _all: true },
+      });
+      expect(result).toEqual({
+        unreadCount: 5,
+        unreadByType: { INVITE: 2, NOTICE: 3, REMINDER: 0 },
+      });
+    });
+
+    it('읽지 않은 알림이 없으면 모든 개수를 0으로 반환한다', async () => {
+      mockPrisma.notification.groupBy.mockResolvedValue([]);
+
+      await expect(repository.findUnreadSummary('user-001')).resolves.toEqual({
+        unreadCount: 0,
+        unreadByType: { INVITE: 0, NOTICE: 0, REMINDER: 0 },
+      });
+    });
   });
 
   describe('findNotifications', () => {

--- a/backend/src/modules/notifications/repositories/notifications.prisma-repository.ts
+++ b/backend/src/modules/notifications/repositories/notifications.prisma-repository.ts
@@ -11,6 +11,7 @@ import type { MarkAllReadResult } from '../types/mark-all-read-result.type';
 import type { MarkManyReadResult } from '../types/mark-many-read-result.type';
 import type { MarkNotificationReadResult } from '../types/mark-notification-read-result.type';
 import type { GetNotificationsResult, NotificationListItem, NotificationReference } from '../types/notification-list-item.type';
+import type { NotificationUnreadSummary } from '../types/notification-unread-summary.type';
 
 import type { CreateNotificationRepositoryInput, NotificationsRepository } from './notifications.repository';
 
@@ -114,6 +115,28 @@ export class NotificationsPrismaRepository implements NotificationsRepository {
       items: notifications.map(n => this.mapNotification(n, references)),
       meta: { count, take: query.take, next },
     };
+  }
+
+  async findUnreadSummary(userId: string, tx?: Prisma.TransactionClient): Promise<NotificationUnreadSummary> {
+    const client = this.getClient(tx);
+    const counts = await client.notification.groupBy({
+      by: ['type'],
+      where: { userId, isRead: false },
+      _count: { _all: true },
+    });
+
+    const unreadByType = {
+      INVITE: 0,
+      NOTICE: 0,
+      REMINDER: 0,
+    } satisfies Record<NotificationType, number>;
+
+    for (const count of counts) {
+      unreadByType[count.type] = count._count._all;
+    }
+
+    const unreadCount = Object.values(unreadByType).reduce((total, count) => total + count, 0);
+    return { unreadCount, unreadByType };
   }
 
   /**

--- a/backend/src/modules/notifications/repositories/notifications.repository.ts
+++ b/backend/src/modules/notifications/repositories/notifications.repository.ts
@@ -6,6 +6,7 @@ import type { MarkAllReadResult } from '../types/mark-all-read-result.type';
 import type { MarkManyReadResult } from '../types/mark-many-read-result.type';
 import type { MarkNotificationReadResult } from '../types/mark-notification-read-result.type';
 import type { GetNotificationsResult } from '../types/notification-list-item.type';
+import type { NotificationUnreadSummary } from '../types/notification-unread-summary.type';
 
 export const NOTIFICATIONS_REPOSITORY = Symbol('NOTIFICATIONS_REPOSITORY');
 
@@ -24,6 +25,7 @@ export interface NotificationsRepository {
   createNotification(input: CreateNotificationRepositoryInput, tx?: Prisma.TransactionClient): Promise<void>;
   createManyNotifications(inputs: CreateNotificationRepositoryInput[], tx?: Prisma.TransactionClient): Promise<void>;
   findNotifications(userId: string, query: GetNotificationsQuery, tx?: Prisma.TransactionClient): Promise<GetNotificationsResult>;
+  findUnreadSummary(userId: string, tx?: Prisma.TransactionClient): Promise<NotificationUnreadSummary>;
   markAllNotificationsAsRead(userId: string, tx?: Prisma.TransactionClient): Promise<MarkAllReadResult>;
   markManyNotificationsAsRead(userId: string, notificationIds: string[], tx?: Prisma.TransactionClient): Promise<MarkManyReadResult>;
   markNotificationAsRead(userId: string, notificationId: string, tx?: Prisma.TransactionClient): Promise<MarkNotificationReadResult | undefined>;

--- a/backend/src/modules/notifications/types/notification-unread-summary.type.ts
+++ b/backend/src/modules/notifications/types/notification-unread-summary.type.ts
@@ -1,0 +1,6 @@
+import type { NotificationType } from '../../../generated/prisma';
+
+export interface NotificationUnreadSummary {
+  unreadCount: number;
+  unreadByType: Record<NotificationType, number>;
+}

--- a/backend/src/modules/schedules/dto/create-schedule.dto.ts
+++ b/backend/src/modules/schedules/dto/create-schedule.dto.ts
@@ -1,5 +1,6 @@
-import { Transform } from 'class-transformer';
-import { IsArray, IsEnum, IsISO8601, IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import { IsArray, IsEnum, IsISO8601, IsNotEmpty, IsOptional, IsString, IsUUID, ValidateNested } from 'class-validator';
 import { enumValidationMessage } from 'src/common/validation-message/enum-validation.message';
 import { iso8601ValidationMessage } from 'src/common/validation-message/iso8601-validation.message';
 import { notemptyValidationMessage } from 'src/common/validation-message/notempty-validation.message';
@@ -8,6 +9,8 @@ import { uuidValidationMessage } from 'src/common/validation-message/uuid-valida
 
 import { trimStringValue } from '../../../common/validation/transform.util';
 import { ScheduleStatus, ScheduleType } from '../../../generated/prisma';
+
+import { ScheduleReferenceFileDto } from './schedule-reference-file.dto';
 
 /**
  * 일정 생성 요청 본문을 검증한다.
@@ -57,6 +60,20 @@ export class CreateScheduleBodyDto {
   @IsOptional()
   @IsString({ message: stringValidationMessage })
   memo?: string;
+
+  @ApiPropertyOptional({ description: '일정 관련 외부 링크 목록', type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true, message: stringValidationMessage })
+  @IsNotEmpty({ each: true, message: notemptyValidationMessage })
+  externalLinks?: string[];
+
+  @ApiPropertyOptional({ description: '일정 참고자료 파일 목록', type: [ScheduleReferenceFileDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ScheduleReferenceFileDto)
+  referenceFiles?: ScheduleReferenceFileDto[];
 }
 
 export type CreateScheduleInput = CreateScheduleBodyDto;

--- a/backend/src/modules/schedules/dto/schedule-reference-file.dto.ts
+++ b/backend/src/modules/schedules/dto/schedule-reference-file.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+import { lengthValidationMessage } from '../../../common/validation-message/length-validation.message';
+import { notemptyValidationMessage } from '../../../common/validation-message/notempty-validation.message';
+import { stringValidationMessage } from '../../../common/validation-message/string-validation.message';
+
+/**
+ * 일정 참고자료 파일 항목. fileUrl은 storage 모듈 업로드 후 반환된 objectUrl이다.
+ */
+export class ScheduleReferenceFileDto {
+  @ApiProperty({ description: '파일 URL (storage 업로드 후 objectUrl)', example: 'https://.../schedule-references/uuid.pdf' })
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty({ message: notemptyValidationMessage })
+  fileUrl!: string;
+
+  @ApiProperty({ description: '원본 파일명 (최대 255자)', example: '합주_공지.pdf' })
+  @IsString({ message: stringValidationMessage })
+  @IsNotEmpty({ message: notemptyValidationMessage })
+  @MaxLength(255, { message: lengthValidationMessage })
+  fileName!: string;
+}

--- a/backend/src/modules/schedules/dto/update-schedule.dto.ts
+++ b/backend/src/modules/schedules/dto/update-schedule.dto.ts
@@ -1,5 +1,6 @@
-import { Transform } from 'class-transformer';
-import { IsArray, IsEnum, IsISO8601, IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import { IsArray, IsEnum, IsISO8601, IsNotEmpty, IsOptional, IsString, IsUUID, ValidateNested } from 'class-validator';
 import { enumValidationMessage } from 'src/common/validation-message/enum-validation.message';
 import { iso8601ValidationMessage } from 'src/common/validation-message/iso8601-validation.message';
 import { notemptyValidationMessage } from 'src/common/validation-message/notempty-validation.message';
@@ -8,6 +9,8 @@ import { uuidValidationMessage } from 'src/common/validation-message/uuid-valida
 
 import { trimStringValue } from '../../../common/validation/transform.util';
 import { ScheduleStatus, ScheduleType } from '../../../generated/prisma';
+
+import { ScheduleReferenceFileDto } from './schedule-reference-file.dto';
 
 /**
  * 일정 수정 요청 본문을 검증한다. 모든 필드는 선택이며 전달된 필드만 업데이트된다.
@@ -57,6 +60,20 @@ export class UpdateScheduleBodyDto {
   @IsOptional()
   @IsString({ message: stringValidationMessage })
   memo?: string;
+
+  @ApiPropertyOptional({ description: '일정 관련 외부 링크 목록 (전달 시 전체 교체)', type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true, message: stringValidationMessage })
+  @IsNotEmpty({ each: true, message: notemptyValidationMessage })
+  externalLinks?: string[];
+
+  @ApiPropertyOptional({ description: '일정 참고자료 파일 목록 (전달 시 전체 교체)', type: [ScheduleReferenceFileDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ScheduleReferenceFileDto)
+  referenceFiles?: ScheduleReferenceFileDto[];
 }
 
 export type UpdateScheduleInput = UpdateScheduleBodyDto;

--- a/backend/src/modules/schedules/repositories/schedules.prisma-repository.spec.ts
+++ b/backend/src/modules/schedules/repositories/schedules.prisma-repository.spec.ts
@@ -1,0 +1,127 @@
+import type { PrismaService } from '../../../database/prisma';
+import { ScheduleStatus, ScheduleType } from '../../../generated/prisma';
+
+import { SchedulesPrismaRepository } from './schedules.prisma-repository';
+
+const SCHEDULE_ID = '11111111-1111-4111-8111-111111111111';
+const BAND_SPACE_ID = '22222222-2222-4222-8222-222222222222';
+const BAND_MEMBER_ID = '33333333-3333-4333-8333-333333333333';
+const CREATED_AT = new Date('2026-08-11T00:00:00.000Z');
+
+const createPrismaMock = () => ({
+  schedule: {
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+  scheduleSong: {
+    createMany: jest.fn(),
+    deleteMany: jest.fn(),
+    findMany: jest.fn(),
+  },
+  scheduleParticipant: {
+    createMany: jest.fn(),
+    deleteMany: jest.fn(),
+    count: jest.fn(),
+  },
+  scheduleTeam: {
+    create: jest.fn(),
+  },
+  scheduleReferenceFile: {
+    createMany: jest.fn(),
+    deleteMany: jest.fn(),
+    findMany: jest.fn(),
+  },
+  song: {
+    findMany: jest.fn(),
+  },
+});
+
+const scheduleRow = {
+  id: SCHEDULE_ID,
+  bandSpaceId: BAND_SPACE_ID,
+  placeId: null,
+  createdByBandMemberId: BAND_MEMBER_ID,
+  scheduleType: ScheduleType.PRACTICE,
+  title: '정기 합주',
+  startAt: new Date('2026-08-12T10:00:00.000Z'),
+  endAt: new Date('2026-08-12T12:00:00.000Z'),
+  status: ScheduleStatus.PLANNED,
+  memo: null,
+  externalLinks: ['https://example.com/notice'],
+  createdAt: CREATED_AT,
+  updatedAt: CREATED_AT,
+};
+
+describe('SchedulesPrismaRepository', () => {
+  let prisma: ReturnType<typeof createPrismaMock>;
+  let repository: SchedulesPrismaRepository;
+
+  beforeEach(() => {
+    prisma = createPrismaMock();
+    repository = new SchedulesPrismaRepository(prisma as unknown as PrismaService);
+  });
+
+  it('일정 생성 시 외부 링크와 참고자료를 함께 저장해 반환한다', async () => {
+    prisma.schedule.create.mockResolvedValue(scheduleRow);
+    prisma.scheduleReferenceFile.findMany.mockResolvedValue([
+      {
+        id: 'reference-file-id',
+        scheduleId: SCHEDULE_ID,
+        fileUrl: 'https://storage.example.com/reference.pdf',
+        fileName: '합주 공지.pdf',
+        createdAt: CREATED_AT,
+      },
+    ]);
+
+    const result = await repository.createSchedule(BAND_SPACE_ID, BAND_MEMBER_ID, {
+      title: '정기 합주',
+      scheduleType: ScheduleType.PRACTICE,
+      startAt: '2026-08-12T10:00:00.000Z',
+      endAt: '2026-08-12T12:00:00.000Z',
+      status: ScheduleStatus.PLANNED,
+      externalLinks: ['https://example.com/notice'],
+      referenceFiles: [{ fileUrl: 'https://storage.example.com/reference.pdf', fileName: '합주 공지.pdf' }],
+    });
+
+    expect(prisma.schedule.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ externalLinks: ['https://example.com/notice'] }) }),
+    );
+    expect(prisma.scheduleReferenceFile.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          scheduleId: SCHEDULE_ID,
+          fileUrl: 'https://storage.example.com/reference.pdf',
+          fileName: '합주 공지.pdf',
+        },
+      ],
+    });
+    expect(result.externalLinks).toEqual(['https://example.com/notice']);
+    expect(result.referenceFiles).toEqual([
+      {
+        id: 'reference-file-id',
+        fileUrl: 'https://storage.example.com/reference.pdf',
+        fileName: '합주 공지.pdf',
+        createdAt: CREATED_AT.toISOString(),
+      },
+    ]);
+  });
+
+  it('수정 요청에 빈 배열이 오면 외부 링크와 참고자료를 모두 비운다', async () => {
+    prisma.schedule.update.mockResolvedValue({ ...scheduleRow, externalLinks: [] });
+    prisma.scheduleParticipant.count.mockResolvedValue(0);
+    prisma.scheduleReferenceFile.findMany.mockResolvedValue([]);
+
+    const result = await repository.updateSchedule(SCHEDULE_ID, {
+      songIds: [],
+      participantBandMemberIds: [],
+      externalLinks: [],
+      referenceFiles: [],
+    });
+
+    expect(prisma.schedule.update).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ externalLinks: { set: [] } }) }));
+    expect(prisma.scheduleReferenceFile.deleteMany).toHaveBeenCalledWith({ where: { scheduleId: SCHEDULE_ID } });
+    expect(prisma.scheduleReferenceFile.createMany).not.toHaveBeenCalled();
+    expect(result.externalLinks).toEqual([]);
+    expect(result.referenceFiles).toEqual([]);
+  });
+});

--- a/backend/src/modules/schedules/repositories/schedules.prisma-repository.ts
+++ b/backend/src/modules/schedules/repositories/schedules.prisma-repository.ts
@@ -10,6 +10,7 @@ import type { BandScheduleListItem, GetBandSchedulesResult } from '../types/band
 import type { CreateScheduleResult, ScheduleSongItem } from '../types/create-schedule-result.type';
 import type { GetScheduleDetailResult } from '../types/schedule-detail.type';
 import type { GetSpaceSchedulesResult, ScheduleListMeta } from '../types/schedule-list-item.type';
+import type { ScheduleReferenceFileItem } from '../types/schedule-reference-file.type';
 import type { UpdateScheduleResult } from '../types/update-schedule-result.type';
 
 import type { SchedulesRepository } from './schedules.repository';
@@ -40,6 +41,7 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
         status: input.status,
         placeId: input.placeId ?? null,
         memo: input.memo ?? null,
+        externalLinks: input.externalLinks,
       },
     });
 
@@ -64,6 +66,16 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
       });
     }
 
+    if (input.referenceFiles !== undefined && input.referenceFiles.length > 0) {
+      await client.scheduleReferenceFile.createMany({
+        data: input.referenceFiles.map(referenceFile => ({
+          scheduleId: schedule.id,
+          fileUrl: referenceFile.fileUrl,
+          fileName: referenceFile.fileName,
+        })),
+      });
+    }
+
     const songs =
       songIds.length > 0
         ? await client.song.findMany({
@@ -73,6 +85,11 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
         : [];
 
     const participantCount = participantBandMemberIds.length;
+
+    const referenceFiles = await client.scheduleReferenceFile.findMany({
+      where: { scheduleId: schedule.id },
+      orderBy: { createdAt: 'asc' },
+    });
 
     return {
       scheduleId: schedule.id,
@@ -88,6 +105,8 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
       participantCount,
       teamId: input.teamId ?? null,
       memo: schedule.memo,
+      externalLinks: schedule.externalLinks,
+      referenceFiles: this.mapReferenceFiles(referenceFiles),
       createdAt: schedule.createdAt.toISOString(),
     };
   }
@@ -140,6 +159,7 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
             },
           },
         },
+        referenceFiles: { orderBy: { createdAt: 'asc' } },
       },
     });
 
@@ -169,6 +189,8 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
           note: p.note ?? null,
         })),
         memo: row.memo,
+        externalLinks: row.externalLinks,
+        referenceFiles: this.mapReferenceFiles(row.referenceFiles),
         createdByBandMemberId: row.createdByBandMemberId,
         isMine,
         createdAt: row.createdAt.toISOString(),
@@ -190,6 +212,7 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
         ...(input.placeId !== undefined && { placeId: input.placeId }),
         ...(input.status !== undefined && { status: input.status }),
         ...(input.memo !== undefined && { memo: input.memo }),
+        ...(input.externalLinks !== undefined && { externalLinks: { set: input.externalLinks } }),
       },
     });
 
@@ -211,12 +234,30 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
       }
     }
 
+    if (input.referenceFiles !== undefined) {
+      await client.scheduleReferenceFile.deleteMany({ where: { scheduleId } });
+      if (input.referenceFiles.length > 0) {
+        await client.scheduleReferenceFile.createMany({
+          data: input.referenceFiles.map(referenceFile => ({
+            scheduleId,
+            fileUrl: referenceFile.fileUrl,
+            fileName: referenceFile.fileName,
+          })),
+        });
+      }
+    }
+
     const songIds =
       input.songIds !== undefined
         ? input.songIds
         : (await client.scheduleSong.findMany({ where: { scheduleId }, select: { songId: true } })).map(s => s.songId);
 
     const participantCount = await client.scheduleParticipant.count({ where: { scheduleId } });
+
+    const referenceFiles = await client.scheduleReferenceFile.findMany({
+      where: { scheduleId },
+      orderBy: { createdAt: 'asc' },
+    });
 
     return {
       scheduleId: updated.id,
@@ -230,6 +271,8 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
       songIds,
       participantCount,
       memo: updated.memo,
+      externalLinks: updated.externalLinks,
+      referenceFiles: this.mapReferenceFiles(referenceFiles),
       updatedAt: updated.updatedAt.toISOString(),
     };
   }
@@ -430,5 +473,14 @@ export class SchedulesPrismaRepository implements SchedulesRepository {
       })),
       meta,
     };
+  }
+
+  private mapReferenceFiles(referenceFiles: { id: string; fileUrl: string; fileName: string; createdAt: Date }[]): ScheduleReferenceFileItem[] {
+    return referenceFiles.map(referenceFile => ({
+      id: referenceFile.id,
+      fileUrl: referenceFile.fileUrl,
+      fileName: referenceFile.fileName,
+      createdAt: referenceFile.createdAt.toISOString(),
+    }));
   }
 }

--- a/backend/src/modules/schedules/repositories/schedules.repository.ts
+++ b/backend/src/modules/schedules/repositories/schedules.repository.ts
@@ -13,7 +13,7 @@ export const SCHEDULES_REPOSITORY = Symbol('SCHEDULES_REPOSITORY');
 export interface SchedulesRepository {
   /**
    * 밴드 공간에 일정을 생성한다.
-   * songIds, participantBandMemberIds가 있으면 각 중간 테이블에도 레코드를 삽입한다.
+   * songIds, participantBandMemberIds, referenceFiles가 있으면 연관 레코드도 삽입한다.
    */
   createSchedule(
     bandSpaceId: string,
@@ -25,7 +25,7 @@ export interface SchedulesRepository {
   /**
    * 일정을 수정한다.
    * songIds가 있으면 ScheduleSong을 전량 교체(deleteMany → createMany)한다.
-   * participantBandMemberIds가 있으면 ScheduleParticipant를 전량 교체한다.
+   * participantBandMemberIds와 referenceFiles가 있으면 각 연관 레코드를 전량 교체한다.
    */
   updateSchedule(scheduleId: string, input: UpdateScheduleInput, tx?: Prisma.TransactionClient): Promise<UpdateScheduleResult>;
 

--- a/backend/src/modules/schedules/schedules.service.spec.ts
+++ b/backend/src/modules/schedules/schedules.service.spec.ts
@@ -36,6 +36,8 @@ const createScheduleResult: CreateScheduleResult = {
   participantCount: 0,
   teamId: null,
   memo: null,
+  externalLinks: [],
+  referenceFiles: [],
   createdAt: '2026-05-29T00:00:00.000Z',
 };
 
@@ -51,6 +53,8 @@ const updateScheduleResult: UpdateScheduleResult = {
   songIds: [SONG_ID],
   participantCount: 2,
   memo: null,
+  externalLinks: [],
+  referenceFiles: [],
   updatedAt: '2026-05-29T01:00:00.000Z',
 };
 
@@ -77,6 +81,8 @@ const scheduleDetailResult: GetScheduleDetailResult = {
       },
     ],
     memo: null,
+    externalLinks: [],
+    referenceFiles: [],
     createdByBandMemberId: BAND_MEMBER_ID,
     isMine: true,
     createdAt: '2026-05-29T00:00:00.000Z',

--- a/backend/src/modules/schedules/types/create-schedule-result.type.ts
+++ b/backend/src/modules/schedules/types/create-schedule-result.type.ts
@@ -1,3 +1,5 @@
+import type { ScheduleReferenceFileItem } from './schedule-reference-file.type';
+
 export interface ScheduleSongItem {
   songId: string;
   title: string;
@@ -18,5 +20,7 @@ export interface CreateScheduleResult {
   participantCount: number;
   teamId: string | null;
   memo: string | null;
+  externalLinks: string[];
+  referenceFiles: ScheduleReferenceFileItem[];
   createdAt: string;
 }

--- a/backend/src/modules/schedules/types/schedule-detail.type.ts
+++ b/backend/src/modules/schedules/types/schedule-detail.type.ts
@@ -1,4 +1,5 @@
 import type { ScheduleSongItem } from './create-schedule-result.type';
+import type { ScheduleReferenceFileItem } from './schedule-reference-file.type';
 
 export interface ScheduleParticipantDetail {
   participantId: string;
@@ -29,6 +30,8 @@ export interface GetScheduleDetailResult {
     songs: ScheduleSongItem[];
     participants: ScheduleParticipantDetail[];
     memo: string | null;
+    externalLinks: string[];
+    referenceFiles: ScheduleReferenceFileItem[];
     createdByBandMemberId: string;
     isMine: boolean;
     createdAt: string;

--- a/backend/src/modules/schedules/types/schedule-reference-file.type.ts
+++ b/backend/src/modules/schedules/types/schedule-reference-file.type.ts
@@ -1,0 +1,6 @@
+export interface ScheduleReferenceFileItem {
+  id: string;
+  fileUrl: string;
+  fileName: string;
+  createdAt: string;
+}

--- a/backend/src/modules/schedules/types/update-schedule-result.type.ts
+++ b/backend/src/modules/schedules/types/update-schedule-result.type.ts
@@ -1,3 +1,5 @@
+import type { ScheduleReferenceFileItem } from './schedule-reference-file.type';
+
 export interface UpdateScheduleResult {
   scheduleId: string;
   spaceId: string;
@@ -10,5 +12,7 @@ export interface UpdateScheduleResult {
   songIds: string[];
   participantCount: number;
   memo: string | null;
+  externalLinks: string[];
+  referenceFiles: ScheduleReferenceFileItem[];
   updatedAt: string;
 }


### PR DESCRIPTION
## ⏱ 소요 시간

- 리뷰 예상 시간: 20분

<br/>

## 📌 작업 요약

PR #159 프론트 기능 연동을 위한 백엔드 기능 추가

- 링크 미리보기 API 추가
- 일정 외부 링크 및 참고자료 첨부 기능 추가
- 알림 타입별 미읽음 요약 API 추가

<br/>

## 📝 작업 내용

1. `GET /link-previews` 추가
   - OG 메타데이터와 favicon을 파싱하여 링크 미리보기 정보 제공
   - DNS 조회 결과를 검증하여 localhost, 사설 IP, 예약 IP 접근 차단
   - 검증한 IP로 직접 연결하여 DNS rebinding 방어
   - 리다이렉트 목적지를 매번 재검증하여 내부망 우회 접근 차단
   - 요청 타임아웃과 응답 크기 제한을 적용하여 외부 서버로 인한 리소스 점유 방지
   - 조회 실패 시 `null`을 반환하여 프론트의 자연스러운 폴백 처리 지원

2. 일정 첨부 필드 추가
   - 외부 링크를 `externalLinks: string[]`로 저장
   - 참고자료를 `referenceFiles: { fileUrl, fileName }[]`로 저장
   - 일정 생성·수정·상세 조회에 첨부 정보 반영
   - 전체 교체 방식을 적용하여 첨부 수정 로직 단순화
   - 일정과 참고자료에 cascade 삭제를 적용하여 고아 데이터 발생 방지

3. `GET /notifications/unread-summary` 추가
   - Prisma `groupBy`를 적용하여 전체 및 타입별 미읽음 개수를 한 번에 조회
   - 기존 `(userId, isRead, type)` 인덱스를 활용하여 집계 쿼리 비용 최소화
   - 알림이 없는 타입도 `0`으로 반환하여 프론트의 별도 보정 로직 제거

<br/>

## 🚨 주요 고민 및 해결 과정

### 일정 참고자료 저장 구조

제안은 `referenceFiles: string[]` 형태로 object URL만 저장하는 방식

presigned URL 업로드 결과가 UUID 기반 경로이므로 URL만 저장하면 사용자가 업로드한 원본 파일명 복원 불가

기존 `SongReferenceFile`과 동일하게 `ScheduleReferenceFile` 모델을 추가하고 `fileUrl`, `fileName`을 함께 저장하여 화면에서 원본 파일명 제공 가능

파일별 `id`, `createdAt`을 저장하여 파일 식별과 정렬 가능

일정과 참고자료 사이에 cascade 삭제를 적용하여 일정 삭제 후 참고자료 레코드가 남는 문제 방지

별도 메타데이터가 필요 없는 외부 링크는 `String[]`로 유지하여 불필요한 테이블과 조회 로직 추가 방지

첨부 필드에 전체 교체 방식을 적용하여 부분 추가·삭제를 위한 별도 API 없이 생성과 수정 계약 통일

- 필드 미전달: 기존 값 유지
- 배열 전달: 전달된 값으로 전체 교체
- 빈 배열 전달: 전체 삭제